### PR TITLE
feat(toolkit/oop): instance-addressable discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,6 +2890,7 @@ dependencies = [
  "cf-gears-toolkit-odata",
  "cf-gears-toolkit-sdk",
  "cf-gears-toolkit-security",
+ "cf-gears-toolkit-stable-hash",
  "cf-gears-toolkit-transport-grpc",
  "cf-gears-toolkit-utils",
  "chrono",

--- a/docs/arch/toolkit-oop/ADR/0009-cpt-cf-adr-instance-addressable-discovery.md
+++ b/docs/arch/toolkit-oop/ADR/0009-cpt-cf-adr-instance-addressable-discovery.md
@@ -59,13 +59,6 @@ axis is solved by directory **labels + targeted resolution**. Concretely, today 
 We need to decide how (and whether) the platform supports targeting a specific instance, and where that lives
 relative to the directory contract and the REST contract-codegen client-wiring layer.
 
-> **This ADR is the platform's single service-discovery layer.** The cluster gear's in-SDK
-> `ServiceDiscoveryV1` (instance registration, serving intent, metadata filtering, TTL heartbeat, and topology
-> watch as a follow-up) is **superseded** by the directory and its capability consolidated here so there is exactly **one**
-> source of topology truth. The actual code removal is **out of scope for this ADR** - it is executed by the
-> cluster gear's own decomposition as a separate, coordinated change; this ADR is the *design* that replaces
-> it. See [Relationship to cluster `ServiceDiscoveryV1`](#relationship-to-cluster-servicediscoveryv1).
-
 ## Decision Drivers
 
 * **Correctness of split gears must be structural, not flag-dependent** - a role-split or sharded gear must
@@ -154,6 +147,69 @@ Naming cannot express this (they are the same service), so it is solved by direc
 The two axes are orthogonal and compose: **role selects the name, label selects the instance within it** (the
 second resolve line above targets an ingest shard the first line cannot reach).
 
+**Mechanism: the manifest declares a closed set of role-names; the boot mode maps into it (decision).** The
+structural guarantee above ("a forgotten flag cannot misroute, because there is no flag") rests on *where* the
+registration name comes from, and two names must not be conflated:
+
+* `#[toolkit::gear(name = "...")]` is a **compile-time string literal** validated at macro expansion
+  (`libs/toolkit-macros`), fixing the gear's **identity** - one binary cannot declare three identities this
+  way, nor should it.
+* The name that actually reaches the directory is a **runtime** value (`OopRunOptions.gear_name`, supplied by
+  `main.rs` via `libs/toolkit/src/bootstrap/oop.rs`). If that were a *free-form* runtime string, a mis-set boot
+  mode could register an `ingest` instance under `event-broker`, and a front-door caller would round-robin
+  straight into it - the **same fail-open the `entrypoint` field was rejected for**, merely moved from a
+  boolean to a string. "No flag" would not hold.
+
+The property is kept structural by **not** taking the directory name as a free runtime string. Instead: **the
+gear manifest declares the closed set of role-qualified directory names the gear may register under, together
+with the `DeploymentMode -> role-name` map; the boot mode selects a name from that closed set; and bootstrap
+refuses to start on a mode whose resolved name is not in the declared set.** Concretely:
+
+* A role-split gear declares its role-names **once, at the manifest / gear-declaration level** (e.g. a
+  `roles = ["event-broker", "event-broker-ingest", "event-broker-delivery"]` set alongside
+  `#[toolkit::gear(...)]`, plus the `DeploymentMode -> role-name` mapping). The bare gear identity
+  (`event-broker`) is one entry in that set - the front door.
+* At boot, `OopRunOptions.gear_name` is **derived** from `(declared map, boot mode)` and **validated against the
+  declared closed set**. A mode with no mapping, or a name outside the set, is a **hard start-time error**
+  (fail-fast) - never a silent default to the bare name.
+* The residual fail-open is therefore removed: a mis-wired mode **cannot invent a name**. The worst case is a
+  mode that maps to a valid *internal* role-name, which surfaces as that role being **absent from the front
+  door** (the §1b readiness verdict / §6 not-ready), not as an internal instance cross-routed under the bare
+  name.
+
+This is the single mechanism the whole role axis rests on, so it is specified here rather than deferred to the
+implementing change.
+
+### 1b. Dependencies and readiness across role-qualified names
+
+Splitting one gear into several directory names splits its **dependency graph** too, so `deps` is stated in
+terms of *names*, not gear identity:
+
+* **A consumer** declares `deps` on the **name it actually calls** - normally the front door
+  (`deps = [event-broker]`), which gates only on dispatcher readiness. A consumer that legitimately targets an
+  internal role declares that **role-name** explicitly (`deps = [event-broker-ingest]`); nothing gates on an
+  internal role-name a consumer never named.
+* **A role-split gear** declares, in its manifest, the role-names it depends on **as directory names**,
+  including its **own other role-names**: the `dispatcher` front door depends on `event-broker-ingest` /
+  `event-broker-delivery`. Because those are **distinct directory names** - not the gear's own identity - this
+  is **not** a self-dependency in the topo-sort's sense (a name never depends on itself) and introduces **no
+  cycle**: the deps topo-sort operates on directory names throughout, so "a gear depending on its own other
+  role-names" is just a normal edge between two names that happen to be produced by one binary.
+* **Readiness gating** (ADR-0005) is **per name**: `deps = [event-broker-ingest]` gates until at least one
+  healthy instance registers under `event-broker-ingest`, exactly as for any other name.
+
+**Permanent-unresolvable verdict (decision).** `Ok(empty)` reads as "not ready yet" (§6), which is correct
+*transiently* but wrong *forever*: a **misconfigured or never-deployed** role-name (wrong boot mode, missing
+workload, typo) also returns `Ok(empty)` indefinitely, indistinguishable from a fleet still coming up. This is
+the residual of the §6 gap the ownership-fencing contract closes for *stale targets* but not for *absent names*.
+The platform therefore MUST, for a name a consumer declared a **dependency** on (not for ad-hoc
+`resolve_by_labels` probes), emit a distinct **unresolvable-dependency** readiness verdict once a
+**configurable grace window** elapses with **zero** registered instances: readiness gating flips that
+dependency from "not-ready" to a **hard, surfaced error** (a failed `/readyz` naming the unresolved name)
+rather than a perpetual silent 503. It is owned by the readiness layer (ADR-0005) and is keyed on the
+**declared-dependency** name set so an ad-hoc empty label result stays a benign `Ok(empty)`. The grace-window
+default and per-dep override are readiness-layer implementation details.
+
 ### 2. Enabling mechanism: instance labels + targeted resolution
 
 Within a directory name, addressing is keyed on **`(name, selector) -> endpoint`**: *which name* (already
@@ -174,7 +230,8 @@ Add **one** targeted lookup to `DirectoryClient`, backed by selection in `GearMa
 clients:
 
 * `resolve_by_labels(name, selector)` - the set of instances of `name` matching a `LabelSelector` (see §6),
-  each carrying its `instance_id`, `labels`, readiness state, and endpoints.
+  each carrying its `instance_id`, `labels`, and endpoints - with **no** readiness/health annotation. Unhealthy
+  matches remain in the set; liveness is the caller's responsibility (health contract in §6).
 
 There is deliberately **no** `resolve_instance(gear, instance_id)`. The only live `instance_id` a caller can
 hold comes from a prior `resolve_by_labels` result (which already carries the endpoint), so a
@@ -321,8 +378,9 @@ There is one targeted lookup (§2); its cardinality and health contract, and the
 contract, are:
 
 * **`resolve_by_labels(name, selector)` -> a set (array)** - effectively `list_instances(name)` filtered by the
-  selector, returning each match's `instance_id`, `labels`, readiness state, and endpoints (gRPC
-  `endpoint` and/or `rest_endpoint`). The selector is a **`LabelSelector` struct** wrapping a **map of equality
+  selector, returning each match's `instance_id`, `labels`, and endpoints (gRPC
+  `endpoint` and/or `rest_endpoint`) - i.e. **addresses**, with **no** per-result health annotation. The selector
+  is a **`LabelSelector` struct** wrapping a **map of equality
   requirements matched with AND semantics** (Kubernetes `matchLabels` style): an instance matches only if it
   carries **every** requested `key=value` pair (e.g. `shard=7`); an empty selector matches
   all instances of the name. Passing a **struct rather than a bare map** keeps future filters (e.g.
@@ -330,8 +388,8 @@ contract, are:
   RPC request message is already additively extensible, but the Rust trait signature is not unless the argument
   is a struct. This is the enumeration form the broker dispatcher uses to build/refresh a partition->instance
   map, and that fan-out/broadcast consumers use to reach every match. Set-based / inequality **expression**
-  selectors (`in`, `notin`, `!=`) are out of scope for Layer 1 (equality-AND only); **health filtering stays
-  caller-side** (health contract below), so the selector carries no `only_serving`-style flag.
+  selectors (`in`, `notin`, `!=`) are out of scope for Layer 1 (equality-AND only); the selector carries no
+  `only_serving`-style flag - **liveness is the caller's concern** (health contract below).
 * **"pick one from the matched set"** is an **application-owned selector** over an already-targeted label set
   (first / consistent-hash / caller policy) - **not** toolkit load balancing. The toolkit's only load-balancing
   primitive is round-robin over name resolution (§3-§4); `resolve_by_labels` merely returns the set,
@@ -348,29 +406,26 @@ contract, are:
 * **Empty-set semantics**: zero matches is `Ok(empty)`, kept distinct from a
   directory-backend error - preserving the not-found vs. failure contract of ADR-0005, so an empty result reads
   as "not ready yet," not "outage."
-* **Health contract (decision):** every lookup annotates each returned instance with its readiness state
-  (`InstanceState`: `Registered` / `Ready` / `Healthy` / `Quarantined` / `Draining`; only `Ready` / `Healthy`
-  are **serving**, the rest are **not-ready**). This is the **directory's annotation of a resolution result** and
-  is **derived from** the instance's readiness signal ([ADR-0005](0005-cpt-cf-adr-eventual-readiness.md)), not a
-  second health system; it is *not* the same enum as ADR-0005's readiness-probe `state`. Mapping to ADR-0005:
-  `Ready`/`Healthy` correspond to ADR-0005 `Ready`/`Degraded` (serving / `200`); `Registered` to `Starting`
-  (registered, deps not yet resolved); `Quarantined` to a failing readiness probe (`Unhealthy`->`Starting`); and
-  `Draining` to `Draining`. A caller can thus always distinguish **no match** (`Ok(empty)`)
-  from **matched-but-not-ready**. The two modes share these error semantics and differ only in health
-  *filtering*:
-  * **Name round-robin** (`resolve_rest_service` / `resolve_grpc_service`) rotates over the resolved name,
-    **preferring** serving (`Ready` / `Healthy`) instances but, when none are serving, **falling back to RR
-    over the full not-ready set - `Quarantined` *and* `Draining` included**. Draining instances are
-    graceful-shutdown targets upstreams stop routing to, but the toolkit still prefers a draining endpoint over
-    `None` rather than dropping the last route. Concretely: a name whose instances are **all `Quarantined`**
-    resolves to a quarantined endpoint, and a name whose instances are **all `Draining`** likewise resolves to a
-    draining endpoint. `None` is returned **only** when the candidate set is **empty** - i.e. no instance
-    registered under the name exposes the requested endpoint at all - never merely because every instance is
-    not-ready. *(One transport asymmetry - gRPC service-scoped resolution does **not** yet fall back and instead
-    returns `None` when none are serving - is tracked in Implementation notes.)*
-  * **`resolve_by_labels(name, selector)`** returns the **full** matching set **regardless of health**, each
-    entry carrying its readiness state; an all-unhealthy match is still `Ok(non-empty)`, distinct from
-    `Ok(empty)` and from a backend error.
+* **Health contract (decision): the directory returns addresses, not a per-result health verdict.** A resolution
+  result carries **no readiness annotation** — the directory is an addressing layer, not a second health system.
+  `Ok(empty)` means **no match** (distinct from a backend error); a **matched-but-not-serving** instance is
+  discovered by the caller **dialing it** and corrected via the stale-owner path below, not by a directory flag.
+  Health-aware selection is confined to **name round-robin**, where it is a **server-side selection detail** of
+  the resolving directory (computed over its own instance health, `InstanceState`, derived from
+  [ADR-0005](0005-cpt-cf-adr-eventual-readiness.md) readiness) and **never appears on `resolve_by_labels`
+  results**. The two resolution modes therefore differ as follows:
+  * **Name round-robin** (`resolve_rest_service` / `resolve_grpc_service`) returns a **single already-selected
+    endpoint**: the directory **prefers** serving (`Ready` / `Healthy`) instances but, when none are serving,
+    **falls back to RR over the full not-ready set** (`Quarantined` *and* `Draining` included) so a non-empty
+    name never yields `None` merely because nothing is serving. `None` is returned **only** when the candidate
+    set is **empty**. This preference is uniform across transports (REST and gRPC service-scoped resolution
+    both fall back; see Implementation notes) and is entirely internal to the resolving directory — it is not
+    surfaced as result metadata.
+  * **`resolve_by_labels(name, selector)`** returns the **full matched set as addresses, regardless of health**.
+    For sharding / leadership the caller MUST target the **owner** of the key; health-filtering here would
+    misroute to a **non-owner**, so a not-serving owner is handled by the call outcome + the stale-owner
+    correction below, never by dropping it from the set. An all-unhealthy match is still `Ok(non-empty)`,
+    distinct from `Ok(empty)` and from a backend error.
 
 * **Stale-ownership correction path (required contract).** A poll-refreshed shard/owner map (§2) is inherently
   stale between refreshes, so ownership is **not** established by the directory result alone - it must be
@@ -408,22 +463,15 @@ REST contract codegen. This ADR fixes the **contract shape** (Layer 1) so it can
 with that codegen's directory edits (which also modify `ServiceInstanceInfo` / `grpc/client.rs`) rather than in
 a merge scramble.
 
-**Relationship to the event-broker's current primitive.** event-broker ADR-0007 (Accepted) has
-`domain/cluster.rs` resolve the cluster gear's `ServiceDiscoveryV1` via `ClientHub` under the `evbk` prefix -
-so the broker has a *working* targeting primitive today. That primitive is exactly the cluster
-`ServiceDiscoveryV1` this ADR **supersedes and replaces** (see [Relationship to cluster
-`ServiceDiscoveryV1`](#relationship-to-cluster-servicediscoveryv1)); Layer 1 is therefore not "unblocking
-something new" but **the successor substrate** the broker's dispatcher->ingest targeting must move onto once
-cluster discovery is retired (by the cluster gear's own decomposition, not this ADR). The broker's
-decomposition already assumes one binary with mode-selected wiring, so its `ingest` / `delivery` modes register
-their **role-qualified directory names** (§1) - no `entrypoint` marker is needed, and the wrong-role failure
-mode is structurally impossible.
+**event-broker adoption.** The event-broker's `dispatcher -> ingest` / `delivery` targeting resolves through the
+directory (Layer 1) with plain HTTP/gRPC clients: its `ingest` / `delivery` modes register **role-qualified
+directory names** (§1) and the dispatcher builds a shard map via `resolve_by_labels`. No `entrypoint` marker is
+needed and the wrong-role failure mode is structurally impossible. Routing a *generated typed* client to a
+specific instance waits on REST contract codegen (Layer 2).
 
-**Watch / change-notification (required follow-up, owned here).** The cluster `ServiceDiscoveryV1` being
-removed included a **topology `watch`** (unfiltered `Joined`/`Left`/`Updated` stream). Because this ADR is that
-capability's single successor, a directory-level change-notification API is a **required follow-up owned by
-this design** (not the cluster gear), so removing cluster discovery is not a silent regression. It is
-sequenced *after* Layer 1 (poll + the §6 fencing contract already make correctness *specified*); watch is a
+**Watch / change-notification (follow-up owned here).** A directory-level change-notification API — a topology
+`watch` stream (instance `Joined` / `Left` / `Updated`) — is a **follow-up owned by this design**, sequenced
+*after* Layer 1: poll + the §6 fencing contract already make correctness *specified*, so watch is a
 convergence-latency optimization, not a correctness prerequisite. Until it lands, consumers poll
 `list_instances` / `resolve_by_labels`.
 
@@ -536,41 +584,6 @@ convergence-latency optimization, not a correctness prerequisite. Until it lands
 
 ## More Information
 
-### Relationship to cluster `ServiceDiscoveryV1`
-
-**This ADR supersedes and absorbs the cluster gear's `ServiceDiscoveryV1`; the code removal is executed by the
-cluster gear's own decomposition as a separate, coordinated change, not by this ADR.** There is **one**
-service-discovery layer - the directory - not a directory layer plus a competing cluster layer. The prior
-concern that this ADR added a "second, weaker discovery layer next to a merged one" is resolved by
-*consolidation*: the cluster in-SDK discovery primitive
-(`gears/system/cluster/cluster-sdk/src/discovery/`, its default/standalone/Postgres backends, conformance
-suite, GTS specs, and wiring) will be **retired** by that decomposition work, after which the cluster gear
-keeps only its other three backend traits (cache, distributed lock, leader election). The dependency direction
-is therefore **not** inverted - cluster is not a shipped provider this ADR races; its discovery capability is
-the thing being consolidated here. The event-broker `domain/cluster.rs` `ServiceDiscoveryV1` handle and every
-cluster-side user are retired by that decomposition; until the directory replacement (Layer 1) lands the
-capability still exists in cluster, so there is **no functional gap** during the transition.
-
-Concept mapping (cluster -> directory):
-
-| Cluster `ServiceDiscoveryV1`                             | Directory (this ADR)                                             |
-|----------------------------------------------------------|------------------------------------------------------------------|
-| `ServiceRegistration.metadata: HashMap<String,String>`   | `labels` map on `InstanceInfo` / `ServiceInstanceInfo` (§2)      |
-| `DiscoveryFilter` (AND-conjoined `MetaMatch::{Equals,OneOf}`) | `resolve_by_labels` `LabelSelector` (equality-AND; `OneOf`/expressions are the deferred `matchExpressions`, §6) |
-| `InstanceState::{Enabled, Disabled}` (serving intent)    | readiness state on results (`Registered`/`Ready`/`Healthy`/`Quarantined`/`Draining`, §6) - `Draining` == cluster `Disabled` |
-| `StateFilter::{Enabled, Disabled, Any}` (server-side serving-state filter) | **caller-side** health filtering (§6) - `resolve_by_labels` returns the full set annotated with readiness state; there is no server-side `only_serving` flag |
-| `ServiceHandle::set_state` (runtime serving-intent flip / drain) | no dedicated intent-flip RPC; an instance signals `Draining` through **readiness** (ADR-0005), which name round-robin de-prefers (§6) - the deliberate "intent, not health" split (cluster ADR-008) is folded into the readiness axis |
-| `ServiceHandle::update_metadata` (runtime metadata mutation) | no dedicated update RPC; label changes ride **re-registration** (labels MUST survive re-registration, §2 / Implementation notes) |
-| `ServiceDiscoveryV1::scoped(prefix)` (name sub-namespacing) | not carried over - the directory uses flat, manifest-declared role-qualified names (§1); coordination-namespace scoping is a cluster-internal concern, not a directory primitive |
-| TTL heartbeat / lapse                                    | directory registration + heartbeat loop (§5) / readiness gating (ADR-0005) |
-| `ServiceDiscoveryBackend::watch` (topology stream)       | change-notification **follow-up owned here** (§7, Consequences) - poll `list_instances` / `resolve_by_labels` until it lands; **not** a cluster-scoped layer |
-
-**Boundary (why this is the directory's job, not a gear's):** the directory is a **toolkit-level** primitive
-that every gear (and the edge) already depends on; a gear cannot be the source of topology truth the toolkit
-resolves against without a dependency inversion (the toolkit cannot depend on a gear). Consolidating discovery
-here keeps a single source of truth **and** the correct layering; the cluster gear becomes a *consumer* of this
-layer for its coordinator's shard/leader targeting, like any other gear.
-
 ### Cross-references & required amendments
 
 **Sibling ADRs / PRD.** Some of these are true **amendments** (this ADR changes a shape they assert), not just
@@ -608,7 +621,7 @@ references; the amendment notes are recorded inline in each target document:
   gating ([ADR-0005 Consequences](0005-cpt-cf-adr-eventual-readiness.md#consequences)).
 * **[event-broker service decomposition](../../../../gears/system/event-broker/docs/ADR/0007-service-decomposition.md)**
   (the *event-broker's* ADR-0007, Accepted - distinct from the toolkit-oop ADR-0007 above) is the consuming
-  design - see §7's *Relationship to the event-broker's current primitive*.
+  design - see §7's *event-broker adoption*.
 
 **REST contract codegen (PRD §4.1).** The trait-first REST client generation roadmap item - *"REST client
 generation from annotated Rust traits (trait-first, `#[toolkit::rest_contract]` proc-macro)"* in

--- a/docs/arch/toolkit-oop/DESIGN.md
+++ b/docs/arch/toolkit-oop/DESIGN.md
@@ -80,7 +80,7 @@ OoP gear lifecycle, discovery coordination, and gateway registration. The archit
 | `cpt-cf-adr-platform-plane-auth`   | Platform-plane authentication: SA tokens (Profile 3) / bootstrap token (Profile 2) first, mTLS + SPIFFE next |
 | `cpt-cf-adr-rest-first-oop`         | REST as primary OoP protocol; each gear runs its own HTTP server                                     |
 | `cpt-cf-adr-gateway-abstraction`    | GatewayProvider trait abstracts built-in and external gateways                                         |
-| `cpt-cf-adr-instance-addressable-discovery` | Target a specific gear instance (role/shard) via additive directory metadata + targeted resolve; RR stays the default |
+| `cpt-cf-adr-instance-addressable-discovery` | Roles use role-qualified directory names; additive directory labels + targeted resolve select a specific shard/peer within a directory name; RR stays the default |
 
 ### 1.3 Architecture Layers
 

--- a/docs/arch/toolkit-oop/PRD.md
+++ b/docs/arch/toolkit-oop/PRD.md
@@ -142,7 +142,7 @@ application code remains deployment-agnostic. ToolKit Distributed Gears bring th
 - Deployment Profile 3: K8s Native (each gear = pod, external gateway, k8s DNS discovery)
 - Two-plane auth — gateway validates the JWT at the edge; OoP gears **re-validate it per hop** (tenant plane) and use a tenant-less identity for infra calls (platform plane). See [ADR-0008](ADR/0008-cpt-cf-adr-two-plane-auth.md)
 - Direct gear-to-gear REST communication (not routed through gateway)
-- Instance-addressable discovery — target a specific gear instance (role/shard) via additive directory metadata + targeted resolve, with round-robin remaining the default. Targeted selection does **not** expand the Toolkit's load-balancing scope beyond round-robin: the directory only enumerates/pinpoints instances; any pick-one over a matched set (e.g. consistent-hash sharding) is application-owned policy in the consuming gear. See [ADR-0009](ADR/0009-cpt-cf-adr-instance-addressable-discovery.md)
+- Instance-addressable discovery — roles use role-qualified directory names, while additive directory labels + targeted resolve select a specific shard/peer within a directory name, with round-robin remaining the default. Targeted selection does **not** expand the Toolkit's load-balancing scope beyond round-robin: the directory only enumerates/pinpoints instances; any pick-one over a matched set (e.g. consistent-hash sharding) is application-owned policy in the consuming gear. See [ADR-0009](ADR/0009-cpt-cf-adr-instance-addressable-discovery.md)
 - Public vs. internal API distinction in route registration
 - REST client generation from annotated Rust traits (trait-first, `#[toolkit::rest_contract]` proc-macro)
 - Gateway abstraction trait with built-in ToolKit implementation

--- a/gears/system/api-gateway/src/proxy.rs
+++ b/gears/system/api-gateway/src/proxy.rs
@@ -449,6 +449,7 @@ mod tests {
             version: None,
             rest_endpoint: Some(ServiceEndpoint::new(uri)),
             openapi_spec: Some(spec),
+            labels: std::collections::BTreeMap::new(),
         })
         .await
         .unwrap();
@@ -526,6 +527,7 @@ mod tests {
             version: None,
             rest_endpoint: Some(ServiceEndpoint::new("http://calc:8080")),
             openapi_spec: Some(public_spec("calc", "/calc/v1/sub")),
+            labels: std::collections::BTreeMap::new(),
         })
         .await
         .unwrap();
@@ -589,6 +591,7 @@ mod tests {
             version: None,
             rest_endpoint: None,
             openapi_spec: None,
+            labels: std::collections::BTreeMap::new(),
         })
         .await
         .unwrap();
@@ -615,6 +618,7 @@ mod tests {
             version: None,
             rest_endpoint: Some(ServiceEndpoint::new("http://specless:8080")),
             openapi_spec: None,
+            labels: std::collections::BTreeMap::new(),
         })
         .await
         .unwrap();
@@ -894,6 +898,7 @@ mod tests {
             version: None,
             rest_endpoint: Some(ServiceEndpoint::new("http://calc:8080")),
             openapi_spec: Some(public_spec("calc", "/calc/v1/sub")),
+            labels: std::collections::BTreeMap::new(),
         })
         .await
         .unwrap();
@@ -958,6 +963,7 @@ mod tests {
             openapi_spec: None,
             openapi_spec_hash: hash.map(ToOwned::to_owned),
             grpc_services: Vec::new(),
+            labels: std::collections::BTreeMap::new(),
         }
     }
 

--- a/gears/system/gear-orchestrator/src/server.rs
+++ b/gears/system/gear-orchestrator/src/server.rs
@@ -15,10 +15,10 @@ use toolkit_transport_grpc::extract_internal_token_grpc;
 use cf_system_sdks::directory::{
     DeregisterInstanceRequest, DirectoryClient, DirectoryInvalidArgument, DirectoryNotFound,
     DirectoryService, DirectoryServiceServer, GetOpenApiSpecRequest, GetOpenApiSpecResponse,
-    HeartbeatRequest, InstanceInfo, ListAllInstancesRequest, ListAllInstancesResponse,
-    ListInstancesRequest, ListInstancesResponse, RegisterInstanceInfo, RegisterInstanceRequest,
-    ResolveGrpcServiceRequest, ResolveGrpcServiceResponse, ResolveRestServiceRequest,
-    ResolveRestServiceResponse, ServiceEndpoint, ServiceInstanceInfo,
+    GrpcServiceEndpoint, HeartbeatRequest, InstanceInfo, ListAllInstancesRequest,
+    ListAllInstancesResponse, ListInstancesRequest, ListInstancesResponse, RegisterInstanceInfo,
+    RegisterInstanceRequest, ResolveGrpcServiceRequest, ResolveGrpcServiceResponse,
+    ResolveRestServiceRequest, ResolveRestServiceResponse, ServiceEndpoint, ServiceInstanceInfo,
 };
 
 /// Map a lookup failure onto a gRPC status, keeping "not registered" distinct
@@ -224,6 +224,7 @@ impl DirectoryService for DirectoryServiceImpl {
             },
             rest_endpoint: req.rest_endpoint_uri.map(ServiceEndpoint::new),
             openapi_spec: req.openapi_spec,
+            labels: req.labels.into_iter().collect(),
         };
 
         self.api
@@ -272,6 +273,15 @@ fn domain_instance_to_proto(i: ServiceInstanceInfo) -> InstanceInfo {
         rest_endpoint_uri: i.rest_endpoint.map(|ep| ep.uri),
         openapi_spec: i.openapi_spec,
         openapi_spec_hash: i.openapi_spec_hash,
+        labels: i.labels.into_iter().collect(),
+        grpc_services: i
+            .grpc_services
+            .into_iter()
+            .map(|(service_name, ep)| GrpcServiceEndpoint {
+                service_name,
+                endpoint_uri: ep.uri,
+            })
+            .collect(),
     }
 }
 
@@ -318,6 +328,7 @@ mod tests {
             version: "1.0.0".to_owned(),
             rest_endpoint_uri: Some("http://billing:8080".to_owned()),
             openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
+            labels: std::collections::HashMap::new(),
         }))
         .await
         .unwrap();
@@ -420,6 +431,7 @@ mod tests {
                 version: Some("1.0.0".to_owned()),
                 rest_endpoint: Some(ServiceEndpoint::http("billing", 8080)),
                 openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
+                labels: std::collections::BTreeMap::new(),
             })
             .await
             .unwrap();
@@ -430,6 +442,101 @@ mod tests {
 
         let spec = client.get_openapi_spec("billing").await.unwrap();
         assert!(spec.contains("openapi"));
+    }
+
+    /// `labels` declared at registration survive the
+    /// full proto round-trip and drive `resolve_by_labels` targeting end-to-end
+    /// over gRPC (register-with-labels -> `list_instances` on the wire -> the
+    /// default `resolve_by_labels` selector filter).
+    #[tokio::test]
+    async fn grpc_round_trip_labels_drive_resolve_by_labels() {
+        use cf_system_sdks::directory::{DirectoryGrpcClient, LabelSelector};
+        use std::collections::BTreeMap;
+        use tonic::transport::Server;
+
+        let manager = Arc::new(GearManager::new());
+        let api: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(manager));
+        let grpc_service = make_directory_service(api, None);
+
+        let addr = std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap();
+
+        tokio::spawn(async move {
+            Server::builder()
+                .add_service(grpc_service)
+                .serve(addr)
+                .await
+                .unwrap();
+        });
+
+        let client: Arc<dyn DirectoryClient> = Arc::new(
+            DirectoryGrpcClient::connect(format!("http://{addr}"))
+                .await
+                .unwrap(),
+        );
+
+        // Two shards of one directory name, distinguished only by a label. Each
+        // also advertises a per-instance gRPC endpoint so we can prove targeted
+        // gRPC-endpoint resolution survives the wire.
+        for shard in ["0", "1"] {
+            client
+                .register_instance(RegisterInstanceInfo {
+                    gear: "event-broker-ingest".to_owned(),
+                    instance_id: Uuid::new_v4().to_string(),
+                    grpc_services: vec![(
+                        "ingest.v1.Ingest".to_owned(),
+                        ServiceEndpoint::new(format!("http://ingest-{shard}:9090")),
+                    )],
+                    version: Some("1.0.0".to_owned()),
+                    rest_endpoint: Some(ServiceEndpoint::new(format!(
+                        "http://ingest-{shard}:8080"
+                    ))),
+                    openapi_spec: None,
+                    labels: BTreeMap::from([("shard".to_owned(), shard.to_owned())]),
+                })
+                .await
+                .unwrap();
+        }
+
+        // Targeted resolve pinpoints exactly the labelled shard, proving the
+        // labels crossed the wire on both register and list.
+        let matched = client
+            .resolve_by_labels(
+                "event-broker-ingest",
+                &LabelSelector::new().with("shard", "1"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(matched.len(), 1);
+        assert_eq!(
+            matched[0].labels.get("shard").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            matched[0].rest_endpoint.as_ref().map(|e| e.uri.as_str()),
+            Some("http://ingest-1:8080")
+        );
+        // The targeted instance's gRPC endpoint also survives the round-trip, so
+        // a caller can dial it by service name (effective key `(name, selector, service_name)`).
+        let (svc_name, svc_ep) = matched[0]
+            .grpc_services
+            .iter()
+            .find(|(name, _)| name == "ingest.v1.Ingest")
+            .expect("targeted instance advertises its gRPC service over the wire");
+        assert_eq!(svc_name, "ingest.v1.Ingest");
+        assert_eq!(svc_ep.uri, "http://ingest-1:9090");
+
+        // An empty selector still returns the whole set over the wire.
+        assert_eq!(
+            client
+                .resolve_by_labels("event-broker-ingest", &LabelSelector::new())
+                .await
+                .unwrap()
+                .len(),
+            2
+        );
     }
 
     /// `list_all_instances` returns every registered gear (across gears) with
@@ -448,6 +555,7 @@ mod tests {
                 version: "1.0.0".to_owned(),
                 rest_endpoint_uri: Some(format!("http://{gear}:{port}")),
                 openapi_spec: Some(format!("{{\"openapi\":\"3.1.0\",\"x\":\"{gear}\"}}")),
+                labels: std::collections::HashMap::new(),
             }))
             .await
             .unwrap();
@@ -544,6 +652,7 @@ mod tests {
                 version: Some("1.0.0".to_owned()),
                 rest_endpoint: Some(ServiceEndpoint::http("billing", 8080)),
                 openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
+                labels: std::collections::BTreeMap::new(),
             })
             .await
             .expect("authenticated register should succeed");

--- a/gears/system/grpc-hub/src/gear.rs
+++ b/gears/system/grpc-hub/src/gear.rs
@@ -536,6 +536,7 @@ impl GrpcHub {
                     version: Some(env!("CARGO_PKG_VERSION").to_owned()),
                     rest_endpoint: None,
                     openapi_spec: None,
+                    labels: std::collections::BTreeMap::new(),
                 };
 
                 directory.register_instance(info).await?;

--- a/libs/system-sdks/sdks/directory/proto/v1/directory.proto
+++ b/libs/system-sdks/sdks/directory/proto/v1/directory.proto
@@ -74,6 +74,8 @@ message InstanceInfo {
   optional string rest_endpoint_uri = 5;
   optional string openapi_spec = 6;
   optional string openapi_spec_hash = 7;
+  map<string, string> labels = 8;
+  repeated GrpcServiceEndpoint grpc_services = 9;
 }
 
 message ListInstancesResponse {
@@ -99,6 +101,7 @@ message RegisterInstanceRequest {
   string version = 4;
   optional string rest_endpoint_uri = 5;
   optional string openapi_spec = 6;
+  map<string, string> labels = 7;
 }
 
 message DeregisterInstanceRequest {

--- a/libs/system-sdks/sdks/directory/src/api.rs
+++ b/libs/system-sdks/sdks/directory/src/api.rs
@@ -4,6 +4,59 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
+use std::collections::BTreeMap;
+
+/// An equality-AND label selector (Kubernetes `matchLabels` style).
+///
+/// An instance matches iff it carries **every** requested `key=value` pair; an
+/// empty selector matches all instances of a name. A struct (not a bare map) so
+/// future filters (e.g. `matchExpressions`) stay additive.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct LabelSelector {
+    match_labels: BTreeMap<String, String>,
+}
+
+impl LabelSelector {
+    /// An empty selector - matches every instance of a name.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a selector from a `matchLabels` map.
+    #[must_use]
+    pub fn from_match_labels(match_labels: BTreeMap<String, String>) -> Self {
+        Self { match_labels }
+    }
+
+    /// Add one `key=value` equality requirement (builder).
+    #[must_use]
+    pub fn with(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.match_labels.insert(key.into(), value.into());
+        self
+    }
+
+    /// The `matchLabels` equality requirements.
+    #[must_use]
+    pub fn match_labels(&self) -> &BTreeMap<String, String> {
+        &self.match_labels
+    }
+
+    /// Whether this selector has no requirements (matches everything).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.match_labels.is_empty()
+    }
+
+    /// AND-match: `labels` satisfies this selector iff it carries **every**
+    /// requested `key=value` pair. An empty selector always matches.
+    #[must_use]
+    pub fn matches(&self, labels: &BTreeMap<String, String>) -> bool {
+        self.match_labels
+            .iter()
+            .all(|(k, v)| labels.get(k).is_some_and(|lv| lv == v))
+    }
+}
 
 /// Represents an endpoint where a service can be reached
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -61,6 +114,10 @@ pub struct ServiceInstanceInfo {
     /// (which replaces the entry wholesale) can augment — rather than clobber —
     /// the previously-registered gRPC services when adding a REST endpoint.
     pub grpc_services: Vec<(String, ServiceEndpoint)>,
+    /// Consumer-defined, opaque instance labels for within-contract targeting
+    /// (`cpt-cf-adr-instance-addressable-discovery` §2), e.g. `shard`, `pod`. The directory only stores and
+    /// filters on them via [`resolve_by_labels`](DirectoryClient::resolve_by_labels).
+    pub labels: BTreeMap<String, String>,
 }
 
 /// Information for registering a new gear instance
@@ -78,6 +135,9 @@ pub struct RegisterInstanceInfo {
     pub rest_endpoint: Option<ServiceEndpoint>,
     /// Optional `OpenAPI` spec (JSON) published by the gear.
     pub openapi_spec: Option<String>,
+    /// Consumer-defined, opaque instance labels (`cpt-cf-adr-instance-addressable-discovery` §2). MUST survive the
+    /// idempotent re-registration path (see `GearManager::register_instance`).
+    pub labels: BTreeMap<String, String>,
 }
 
 /// A resolved gRPC service and the endpoint it is reachable at.
@@ -174,6 +234,28 @@ pub trait DirectoryClient: Send + Sync {
     /// List all service instances for a given gear
     async fn list_instances(&self, gear: &str) -> Result<Vec<ServiceInstanceInfo>>;
 
+    /// Resolve the instances of `name` matching `selector` (`cpt-cf-adr-instance-addressable-discovery` §6).
+    ///
+    /// Returns the **full** matching set **regardless of health** (each entry
+    /// carrying its `labels`, `instance_id`, and endpoints); zero matches is
+    /// `Ok(vec![])`, not an error. Health filtering and "pick one from the set"
+    /// are caller-owned policy, not toolkit load balancing.
+    ///
+    /// The default is `list_instances(name)` filtered by the selector's
+    /// equality-AND semantics. Backends may override to push the filter
+    /// server-side but MUST preserve these semantics.
+    async fn resolve_by_labels(
+        &self,
+        name: &str,
+        selector: &LabelSelector,
+    ) -> Result<Vec<ServiceInstanceInfo>> {
+        let instances = self.list_instances(name).await?;
+        Ok(instances
+            .into_iter()
+            .filter(|inst| selector.matches(&inst.labels))
+            .collect())
+    }
+
     /// List every service instance across all registered gears.
     ///
     /// Used by the edge gateway to discover which gears (and their REST
@@ -216,6 +298,66 @@ mod tests {
     }
 
     #[test]
+    fn label_selector_and_semantics() {
+        let labels = BTreeMap::from([
+            ("shard".to_owned(), "1".to_owned()),
+            ("az".to_owned(), "a".to_owned()),
+        ]);
+
+        // Empty selector matches everything (`cpt-cf-adr-instance-addressable-discovery` §6).
+        assert!(LabelSelector::new().matches(&labels));
+
+        // Single requirement present.
+        assert!(LabelSelector::new().with("shard", "1").matches(&labels));
+
+        // AND semantics: every requested pair must be present.
+        assert!(
+            LabelSelector::new()
+                .with("shard", "1")
+                .with("az", "a")
+                .matches(&labels)
+        );
+
+        // A requested pair with the wrong value does not match.
+        assert!(!LabelSelector::new().with("shard", "2").matches(&labels));
+
+        // A requested key absent from the instance does not match.
+        assert!(!LabelSelector::new().with("region", "eu").matches(&labels));
+    }
+
+    #[test]
+    fn label_selector_builders_and_accessors() {
+        // `new()` / default is empty and matches everything.
+        assert!(LabelSelector::new().is_empty());
+        assert!(LabelSelector::default().match_labels().is_empty());
+
+        // `from_match_labels` round-trips the map and reports non-empty.
+        let map = BTreeMap::from([("shard".to_owned(), "3".to_owned())]);
+        let sel = LabelSelector::from_match_labels(map.clone());
+        assert!(!sel.is_empty());
+        assert_eq!(sel.match_labels(), &map);
+    }
+
+    #[test]
+    fn grpc_service_info_new() {
+        let info =
+            GrpcServiceInfo::new("payment.v1.PaymentApi", ServiceEndpoint::http("pay", 50051));
+        assert_eq!(info.service_name, "payment.v1.PaymentApi");
+        assert_eq!(info.endpoint.uri, concat!("http", "://pay:50051"));
+    }
+
+    #[test]
+    fn directory_sentinels_construct_and_display() {
+        let not_found = DirectoryNotFound::new("gear foo");
+        assert_eq!(not_found.resource, "gear foo");
+        assert_eq!(not_found.to_string(), "directory: not found: gear foo");
+
+        let invalid = DirectoryInvalidArgument::new("bad uuid");
+        assert_eq!(invalid.message, "bad uuid");
+        assert_eq!(invalid.to_string(), "directory: invalid argument: bad uuid");
+    }
+
+    #[test]
     fn test_register_instance_info() {
         let info = RegisterInstanceInfo {
             gear: "test_gear".to_owned(),
@@ -227,6 +369,7 @@ mod tests {
             version: Some("1.0.0".to_owned()),
             rest_endpoint: None,
             openapi_spec: None,
+            labels: BTreeMap::new(),
         };
 
         assert_eq!(info.gear, "test_gear");
@@ -245,6 +388,7 @@ mod tests {
             version: Some("2.0.0".to_owned()),
             rest_endpoint: Some(ServiceEndpoint::http("billing", 8080)),
             openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
+            labels: BTreeMap::new(),
         };
 
         assert_eq!(info.gear, "billing");

--- a/libs/system-sdks/sdks/directory/src/grpc/client.rs
+++ b/libs/system-sdks/sdks/directory/src/grpc/client.rs
@@ -283,6 +283,7 @@ impl DirectoryClient for DirectoryGrpcClient {
             version: info.version.unwrap_or_default(),
             rest_endpoint_uri: info.rest_endpoint.map(|ep| ep.uri),
             openapi_spec: info.openapi_spec,
+            labels: info.labels.into_iter().collect(),
         };
 
         client
@@ -340,11 +341,12 @@ fn proto_instance_to_domain(proto: InstanceInfo) -> ServiceInstanceInfo {
         rest_endpoint: proto.rest_endpoint_uri.map(ServiceEndpoint::new),
         openapi_spec: proto.openapi_spec,
         openapi_spec_hash: proto.openapi_spec_hash,
-        // The list-instances proto response does not break the instance down
-        // per gRPC service, so nothing to carry back over the OoP directory
-        // transport. The in-process `LocalDirectoryClient` populates this from
-        // the live `GearInstance`.
-        grpc_services: Vec::new(),
+        grpc_services: proto
+            .grpc_services
+            .into_iter()
+            .map(|svc| (svc.service_name, ServiceEndpoint::new(svc.endpoint_uri)))
+            .collect(),
+        labels: proto.labels.into_iter().collect(),
     }
 }
 
@@ -391,9 +393,15 @@ mod tests {
             rest_endpoint_uri: Some("http://calc:8080".to_owned()),
             openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
             openapi_spec_hash: None,
+            labels: std::collections::HashMap::from([("shard".to_owned(), "1".to_owned())]),
+            grpc_services: vec![GrpcServiceEndpoint {
+                service_name: "calc.v1.Calculator".to_owned(),
+                endpoint_uri: "http://calc:9090".to_owned(),
+            }],
         };
         let domain = proto_instance_to_domain(proto);
         assert_eq!(domain.gear, "calc");
+        assert_eq!(domain.labels.get("shard").map(String::as_str), Some("1"));
         assert_eq!(domain.instance_id, "calc-1");
         assert_eq!(domain.endpoint.uri, "http://calc:8080");
         assert_eq!(domain.version.as_deref(), Some("1.2.3"));
@@ -402,6 +410,11 @@ mod tests {
             Some("http://calc:8080".to_owned())
         );
         assert!(domain.openapi_spec.is_some());
+        // gRPC services survive the proto -> domain mapping so a targeted
+        // resolve can dial the instance's gRPC endpoint by service name.
+        assert_eq!(domain.grpc_services.len(), 1);
+        assert_eq!(domain.grpc_services[0].0, "calc.v1.Calculator");
+        assert_eq!(domain.grpc_services[0].1.uri, "http://calc:9090");
     }
 
     #[test]
@@ -414,9 +427,13 @@ mod tests {
             rest_endpoint_uri: None,
             openapi_spec: None,
             openapi_spec_hash: None,
+            labels: std::collections::HashMap::new(),
+            grpc_services: Vec::new(),
         };
         let domain = proto_instance_to_domain(proto);
         // An empty proto version string maps to `None` rather than an empty string.
+        assert!(domain.labels.is_empty());
+        assert!(domain.grpc_services.is_empty());
         assert!(domain.version.is_none());
         assert!(domain.rest_endpoint.is_none());
         assert!(domain.openapi_spec.is_none());

--- a/libs/system-sdks/sdks/directory/src/lib.rs
+++ b/libs/system-sdks/sdks/directory/src/lib.rs
@@ -10,7 +10,7 @@ mod api;
 mod grpc;
 
 pub use api::{
-    DirectoryClient, DirectoryInvalidArgument, DirectoryNotFound, GrpcServiceInfo,
+    DirectoryClient, DirectoryInvalidArgument, DirectoryNotFound, GrpcServiceInfo, LabelSelector,
     RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo,
 };
 #[cfg(feature = "grpc")]

--- a/libs/toolkit-macros-tests/tests/ui/fail/gear_name_not_in_roles.rs
+++ b/libs/toolkit-macros-tests/tests/ui/fail/gear_name_not_in_roles.rs
@@ -1,0 +1,20 @@
+// `cpt-cf-adr-instance-addressable-discovery` §1: when a gear declares `roles`, the bare `name` (the front door)
+// MUST be one of them. Here `name` is absent from `roles`, so the macro rejects
+// it at compile time.
+
+#[toolkit::gear(
+    name = "event-broker",
+    roles = ["event-broker-ingest", "event-broker-delivery"],
+    capabilities = []
+)]
+#[derive(Default)]
+pub struct EventBrokerGear;
+
+#[async_trait::async_trait]
+impl toolkit::Gear for EventBrokerGear {
+    async fn init(&self, _ctx: &toolkit::GearCtx) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/libs/toolkit-macros-tests/tests/ui/fail/gear_name_not_in_roles.stderr
+++ b/libs/toolkit-macros-tests/tests/ui/fail/gear_name_not_in_roles.stderr
@@ -1,0 +1,11 @@
+error: gear `name = "event-broker"` must be one of the declared `roles`; got roles = ["event-broker-ingest", "event-broker-delivery"]
+ --> tests/ui/fail/gear_name_not_in_roles.rs:5:1
+  |
+5 | / #[toolkit::gear(
+6 | |     name = "event-broker",
+7 | |     roles = ["event-broker-ingest", "event-broker-delivery"],
+8 | |     capabilities = []
+9 | | )]
+  | |__^
+  |
+  = note: this error originates in the attribute macro `toolkit::gear` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/libs/toolkit-macros-tests/tests/ui/fail/gear_roles_duplicate.rs
+++ b/libs/toolkit-macros-tests/tests/ui/fail/gear_roles_duplicate.rs
@@ -1,0 +1,20 @@
+// `cpt-cf-adr-instance-addressable-discovery` §1: the declared `roles` set is a
+// closed set of distinct role-qualified directory names. A repeated role name is
+// a declaration bug, so the macro rejects it at compile time.
+
+#[toolkit::gear(
+    name = "event-broker",
+    roles = ["event-broker", "event-broker-ingest", "event-broker-ingest"],
+    capabilities = []
+)]
+#[derive(Default)]
+pub struct EventBrokerGear;
+
+#[async_trait::async_trait]
+impl toolkit::Gear for EventBrokerGear {
+    async fn init(&self, _ctx: &toolkit::GearCtx) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/libs/toolkit-macros-tests/tests/ui/fail/gear_roles_duplicate.stderr
+++ b/libs/toolkit-macros-tests/tests/ui/fail/gear_roles_duplicate.stderr
@@ -1,0 +1,5 @@
+error: duplicate role name `event-broker-ingest` in `roles`
+ --> tests/ui/fail/gear_roles_duplicate.rs:7:53
+  |
+7 |     roles = ["event-broker", "event-broker-ingest", "event-broker-ingest"],
+  |                                                     ^^^^^^^^^^^^^^^^^^^^^

--- a/libs/toolkit-macros-tests/tests/ui/pass/gear_roles_ok.rs
+++ b/libs/toolkit-macros-tests/tests/ui/pass/gear_roles_ok.rs
@@ -1,0 +1,28 @@
+// `cpt-cf-adr-instance-addressable-discovery` §1: a role-split gear declares its closed set of role-qualified
+// directory names via `roles = [...]`. The macro emits a `ROLES` associated
+// const and self-registers the set into the `DeclaredRoles` inventory, so OoP
+// bootstrap enforces the role/front-door split without `main.rs` wiring. The
+// bare `name` must be one of the roles.
+
+#[toolkit::gear(
+    name = "event-broker", // front-door role (must be a member of `roles`)
+    roles = ["event-broker", "event-broker-ingest", "event-broker-delivery"],
+    capabilities = []
+)]
+#[derive(Default)]
+pub struct EventBrokerGear;
+
+#[async_trait::async_trait]
+impl toolkit::Gear for EventBrokerGear {
+    async fn init(&self, _ctx: &toolkit::GearCtx) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+fn main() {
+    // The declared closed set is available as an associated const.
+    assert_eq!(
+        EventBrokerGear::ROLES,
+        ["event-broker", "event-broker-ingest", "event-broker-delivery"]
+    );
+}

--- a/libs/toolkit-macros/src/lib.rs
+++ b/libs/toolkit-macros/src/lib.rs
@@ -23,6 +23,11 @@ struct GearConfig {
     ctor: Option<Expr>,           // arbitrary constructor expression
     client: Option<Path>,         // trait path for client DX helpers
     lifecycle: Option<LcGearCfg>, // optional lifecycle config (on type)
+    /// Closed set of role-qualified directory names this gear may register
+    /// under (`cpt-cf-adr-instance-addressable-discovery` section 1). Empty for
+    /// a single-role gear; when non-empty the bare `name` MUST be a member, and
+    /// the macro emits a `ROLES` const.
+    roles: Vec<String>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -205,12 +210,14 @@ impl Parse for GearConfig {
         let mut ctor: Option<Expr> = None;
         let mut client: Option<Path> = None;
         let mut lifecycle: Option<LcGearCfg> = None;
+        let mut roles: Vec<String> = Vec::new();
 
         let mut seen_name = false;
         let mut seen_deps = false;
         let mut seen_caps = false;
         let mut seen_ctor = false;
         let mut seen_client = false;
+        let mut seen_roles = false;
         let mut seen_lifecycle = false;
 
         let punctuated: Punctuated<Meta, Token![,]> =
@@ -377,6 +384,50 @@ impl Parse for GearConfig {
                         }
                     }
                 }
+                Meta::NameValue(nv) if nv.path.is_ident("roles") => {
+                    if seen_roles {
+                        return Err(syn::Error::new_spanned(
+                            nv.path,
+                            "duplicate `roles` parameter",
+                        ));
+                    }
+                    seen_roles = true;
+                    match nv.value.clone() {
+                        Expr::Array(arr) => {
+                            for elem in arr.elems {
+                                match elem {
+                                    Expr::Lit(syn::ExprLit {
+                                        lit: Lit::Str(s), ..
+                                    }) => {
+                                        let role = s.value();
+                                        if let Err(err) = validate_kebab_case(&role) {
+                                            return Err(syn::Error::new_spanned(s, err));
+                                        }
+                                        if roles.contains(&role) {
+                                            return Err(syn::Error::new_spanned(
+                                                s,
+                                                format!("duplicate role name `{role}` in `roles`"),
+                                            ));
+                                        }
+                                        roles.push(role);
+                                    }
+                                    other => {
+                                        return Err(syn::Error::new_spanned(
+                                            other,
+                                            "roles must be string literals, e.g. roles = [\"event-broker\", \"event-broker-ingest\"]",
+                                        ));
+                                    }
+                                }
+                            }
+                        }
+                        other => {
+                            return Err(syn::Error::new_spanned(
+                                other,
+                                "roles must be an array of string literals, e.g. roles = [\"event-broker\", \"event-broker-ingest\"]",
+                            ));
+                        }
+                    }
+                }
                 // Accept `lifecycle(...)` and also namespaced like `toolkit::gear::lifecycle(...)`
                 Meta::List(list) if path_last_is(&list.path, "lifecycle") => {
                     if seen_lifecycle {
@@ -404,6 +455,19 @@ impl Parse for GearConfig {
             )
         })?;
 
+        // `cpt-cf-adr-instance-addressable-discovery` section 1: a declared role
+        // set makes the bare `name` (the front door) MUST be a member, keeping
+        // the mode->name mapping structural.
+        if !roles.is_empty() && !roles.iter().any(|r| r == &name) {
+            return Err(syn::Error::new(
+                Span::call_site(),
+                format!(
+                    "gear `name = \"{name}\"` must be one of the declared `roles`; \
+                     got roles = {roles:?}"
+                ),
+            ));
+        }
+
         Ok(GearConfig {
             name,
             deps,
@@ -411,6 +475,7 @@ impl Parse for GearConfig {
             ctor,
             client,
             lifecycle,
+            roles,
         })
     }
 }
@@ -516,6 +581,7 @@ pub fn gear(attr: TokenStream, item: TokenStream) -> TokenStream {
     let ctor_expr_opt: Option<Expr> = config.ctor.clone();
     let client_trait_opt: Option<Path> = config.client.clone();
     let lifecycle_cfg_opt: Option<LcGearCfg> = config.lifecycle;
+    let roles_owned: Vec<String> = config.roles;
 
     // Prepare string literals for name/deps
     let name_lit = LitStr::new(&name_owned, Span::call_site());
@@ -524,6 +590,40 @@ pub fn gear(attr: TokenStream, item: TokenStream) -> TokenStream {
         .iter()
         .map(|ident| LitStr::new(&ident.to_string().replace('_', "-"), Span::call_site()))
         .collect();
+
+    // `cpt-cf-adr-instance-addressable-discovery` section 1: emit the declared
+    // role set as a `ROLES` const the OoP `main.rs` forwards to
+    // `OopRunOptions.role_names` (single source of truth). Emitted only when
+    // declared, so single-role gears are unaffected.
+    let roles_const = if roles_owned.is_empty() {
+        quote! {}
+    } else {
+        let role_lits: Vec<LitStr> = roles_owned
+            .iter()
+            .map(|r| LitStr::new(r, Span::call_site()))
+            .collect();
+        quote! {
+            impl #impl_generics #struct_ident #ty_generics #where_clause {
+                /// Closed set of role-qualified directory names this gear may
+                /// register under (`cpt-cf-adr-instance-addressable-discovery`
+                /// section 1). Also submitted to the `DeclaredRoles` inventory
+                /// so OoP bootstrap enforces the role/front-door split with no
+                /// `main.rs` wiring.
+                pub const ROLES: &'static [&'static str] = &[#(#role_lits),*];
+            }
+
+            // Self-register the closed role set (with its declaring gear
+            // identity) so bootstrap can discover it from the linked binary
+            // (no `main.rs` forwarding required) and validate the booted name
+            // against this gear's own roles, not a cross-gear union.
+            ::toolkit::inventory::submit! {
+                ::toolkit::registry::DeclaredRoles {
+                    gear: #name_lit,
+                    roles: &[#(#role_lits),*],
+                }
+            }
+        }
+    };
 
     // Constructor expression (provided or Default::default())
     let constructor = if let Some(expr) = &ctor_expr_opt {
@@ -814,6 +914,9 @@ pub fn gear(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         // Re-export gear dependencies to force-link their inventory registrations
         #(#dep_reexports)*
+
+        // `cpt-cf-adr-instance-addressable-discovery` sec.1 role-qualified names: gear-declared closed set (if any)
+        #roles_const
 
         // Registrator that targets the *builder*, not the final registry
         #[doc(hidden)]
@@ -1299,4 +1402,122 @@ pub fn domain_model(_attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn derive_expand_vars(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     TokenStream::from(expand_vars::derive(&input))
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    fn parse_gear(attr: &str) -> syn::Result<GearConfig> {
+        syn::parse_str::<GearConfig>(attr)
+    }
+
+    #[test]
+    fn roles_valid_with_name_as_front_door() {
+        let cfg =
+            parse_gear(r#"name = "event-broker", roles = ["event-broker", "event-broker-ingest"]"#)
+                .expect("valid role-split gear");
+        assert_eq!(cfg.name, "event-broker");
+        assert_eq!(
+            cfg.roles,
+            vec!["event-broker".to_owned(), "event-broker-ingest".to_owned()]
+        );
+    }
+
+    #[test]
+    fn roles_reject_duplicate_element() {
+        let err = parse_gear(r#"name = "x", roles = ["x", "x-a", "x-a"]"#)
+            .err()
+            .unwrap();
+        assert!(
+            err.to_string().contains("duplicate role name `x-a`"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn roles_reject_non_kebab_element() {
+        let err = parse_gear(r#"name = "x", roles = ["x", "X-A"]"#)
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("lowercase"), "got: {err}");
+    }
+
+    #[test]
+    fn roles_reject_non_string_element() {
+        let err = parse_gear(r#"name = "x", roles = ["x", 1]"#).err().unwrap();
+        assert!(
+            err.to_string().contains("roles must be string literals"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn roles_reject_non_array_value() {
+        let err = parse_gear(r#"name = "x", roles = "x""#).err().unwrap();
+        assert!(
+            err.to_string().contains("roles must be an array"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn roles_reject_name_not_a_member() {
+        let err = parse_gear(r#"name = "event-broker", roles = ["event-broker-ingest"]"#)
+            .err()
+            .unwrap();
+        assert!(
+            err.to_string()
+                .contains("must be one of the declared `roles`"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn roles_reject_duplicate_param() {
+        let err = parse_gear(r#"name = "x", roles = ["x"], roles = ["x"]"#)
+            .err()
+            .unwrap();
+        assert!(
+            err.to_string().contains("duplicate `roles` parameter"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_kebab_case_covers_all_rejection_shapes() {
+        assert!(validate_kebab_case("").is_err());
+        assert!(
+            validate_kebab_case("file_parser")
+                .unwrap_err()
+                .contains("kebab-case")
+        );
+        assert!(
+            validate_kebab_case("Parser")
+                .unwrap_err()
+                .contains("lowercase letter")
+        );
+        assert!(
+            validate_kebab_case("-parser")
+                .unwrap_err()
+                .contains("lowercase letter")
+        );
+        assert!(
+            validate_kebab_case("parser-")
+                .unwrap_err()
+                .contains("end with a hyphen")
+        );
+        assert!(
+            validate_kebab_case("a--b")
+                .unwrap_err()
+                .contains("consecutive hyphens")
+        );
+        assert!(
+            validate_kebab_case("a.b")
+                .unwrap_err()
+                .contains("only lowercase")
+        );
+        assert!(validate_kebab_case("event-broker-1").is_ok());
+    }
 }

--- a/libs/toolkit/Cargo.toml
+++ b/libs/toolkit/Cargo.toml
@@ -111,6 +111,7 @@ toolkit-db = { workspace = true, optional = true }
 sea-orm-migration = { workspace = true, optional = true }
 toolkit-odata = { workspace = true }
 toolkit-sdk = { workspace = true }
+toolkit-stable-hash = { workspace = true }
 cf-gears-system-sdks = { workspace = true, features = ["directory"] }
 # `rest-client` is not optional: `discovery` and the runtime proxy-wiring phase
 # use `toolkit_contract::runtime::resolving`, which lives behind it.

--- a/libs/toolkit/src/bootstrap/config/mod.rs
+++ b/libs/toolkit/src/bootstrap/config/mod.rs
@@ -165,6 +165,23 @@ pub struct OopHttpConfig {
     /// unspecified host (`0.0.0.0`) rewritten to `127.0.0.1`.
     #[serde(default)]
     pub advertise_uri: Option<String>,
+    /// Fail fast (refuse to start) when the effective `advertise_uri` is unset
+    /// or resolves to a bind-only address (loopback / `0.0.0.0` / `localhost`)
+    /// rather than an address reachable by *other* gears (`cpt-cf-adr-instance-addressable-discovery` §5).
+    ///
+    /// Defaults to `false` so Profile 1 and single-node Profile 2 over UDS (and
+    /// local demos on loopback) start normally. Set `true` in **multi-host
+    /// Profile 2** and **Profile 3**, where a silently-registered loopback
+    /// endpoint is a registered-but-unreachable instance; there, supply the pod
+    /// FQDN / Service DNS as `advertise_uri`. UDS advertise URIs are exempt.
+    #[serde(default)]
+    pub require_reachable_advertise_uri: bool,
+    /// Deployment-sourced instance labels (`cpt-cf-adr-instance-addressable-discovery` §2) registered with the
+    /// directory for targeting via `resolve_by_labels` (e.g. `shard: "1"`).
+    /// Settable in config or via `APP__OOP_HTTP__LABELS__<key>` env overrides, so
+    /// a deployment can inject per-pod identity without baking it into the YAML.
+    #[serde(default)]
+    pub labels: std::collections::BTreeMap<String, String>,
     /// Platform-plane (`InternalAuthenticator`) configuration. When present it
     /// drives both the *inbound* HTTP validator on the gear's own routes and
     /// the *outbound* credential attached to the gear's `DirectoryService`

--- a/libs/toolkit/src/bootstrap/oop.rs
+++ b/libs/toolkit/src/bootstrap/oop.rs
@@ -37,6 +37,7 @@
 //!         print_config: false,
 //!         heartbeat_interval_secs: 5,
 //!         version: None,
+//!         role_names: None,
 //!     };
 //!
 //!     run_oop_with_options(opts).await
@@ -91,6 +92,17 @@ pub struct OopRunOptions {
     /// Gear version (used for `DirectoryService` registration and `OpenAPI` version).
     /// Defaults to `None`.
     pub version: Option<String>,
+
+    /// Optional **override** of the closed set of role-qualified directory names
+    /// this gear binary may register under (`cpt-cf-adr-instance-addressable-discovery`).
+    /// When the resolved [`gear_name`](Self::gear_name) is not a member, bootstrap
+    /// **refuses to start**, making the role / front-door split structural.
+    ///
+    /// Normally left `None`: the set is auto-discovered from the linked gear's
+    /// `#[toolkit::gear(roles = [...])]` declaration (via the `DeclaredRoles`
+    /// inventory), so it cannot be forgotten in `main.rs`. Set `Some(..)` only to
+    /// override that discovery.
+    pub role_names: Option<Vec<String>>,
 }
 
 impl Default for OopRunOptions {
@@ -112,6 +124,7 @@ impl Default for OopRunOptions {
             print_config: false,
             heartbeat_interval_secs: 5,
             version: None,
+            role_names: None,
         }
     }
 }
@@ -389,6 +402,7 @@ fn merge_json_objects(target: &mut serde_json::Value, source: &serde_json::Value
 ///         print_config: false,
 ///         heartbeat_interval_secs: 5,
 ///         version: None,
+///         role_names: None,
 ///     };
 ///
 ///     run_oop_with_options(opts).await
@@ -409,6 +423,19 @@ fn merge_json_objects(target: &mut serde_json::Value, source: &serde_json::Value
 pub async fn run_oop_with_options(opts: OopRunOptions) -> Result<()> {
     // Generate instance ID if not provided
     let instance_id = opts.instance_id.unwrap_or_else(Uuid::new_v4);
+
+    // Structural role-name guard (`cpt-cf-adr-instance-addressable-discovery` §1):
+    // fail fast if the resolved `gear_name` is not a member of the gear's
+    // declared role set, rather than registering under an undeclared name. The
+    // role set is discovered from the booted gear's own `#[toolkit::gear(roles =
+    // [...])]` declaration (via inventory), selected by declaring identity so a
+    // binary linking several role-split gears validates each against *its own*
+    // roles, never the cross-gear union. An explicit `opts.role_names` overrides.
+    let role_names = effective_role_names(
+        opts.role_names.clone(),
+        crate::registry::declared_roles_for(&opts.gear_name).unwrap_or_default(),
+    );
+    validate_role_name(&opts.gear_name, role_names.as_deref())?;
 
     // Create root cancellation token for the entire process.
     // This token drives shutdown for the gear runtime and all background tasks.
@@ -665,6 +692,20 @@ async fn build_oop_serve_options(
         .clone()
         .unwrap_or_else(|| default_advertise_uri(listen_addr));
 
+    // `cpt-cf-adr-instance-addressable-discovery` §5 fail-fast: in multi-host Profile 2 / Profile 3 the runtime
+    // MUST refuse to start rather than register a bind-only (loopback /
+    // `0.0.0.0` / `localhost`) endpoint that other gears cannot reach. Gated by
+    // config so Profile 1 and single-node Profile 2 over UDS start normally.
+    if cfg.require_reachable_advertise_uri && !advertise_uri_is_reachable(&advertise_uri) {
+        anyhow::bail!(
+            "oop_http.advertise_uri {advertise_uri:?} is a bind-only address \
+             (loopback / 0.0.0.0 / localhost) but require_reachable_advertise_uri is set: \
+             in multi-host Profile 2 / Profile 3, set advertise_uri to an address other gears \
+             can reach (e.g. the pod FQDN `$(HOSTNAME).<service>.$(POD_NAMESPACE).svc:<port>` or \
+             the Service DNS name), per cpt-cf-adr-instance-addressable-discovery §5"
+        );
+    }
+
     let internal_authenticator = build_internal_authenticator(cfg.internal_auth.as_ref()).await?;
 
     Ok(OopServeOptions {
@@ -677,6 +718,9 @@ async fn build_oop_serve_options(
         drain_timeout: Duration::from_secs(cfg.drain_timeout_secs),
         heartbeat_interval,
         healthcheck_timeout: Duration::from_millis(cfg.healthcheck_timeout_ms),
+        // Deployment-sourced instance labels (`cpt-cf-adr-instance-addressable-discovery` §2), from config /
+        // `APP__OOP_HTTP__LABELS__*` env overrides.
+        labels: cfg.labels.clone(),
         directory,
         bearer_authenticator: None,
         internal_authenticator,
@@ -726,6 +770,77 @@ async fn build_internal_authenticator(
     }
 
     Ok(None)
+}
+
+/// Resolve the effective role set to guard against: an explicit
+/// `OopRunOptions.role_names` wins (back-compat / override); otherwise the set
+/// auto-discovered from the linked gear's `#[toolkit::gear(roles = [...])]`
+/// declaration is used. An empty discovered set means no gear declared roles (a
+/// single-role binary), which maps to `None` — no constraint.
+fn effective_role_names(
+    explicit: Option<Vec<String>>,
+    discovered: Vec<String>,
+) -> Option<Vec<String>> {
+    match explicit {
+        Some(roles) => Some(roles),
+        None => (!discovered.is_empty()).then_some(discovered),
+    }
+}
+
+/// Validate the resolved directory `gear_name` against the gear binary's
+/// declared closed set of role-qualified names (`cpt-cf-adr-instance-addressable-discovery` §1).
+///
+/// `None` (single-role gear) always passes. When `Some`, membership is required
+/// — a name outside the set is a hard start-time error, so a mis-set boot mode
+/// cannot register under an undeclared (or the bare front-door) name.
+fn validate_role_name(gear_name: &str, role_names: Option<&[String]>) -> Result<()> {
+    if let Some(roles) = role_names
+        && !roles.iter().any(|r| r == gear_name)
+    {
+        anyhow::bail!(
+            "OoP gear_name {gear_name:?} is not in the declared role-name set {roles:?} \
+             (cpt-cf-adr-instance-addressable-discovery §1): a role-split gear's boot mode must map to one of its \
+             manifest-declared role-qualified names — refusing to start rather than \
+             registering under an undeclared name"
+        );
+    }
+    Ok(())
+}
+
+/// Whether `advertise_uri` points at an address other gears can actually reach
+/// (`cpt-cf-adr-instance-addressable-discovery` §5) — i.e. **not** a bind-only address.
+///
+/// * `unix://…` (UDS) is inherently instance-addressable (single-node Profile 2)
+///   and therefore **reachable/exempt**.
+/// * `localhost`, IPv4/IPv6 **loopback**, and **unspecified** (`0.0.0.0` / `::`)
+///   hosts are **not** reachable.
+/// * Any other host — including a DNS name such as a k8s pod FQDN / Service DNS —
+///   is treated as reachable (the runtime cannot resolve arbitrary DNS at
+///   config time; the operator owns correctness of a concrete name).
+fn advertise_uri_is_reachable(uri: &str) -> bool {
+    if uri.starts_with("unix://") {
+        return true;
+    }
+    let after_scheme = uri.split_once("://").map_or(uri, |(_, rest)| rest);
+    let authority = after_scheme.split('/').next().unwrap_or(after_scheme);
+    // Extract the host, handling bracketed IPv6 (`[::1]:8080`) and `host:port`.
+    let host = authority.strip_prefix('[').map_or_else(
+        || {
+            authority
+                .rsplit_once(':')
+                .map_or(authority, |(host, _port)| host)
+        },
+        |rest| rest.split_once(']').map_or(rest, |(host, _rest)| host),
+    );
+
+    if host.is_empty() || host.eq_ignore_ascii_case("localhost") {
+        return false;
+    }
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        return !(ip.is_loopback() || ip.is_unspecified());
+    }
+    // A non-IP DNS name (pod FQDN / Service DNS) is considered reachable.
+    true
 }
 
 /// Derive a default advertise URI from the bind address. Unspecified hosts

--- a/libs/toolkit/src/bootstrap/oop_tests.rs
+++ b/libs/toolkit/src/bootstrap/oop_tests.rs
@@ -570,6 +570,267 @@ mod database_merge {
 }
 
 // =============================================================================
+// advertise_uri fail-fast (`cpt-cf-adr-instance-addressable-discovery` §5)
+// =============================================================================
+
+mod advertise_uri_reachability {
+    use super::*;
+
+    #[test]
+    fn bind_only_addresses_are_unreachable() {
+        for uri in [
+            "http://127.0.0.1:8080",
+            "http://localhost:8080",
+            "http://0.0.0.0:8080",
+            "http://[::1]:8080",
+            "http://[::]:8080",
+            "https://LOCALHOST:8443",
+        ] {
+            assert!(
+                !advertise_uri_is_reachable(uri),
+                "{uri} should be treated as bind-only / unreachable"
+            );
+        }
+    }
+
+    #[test]
+    fn routable_addresses_are_reachable() {
+        for uri in [
+            // k8s pod FQDN / Service DNS
+            "http://ingest-0.ingest.default.svc:8080",
+            "http://billing.default.svc.cluster.local:8080",
+            // a concrete non-loopback IP
+            "http://10.1.2.3:8080",
+            "http://[2001:db8::1]:8080",
+            // UDS is inherently instance-addressable (single-node Profile 2)
+            "unix:///run/toolkit/ingest.sock",
+        ] {
+            assert!(
+                advertise_uri_is_reachable(uri),
+                "{uri} should be treated as reachable"
+            );
+        }
+    }
+
+    async fn serve_options_with(
+        advertise_uri: Option<&str>,
+        require_reachable: bool,
+    ) -> Result<OopServeOptions> {
+        let cfg = crate::bootstrap::config::OopHttpConfig {
+            listen_addr: "0.0.0.0:8080".to_owned(),
+            probe_bind_addr: None,
+            drain_timeout_secs: 30,
+            healthcheck_timeout_ms: 500,
+            advertise_uri: advertise_uri.map(ToOwned::to_owned),
+            require_reachable_advertise_uri: require_reachable,
+            labels: std::collections::BTreeMap::new(),
+            internal_auth: None,
+        };
+        let dir: Arc<dyn DirectoryClient> = Arc::new(crate::directory::LocalDirectoryClient::new(
+            Arc::new(crate::runtime::GearManager::new()),
+        ));
+        build_oop_serve_options(
+            &cfg,
+            "svc",
+            Uuid::new_v4(),
+            None,
+            Duration::from_secs(5),
+            dir,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn fails_fast_on_loopback_default_when_required() {
+        // advertise_uri unset -> defaults to loopback (0.0.0.0 rewritten to
+        // 127.0.0.1); with the flag set this MUST refuse to start.
+        let err = serve_options_with(None, true).await.unwrap_err();
+        assert!(
+            err.to_string().contains("advertise_uri"),
+            "expected a fail-fast advertise_uri error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn starts_with_reachable_uri_when_required() {
+        let opts = serve_options_with(Some("http://svc.default.svc:8080"), true)
+            .await
+            .expect("reachable advertise_uri should start");
+        assert_eq!(opts.advertise_uri, "http://svc.default.svc:8080");
+    }
+
+    #[tokio::test]
+    async fn loopback_is_allowed_when_not_required() {
+        // Default (flag off) preserves Profile 1 / local-dev behaviour.
+        let opts = serve_options_with(None, false)
+            .await
+            .expect("loopback default is fine when not required");
+        assert!(opts.advertise_uri.contains("127.0.0.1"));
+    }
+}
+
+// =============================================================================
+// role-qualified-name closed-set guard (`cpt-cf-adr-instance-addressable-discovery` §1)
+// =============================================================================
+
+mod role_name_guard {
+    use super::*;
+
+    #[test]
+    fn none_is_a_single_role_gear_and_always_passes() {
+        assert!(validate_role_name("anything", None).is_ok());
+    }
+
+    #[test]
+    fn a_member_of_the_declared_set_passes() {
+        let roles = [
+            "event-broker".to_owned(),
+            "event-broker-ingest".to_owned(),
+            "event-broker-delivery".to_owned(),
+        ];
+        assert!(validate_role_name("event-broker-ingest", Some(&roles)).is_ok());
+        assert!(validate_role_name("event-broker", Some(&roles)).is_ok());
+    }
+
+    #[test]
+    fn a_name_outside_the_declared_set_is_rejected() {
+        let roles = ["event-broker".to_owned(), "event-broker-ingest".to_owned()];
+        // A mis-set boot mode producing an undeclared name must fail fast.
+        let err = validate_role_name("event-broker-typo", Some(&roles)).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("not in the declared role-name set")
+        );
+    }
+
+    #[test]
+    fn effective_role_names_prefers_explicit_override() {
+        // An explicit `OopRunOptions.role_names` wins over discovery.
+        let explicit = vec!["a".to_owned(), "b".to_owned()];
+        let discovered = vec!["x".to_owned()];
+        assert_eq!(
+            effective_role_names(Some(explicit.clone()), discovered),
+            Some(explicit)
+        );
+    }
+
+    #[test]
+    fn effective_role_names_falls_back_to_discovered() {
+        // No explicit set -> use the inventory-discovered role set.
+        let discovered = vec!["event-broker".to_owned(), "event-broker-ingest".to_owned()];
+        assert_eq!(
+            effective_role_names(None, discovered.clone()),
+            Some(discovered)
+        );
+    }
+
+    #[test]
+    fn effective_role_names_none_when_nothing_declared() {
+        // No explicit set and no gear declared roles -> single-role, no constraint.
+        assert_eq!(effective_role_names(None, Vec::new()), None);
+    }
+
+    #[test]
+    fn two_linked_gears_do_not_cross_validate() {
+        // Two role-split gears linked into one binary. Each declares its own
+        // closed set; selection must key on the declaring identity so a name is
+        // validated against *its own* gear's roles, never the cross-gear union
+        // (`cpt-cf-adr-instance-addressable-discovery` §1).
+        let broker: (&str, &[&str]) = ("broker", &["broker", "broker-ingest"]);
+        let cluster: (&str, &[&str]) = ("cluster", &["cluster", "cluster-follower"]);
+        let decls = [broker, cluster];
+
+        // A booted name selects ONLY its own gear's declared set.
+        let broker_roles =
+            crate::registry::select_roles_for(decls.iter().copied(), "broker-ingest").unwrap();
+        assert_eq!(
+            broker_roles,
+            vec!["broker".to_owned(), "broker-ingest".to_owned()]
+        );
+        assert!(!broker_roles.contains(&"cluster".to_owned()));
+
+        let cluster_roles =
+            crate::registry::select_roles_for(decls.iter().copied(), "cluster-follower").unwrap();
+        assert_eq!(
+            cluster_roles,
+            vec!["cluster".to_owned(), "cluster-follower".to_owned()]
+        );
+
+        // The booted name passes against its own gear's roles ...
+        assert!(validate_role_name("broker-ingest", Some(&broker_roles)).is_ok());
+        // ... but must NOT validate against the *other* gear's roles: a union
+        // would have accepted it, per-gear selection rejects the cross-check.
+        assert!(validate_role_name("broker-ingest", Some(&cluster_roles)).is_err());
+
+        // A name declared by neither gear belongs to no role-split gear -> no
+        // constraint (single-role / non-role gear), rather than being wrongly
+        // constrained by another gear's roles.
+        assert_eq!(
+            crate::registry::select_roles_for(decls.iter().copied(), "unrelated"),
+            None
+        );
+    }
+}
+
+// =============================================================================
+// instance labels: config -> OopServeOptions (`cpt-cf-adr-instance-addressable-discovery` §2)
+// =============================================================================
+
+mod instance_labels {
+    use super::*;
+
+    fn cfg_with(
+        labels: std::collections::BTreeMap<String, String>,
+    ) -> crate::bootstrap::config::OopHttpConfig {
+        crate::bootstrap::config::OopHttpConfig {
+            listen_addr: "0.0.0.0:8080".to_owned(),
+            probe_bind_addr: None,
+            drain_timeout_secs: 30,
+            healthcheck_timeout_ms: 500,
+            advertise_uri: None,
+            require_reachable_advertise_uri: false,
+            labels,
+            internal_auth: None,
+        }
+    }
+
+    async fn serve_options_for(cfg: &crate::bootstrap::config::OopHttpConfig) -> OopServeOptions {
+        let dir: Arc<dyn DirectoryClient> = Arc::new(crate::directory::LocalDirectoryClient::new(
+            Arc::new(crate::runtime::GearManager::new()),
+        ));
+        build_oop_serve_options(
+            cfg,
+            "event-broker-ingest",
+            Uuid::new_v4(),
+            None,
+            Duration::from_secs(5),
+            dir,
+        )
+        .await
+        .expect("build should succeed")
+    }
+
+    #[tokio::test]
+    async fn config_labels_thread_through_to_serve_options() {
+        // Config labels surface verbatim on OopServeOptions.labels (which the
+        // presence loop registers with the directory).
+        let cfg = cfg_with(std::collections::BTreeMap::from([
+            ("role".to_owned(), "ingest".to_owned()),
+            ("shard".to_owned(), "3".to_owned()),
+        ]));
+        let opts = serve_options_for(&cfg).await;
+        assert_eq!(opts.labels.get("role").map(String::as_str), Some("ingest"));
+        assert_eq!(opts.labels.get("shard").map(String::as_str), Some("3"));
+    }
+
+    #[tokio::test]
+    async fn no_labels_is_empty() {
+        let opts = serve_options_for(&cfg_with(std::collections::BTreeMap::new())).await;
+        assert!(opts.labels.is_empty());
+    }
+}
+
+// =============================================================================
 // Full OoP Config Build Tests
 // =============================================================================
 

--- a/libs/toolkit/src/directory.rs
+++ b/libs/toolkit/src/directory.rs
@@ -2,39 +2,97 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use std::hash::{Hash, Hasher};
 use std::sync::Arc;
+use toolkit_stable_hash::murmur3_x86_32;
 use uuid::Uuid;
 
 use crate::runtime::{Endpoint, GearInstance, GearManager};
 
+/// Version tag mixed into the [`openapi_spec_hash`] framing. Bump only on an
+/// intentional, breaking change to the token encoding.
+const OPENAPI_SPEC_HASH_VERSION: u8 = 1;
+
+/// Distinct seeds for the two 32-bit halves that compose the 64-bit token.
+const OPENAPI_SPEC_HASH_SEED_HI: u32 = 0x5bd1_e995;
+const OPENAPI_SPEC_HASH_SEED_LO: u32 = 0x1b87_3593;
+
 /// Compute a content token for an `OpenAPI` document, used to detect changes.
 ///
 /// This is a change-detection token (like a k8s `resourceVersion`), **not** a
-/// security digest: the edge only ever compares it against the token from the
-/// previous poll of the *same* directory to decide whether the document
-/// changed. A non-cryptographic `std` hash is therefore sufficient and avoids a
-/// dependency.
+/// security digest: consumers compare it against a previously observed token for
+/// the same spec to decide whether the document changed. A non-cryptographic
+/// hash is therefore sufficient.
 ///
-/// Determinism is scoped to a single binary: `DefaultHasher::new()` uses fixed
-/// keys, so identical input yields the same token for the lifetime of one
-/// directory process. `std` does **not** guarantee the algorithm across Rust
-/// toolchain versions, so a rebuilt/upgraded directory may emit a different
-/// token for the same spec — which is benign here, because tokens are only ever
-/// compared within one directory's poll stream (at worst an upgrade triggers a
-/// single spurious refresh). The token must therefore not be persisted or
-/// compared across binaries.
+/// Uses the versioned stable [`murmur3_x86_32`] rather than `std`'s
+/// `DefaultHasher` so the token is **identical across directory binaries and
+/// Rust versions** (`DefaultHasher` guarantees neither). This matches the wire
+/// contract — the token is serialized (`ServiceInstanceInfo::openapi_spec_hash`)
+/// and consumed by edge clients — so replicas on different builds agree and a
+/// client polling multiple replicas sees no spurious change. Inputs use
+/// **explicit fixed framing** (a version tag plus a length-prefixed field), and
+/// two differently-seeded 32-bit hashes compose the deterministic 64-bit token.
 fn openapi_spec_hash(spec: &str) -> String {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    spec.hash(&mut hasher);
-    format!("{:016x}", hasher.finish())
+    let mut buf = Vec::with_capacity(1 + 8 + spec.len());
+    buf.push(OPENAPI_SPEC_HASH_VERSION);
+    buf.extend_from_slice(&(spec.len() as u64).to_le_bytes());
+    buf.extend_from_slice(spec.as_bytes());
+
+    let hi = murmur3_x86_32(&buf, OPENAPI_SPEC_HASH_SEED_HI);
+    let lo = murmur3_x86_32(&buf, OPENAPI_SPEC_HASH_SEED_LO);
+    let token = (u64::from(hi) << 32) | u64::from(lo);
+    format!("{token:016x}")
 }
 
 // Re-export all types from contracts - this is the single source of truth
 pub use cf_system_sdks::directory::{
-    DirectoryClient, DirectoryInvalidArgument, DirectoryNotFound, GrpcServiceInfo,
+    DirectoryClient, DirectoryInvalidArgument, DirectoryNotFound, GrpcServiceInfo, LabelSelector,
     RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo,
 };
+
+/// Project a live [`GearInstance`] into a [`ServiceInstanceInfo`] resolution
+/// result. Shared by `list_instances` (`include_spec = true`) and
+/// `list_all_instances` (`include_spec = false`, the bounded cross-gear
+/// snapshot). Carries `labels` so `resolve_by_labels` has complete data
+/// (`cpt-cf-adr-instance-addressable-discovery` §2).
+fn instance_to_info(inst: &GearInstance, include_spec: bool) -> ServiceInstanceInfo {
+    // Prefer a gRPC endpoint for the primary `endpoint`; fall back to the REST
+    // endpoint (OoP gears often register REST-only).
+    let endpoint = inst
+        .grpc_services
+        .values()
+        .next()
+        .or(inst.rest_endpoint.as_ref())
+        .map_or_else(
+            || ServiceEndpoint::new(String::new()),
+            |ep| ServiceEndpoint::new(ep.uri.clone()),
+        );
+
+    ServiceInstanceInfo {
+        gear: inst.gear.clone(),
+        instance_id: inst.instance_id.to_string(),
+        endpoint,
+        version: inst.version.clone(),
+        rest_endpoint: inst
+            .rest_endpoint
+            .as_ref()
+            .map(|ep| ServiceEndpoint::new(ep.uri.clone())),
+        openapi_spec_hash: inst.openapi_spec.as_deref().map(openapi_spec_hash),
+        openapi_spec: if include_spec {
+            inst.openapi_spec.clone()
+        } else {
+            None
+        },
+        // Carry every published gRPC service back so the directory-register
+        // phase can augment (not clobber) this instance when it adds a REST
+        // endpoint.
+        grpc_services: inst
+            .grpc_services
+            .iter()
+            .map(|(name, e)| (name.clone(), ServiceEndpoint::new(e.uri.clone())))
+            .collect(),
+        labels: inst.labels.clone(),
+    }
+}
 
 /// Local implementation of `DirectoryClient` that delegates to `GearManager`
 ///
@@ -83,32 +141,16 @@ impl DirectoryClient for LocalDirectoryClient {
     }
 
     async fn list_instances(&self, gear: &str) -> Result<Vec<ServiceInstanceInfo>> {
-        let mut result = Vec::new();
-
-        for inst in self.mgr.instances_of(gear) {
-            if let Some((_, ep)) = inst.grpc_services.iter().next() {
-                result.push(ServiceInstanceInfo {
-                    gear: gear.to_owned(),
-                    instance_id: inst.instance_id.to_string(),
-                    endpoint: ServiceEndpoint::new(ep.uri.clone()),
-                    version: inst.version.clone(),
-                    rest_endpoint: inst
-                        .rest_endpoint
-                        .as_ref()
-                        .map(|ep| ServiceEndpoint::new(ep.uri.clone())),
-                    openapi_spec_hash: inst.openapi_spec.as_deref().map(openapi_spec_hash),
-                    openapi_spec: inst.openapi_spec.clone(),
-                    // Carry every published gRPC service back so the
-                    // directory-register phase can augment (not clobber) this
-                    // instance when it adds a REST endpoint.
-                    grpc_services: inst
-                        .grpc_services
-                        .iter()
-                        .map(|(name, e)| (name.clone(), ServiceEndpoint::new(e.uri.clone())))
-                        .collect(),
-                });
-            }
-        }
+        // Enumeration MUST include **every** instance regardless of transport;
+        // the previous "skip instances with no gRPC service" dropped REST-only
+        // roles that `resolve_by_labels` must be able to target
+        // (`cpt-cf-adr-instance-addressable-discovery`).
+        let result = self
+            .mgr
+            .instances_of(gear)
+            .into_iter()
+            .map(|inst| instance_to_info(&inst, /* include_spec */ true))
+            .collect();
 
         Ok(result)
     }
@@ -118,46 +160,10 @@ impl DirectoryClient for LocalDirectoryClient {
             .mgr
             .all_instances()
             .into_iter()
-            .map(|inst| {
-                // Prefer a gRPC endpoint for the primary `endpoint`; fall back to
-                // the REST endpoint (OoP gears often register REST-only).
-                let endpoint = inst
-                    .grpc_services
-                    .values()
-                    .next()
-                    .or(inst.rest_endpoint.as_ref())
-                    .map_or_else(
-                        || ServiceEndpoint::new(String::new()),
-                        |ep| ServiceEndpoint::new(ep.uri.clone()),
-                    );
-                ServiceInstanceInfo {
-                    gear: inst.gear.clone(),
-                    instance_id: inst.instance_id.to_string(),
-                    endpoint,
-                    version: inst.version.clone(),
-                    rest_endpoint: inst
-                        .rest_endpoint
-                        .as_ref()
-                        .map(|ep| ServiceEndpoint::new(ep.uri.clone())),
-                    // The document itself is deliberately omitted here: the
-                    // cross-gear discovery snapshot must stay small and bounded
-                    // (it is polled every sync interval). Consumers that need
-                    // the document fetch it per gear via `get_openapi_spec`.
-                    // The content hash *is* carried so the edge can detect spec
-                    // changes and skip the fetch + rebuild when unchanged.
-                    openapi_spec_hash: inst.openapi_spec.as_deref().map(openapi_spec_hash),
-                    openapi_spec: None,
-                    // Same rationale as `list_instances`: carry the published
-                    // gRPC services so a later register can augment rather than
-                    // clobber them. Available here because this reads the live
-                    // `GearInstance`.
-                    grpc_services: inst
-                        .grpc_services
-                        .iter()
-                        .map(|(name, e)| (name.clone(), ServiceEndpoint::new(e.uri.clone())))
-                        .collect(),
-                }
-            })
+            // Omit the OpenAPI document (`include_spec = false`) so the polled
+            // cross-gear snapshot stays bounded; the content hash still lets the
+            // edge skip unchanged specs.
+            .map(|inst| instance_to_info(&inst, /* include_spec */ false))
             .collect();
 
         Ok(result)
@@ -191,6 +197,12 @@ impl DirectoryClient for LocalDirectoryClient {
             instance = instance.with_openapi_spec(spec);
         }
 
+        // Apply labels (`cpt-cf-adr-instance-addressable-discovery` §2);
+        // `with_metadata_of` carries them across re-registration.
+        if !info.labels.is_empty() {
+            instance = instance.with_labels(info.labels);
+        }
+
         // Register the instance with the manager
         self.mgr.register_instance(Arc::new(instance));
 
@@ -217,6 +229,30 @@ impl DirectoryClient for LocalDirectoryClient {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn openapi_spec_hash_known_answer_vectors() {
+        // Pinned tokens over representative specs. These MUST stay stable across
+        // directory binaries and Rust versions (the token is serialized and
+        // compared by edge clients); a change means a deliberate encoding bump
+        // (`OPENAPI_SPEC_HASH_VERSION`).
+        let vectors: &[&str] = &[
+            "",
+            "{\"openapi\":\"3.1.0\"}",
+            "{\"openapi\":\"3.1.0\",\"info\":{\"title\":\"calc\"}}",
+        ];
+        let actual: Vec<String> = vectors.iter().map(|s| openapi_spec_hash(s)).collect();
+        let expected: Vec<String> = vec![
+            "fa85af87e70aade0".to_owned(),
+            "88b7d2b224eb6181".to_owned(),
+            "78ac723486d5faee".to_owned(),
+        ];
+        assert_eq!(actual, expected);
+
+        // Tokens are 16 hex chars (zero-padded 64-bit) and change with content.
+        assert!(actual.iter().all(|t| t.len() == 16));
+        assert_ne!(openapi_spec_hash("a"), openapi_spec_hash("b"));
+    }
 
     #[tokio::test]
     async fn test_resolve_grpc_service_not_found() {
@@ -253,6 +289,7 @@ mod tests {
             version: Some("1.0.0".to_owned()),
             rest_endpoint: None,
             openapi_spec: None,
+            labels: std::collections::BTreeMap::new(),
         };
 
         api.register_instance(register_info).await.unwrap();
@@ -278,6 +315,7 @@ mod tests {
             version: Some("1.0.0".to_owned()),
             rest_endpoint: Some(ServiceEndpoint::http("billing", 8080)),
             openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
+            labels: std::collections::BTreeMap::new(),
         };
 
         api.register_instance(register_info).await.unwrap();
@@ -360,6 +398,126 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_by_labels_targets_a_specific_shard() {
+        use std::collections::BTreeMap;
+
+        let dir = Arc::new(GearManager::new());
+        let api = LocalDirectoryClient::new(Arc::clone(&dir));
+
+        // Three shards of one directory name (the `cpt-cf-adr-instance-addressable-discovery` §1 ingest example).
+        for shard in ["0", "1", "2"] {
+            api.register_instance(RegisterInstanceInfo {
+                gear: "event-broker-ingest".to_owned(),
+                instance_id: Uuid::new_v4().to_string(),
+                grpc_services: vec![],
+                version: Some("1.0.0".to_owned()),
+                rest_endpoint: Some(ServiceEndpoint::new(format!("http://ingest-{shard}:8080"))),
+                openapi_spec: None,
+                labels: BTreeMap::from([("shard".to_owned(), shard.to_owned())]),
+            })
+            .await
+            .unwrap();
+        }
+
+        // Targeted resolve pinpoints exactly the requested shard (addressing
+        // only — no health annotation; liveness is the caller's concern).
+        let selector = LabelSelector::new().with("shard", "1");
+        let matched = api
+            .resolve_by_labels("event-broker-ingest", &selector)
+            .await
+            .unwrap();
+        assert_eq!(matched.len(), 1);
+        assert_eq!(
+            matched[0].labels.get("shard").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            matched[0].rest_endpoint.as_ref().map(|e| e.uri.as_str()),
+            Some("http://ingest-1:8080")
+        );
+
+        // An empty selector matches all instances of the name.
+        assert_eq!(
+            api.resolve_by_labels("event-broker-ingest", &LabelSelector::new())
+                .await
+                .unwrap()
+                .len(),
+            3
+        );
+
+        // A non-matching selector yields `Ok(empty)` (not an error).
+        assert!(
+            api.resolve_by_labels(
+                "event-broker-ingest",
+                &LabelSelector::new().with("shard", "9")
+            )
+            .await
+            .unwrap()
+            .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn list_instances_includes_rest_only_roles() {
+        use std::collections::BTreeMap;
+
+        // `cpt-cf-adr-instance-addressable-discovery` enumeration fix: a REST-only instance (no gRPC service) MUST
+        // still be enumerated so `resolve_by_labels` can target it.
+        let dir = Arc::new(GearManager::new());
+        let api = LocalDirectoryClient::new(Arc::clone(&dir));
+        api.register_instance(RegisterInstanceInfo {
+            gear: "rest-only".to_owned(),
+            instance_id: Uuid::new_v4().to_string(),
+            grpc_services: vec![],
+            version: None,
+            rest_endpoint: Some(ServiceEndpoint::http("rest-only", 8080)),
+            openapi_spec: None,
+            labels: BTreeMap::from([("pod".to_owned(), "rest-only-0".to_owned())]),
+        })
+        .await
+        .unwrap();
+
+        let listed = api.list_instances("rest-only").await.unwrap();
+        assert_eq!(listed.len(), 1, "REST-only role must be enumerated");
+        assert_eq!(
+            listed[0].labels.get("pod").map(String::as_str),
+            Some("rest-only-0")
+        );
+    }
+
+    #[tokio::test]
+    async fn labels_survive_reregistration() {
+        use std::collections::BTreeMap;
+
+        // `cpt-cf-adr-instance-addressable-discovery` §2: labels MUST survive the idempotent re-registration path
+        // (a self-heal register must not drop them).
+        let dir = Arc::new(GearManager::new());
+        let api = LocalDirectoryClient::new(Arc::clone(&dir));
+        let id = Uuid::new_v4();
+        let make = |labels: BTreeMap<String, String>| RegisterInstanceInfo {
+            gear: "svc".to_owned(),
+            instance_id: id.to_string(),
+            grpc_services: vec![],
+            version: Some("1.0.0".to_owned()),
+            rest_endpoint: Some(ServiceEndpoint::http("svc", 8080)),
+            openapi_spec: None,
+            labels,
+        };
+
+        api.register_instance(make(BTreeMap::from([("shard".to_owned(), "7".to_owned())])))
+            .await
+            .unwrap();
+        // Re-register the same instance carrying the same labels (self-heal).
+        api.register_instance(make(BTreeMap::from([("shard".to_owned(), "7".to_owned())])))
+            .await
+            .unwrap();
+
+        let insts = dir.instances_of("svc");
+        assert_eq!(insts.len(), 1);
+        assert_eq!(insts[0].labels.get("shard").map(String::as_str), Some("7"));
+    }
+
+    #[tokio::test]
     async fn test_list_all_instances_across_gears() {
         let dir = Arc::new(GearManager::new());
         let api = LocalDirectoryClient::new(Arc::clone(&dir));
@@ -373,6 +531,7 @@ mod tests {
                 version: Some("1.0.0".to_owned()),
                 rest_endpoint: Some(ServiceEndpoint::http(gear, port)),
                 openapi_spec: Some(format!("{{\"openapi\":\"3.1.0\",\"x\":\"{gear}\"}}")),
+                labels: std::collections::BTreeMap::new(),
             })
             .await
             .unwrap();
@@ -389,6 +548,7 @@ mod tests {
                 ServiceEndpoint::new("http://reporting:7000"),
             )],
             version: Some("1.0.0".to_owned()),
+            labels: std::collections::BTreeMap::new(),
             rest_endpoint: None,
             openapi_spec: None,
         })

--- a/libs/toolkit/src/lib.rs
+++ b/libs/toolkit/src/lib.rs
@@ -166,6 +166,11 @@ pub use healthcheck::{
 pub mod discovery;
 pub use discovery::{ConsumerRegistration, DirectoryEndpointResolver};
 
+// Instance-addressable targeting helpers (`cpt-cf-adr-instance-addressable-discovery` §6): label-keyed membership
+// view + consistent-hash pick, and the stale-owner fencing signal.
+pub mod topology;
+pub use topology::{NOT_SHARD_OWNER_PROBLEM_TYPE, NotShardOwner, TopologyView};
+
 // GTS schema support
 pub mod gts;
 

--- a/libs/toolkit/src/registry.rs
+++ b/libs/toolkit/src/registry.rs
@@ -259,6 +259,59 @@ pub struct Registrator(pub fn(&mut RegistryBuilder));
 
 inventory::collect!(Registrator);
 
+/// A gear's declared closed set of role-qualified directory names, submitted by
+/// `#[toolkit::gear(roles = [...])]` (`cpt-cf-adr-instance-addressable-discovery`
+/// section 1) and collected via `inventory`. Retains the declaring gear identity
+/// (`gear`) so the booted gear is validated against only its own role set.
+pub struct DeclaredRoles {
+    /// Bare `#[toolkit::gear(name = ...)]` identity that declared this set.
+    pub gear: &'static str,
+    /// Closed set of role-qualified directory names the gear may register under.
+    pub roles: &'static [&'static str],
+}
+
+inventory::collect!(DeclaredRoles);
+
+/// Deduplicated union of every gear-declared role set linked into this binary.
+/// Whole-binary view only; use [`declared_roles_for`] to scope to the booted gear.
+#[must_use]
+pub fn discovered_role_names() -> Vec<String> {
+    let mut roles: Vec<String> = Vec::new();
+    for declared in ::inventory::iter::<DeclaredRoles> {
+        for &role in declared.roles {
+            if !roles.iter().any(|r| r == role) {
+                roles.push(role.to_owned());
+            }
+        }
+    }
+    roles
+}
+
+/// The role set of the declaration owning `gear_name` (its declaring identity or
+/// one of its role names) — that gear's roles alone, never a union. `None` when
+/// no declaration claims the name (single-role / non-role gear — no constraint).
+pub(crate) fn select_roles_for<'a, I>(declarations: I, gear_name: &str) -> Option<Vec<String>>
+where
+    I: IntoIterator<Item = (&'a str, &'a [&'a str])>,
+{
+    declarations.into_iter().find_map(|(gear, roles)| {
+        (gear == gear_name || roles.contains(&gear_name))
+            .then(|| roles.iter().map(|&r| r.to_owned()).collect())
+    })
+}
+
+/// [`select_roles_for`] over the linked [`DeclaredRoles`] inventory: the booted
+/// gear's own role set, so one gear's name is never validated against another's.
+#[must_use]
+pub fn declared_roles_for(gear_name: &str) -> Option<Vec<String>> {
+    select_roles_for(
+        ::inventory::iter::<DeclaredRoles>
+            .into_iter()
+            .map(|d| (d.gear, d.roles)),
+        gear_name,
+    )
+}
+
 /// The final, topo-sorted runtime registry.
 pub struct GearRegistry {
     gears: Vec<GearEntry>, // topo-sorted

--- a/libs/toolkit/src/runtime/gear_manager.rs
+++ b/libs/toolkit/src/runtime/gear_manager.rs
@@ -1,7 +1,7 @@
 //! Gear Manager - tracks and manages all live gear instances in the runtime
 
 use dashmap::DashMap;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
@@ -95,6 +95,9 @@ pub struct GearInstance {
     pub version: Option<String>,
     pub rest_endpoint: Option<Endpoint>,
     pub openapi_spec: Option<String>,
+    /// Consumer-defined instance labels for within-contract targeting
+    /// (`cpt-cf-adr-instance-addressable-discovery` §2), e.g. `shard`, `pod`.
+    pub labels: BTreeMap<String, String>,
     inner: Arc<parking_lot::RwLock<InstanceRuntimeState>>,
 }
 
@@ -108,6 +111,7 @@ impl Clone for GearInstance {
             version: self.version.clone(),
             rest_endpoint: self.rest_endpoint.clone(),
             openapi_spec: self.openapi_spec.clone(),
+            labels: self.labels.clone(),
             inner: Arc::clone(&self.inner),
         }
     }
@@ -127,6 +131,7 @@ impl GearInstance {
             version: other.version.clone(),
             rest_endpoint: other.rest_endpoint.clone(),
             openapi_spec: other.openapi_spec.clone(),
+            labels: other.labels.clone(),
             inner: Arc::clone(&self.inner),
         }
     }
@@ -142,6 +147,7 @@ impl GearInstance {
             version: None,
             rest_endpoint: None,
             openapi_spec: None,
+            labels: BTreeMap::new(),
             inner: Arc::new(parking_lot::RwLock::new(InstanceRuntimeState {
                 last_heartbeat: Instant::now(),
                 state: InstanceState::Registered,
@@ -171,6 +177,12 @@ impl GearInstance {
 
     pub fn with_openapi_spec(mut self, spec: impl Into<String>) -> Self {
         self.openapi_spec = Some(spec.into());
+        self
+    }
+
+    /// Attach consumer-defined instance labels (`cpt-cf-adr-instance-addressable-discovery` §2).
+    pub fn with_labels(mut self, labels: BTreeMap<String, String>) -> Self {
+        self.labels = labels;
         self
     }
 
@@ -408,23 +420,33 @@ impl GearManager {
         &self,
         service_name: &str,
     ) -> Option<(String, Arc<GearInstance>, Endpoint)> {
-        // Collect all instances that provide this service
-        let mut candidates = Vec::new();
+        // Collect every instance that provides this service, regardless of
+        // health, then prefer serving instances below.
+        let mut all = Vec::new();
         for entry in &self.inner {
             let gear = entry.key().clone();
             for inst in entry.value() {
                 if let Some(ep) = inst.grpc_services.get(service_name) {
-                    let state = inst.state();
-                    if matches!(state, InstanceState::Healthy | InstanceState::Ready) {
-                        candidates.push((gear.clone(), inst.clone(), ep.clone()));
-                    }
+                    all.push((gear.clone(), inst.clone(), ep.clone()));
                 }
             }
         }
 
-        if candidates.is_empty() {
+        if all.is_empty() {
             return None;
         }
+
+        // Prefer serving (`Healthy`/`Ready`) instances, else fall back to the
+        // full not-ready set — same contract as `pick_rest_endpoint_round_robin`
+        // (a non-empty candidate set never yields `None`).
+        let healthy: Vec<_> = all
+            .iter()
+            .filter(|(_, inst, _)| {
+                matches!(inst.state(), InstanceState::Healthy | InstanceState::Ready)
+            })
+            .cloned()
+            .collect();
+        let candidates = if healthy.is_empty() { all } else { healthy };
 
         // Use a counter keyed by service name for round-robin
         let len = candidates.len();
@@ -968,6 +990,31 @@ mod tests {
         assert_ne!(inst1.instance_id, inst2.instance_id);
         // Endpoints should differ
         assert_ne!(ep1, ep2);
+    }
+
+    #[test]
+    fn pick_service_round_robin_falls_back_to_unhealthy() {
+        // `cpt-cf-adr-instance-addressable-discovery` §6: gRPC name-based RR must fall back to the not-ready set
+        // rather than dropping the last route (aligning with the REST helper).
+        let dir = GearManager::new();
+        let id = Uuid::new_v4();
+        let inst = Arc::new(
+            GearInstance::new("svc_gear", id)
+                .with_grpc_service("svc.Service", Endpoint::http("127.0.0.1", 9100)),
+        );
+        dir.register_instance(inst);
+        // Never heartbeat -> stays `Registered` (not serving); quarantine it too.
+        dir.mark_quarantined("svc_gear", id);
+
+        let picked = dir.pick_service_round_robin("svc.Service");
+        assert!(
+            picked.is_some(),
+            "a non-empty candidate set must never yield None, even all-quarantined"
+        );
+        assert_eq!(picked.unwrap().1.instance_id, id);
+
+        // A service with no providing instance still yields None.
+        assert!(dir.pick_service_round_robin("absent.Service").is_none());
     }
 
     #[test]

--- a/libs/toolkit/src/runtime/host_runtime.rs
+++ b/libs/toolkit/src/runtime/host_runtime.rs
@@ -1145,13 +1145,16 @@ impl HostRuntime {
             // (gear, instance_id) with gRPC services during the start phase, so
             // carry those forward instead of clobbering them to empty — adding
             // the REST endpoint must augment, not replace, the entry.
-            let (grpc_services, version) = match dir.list_instances(gear).await {
+            // Carry forward grpc_services, version, AND labels from the existing
+            // entry (`cpt-cf-adr-instance-addressable-discovery` §2: labels MUST survive re-registration) so adding
+            // the REST endpoint augments rather than clobbers the entry.
+            let (grpc_services, version, labels) = match dir.list_instances(gear).await {
                 Ok(insts) => insts
                     .into_iter()
                     .find(|i| i.instance_id == instance_id)
-                    .map(|i| (i.grpc_services, i.version))
+                    .map(|i| (i.grpc_services, i.version, i.labels))
                     .unwrap_or_default(),
-                Err(_) => (Vec::new(), None),
+                Err(_) => (Vec::new(), None, std::collections::BTreeMap::new()),
             };
             let info = crate::RegisterInstanceInfo {
                 gear: gear.to_owned(),
@@ -1162,6 +1165,7 @@ impl HostRuntime {
                 // OpenAPI spec is published separately (grpc-hub start phase);
                 // the REST-augmentation registration does not carry it.
                 openapi_spec: None,
+                labels,
             };
             match dir.register_instance(info).await {
                 Ok(()) => {

--- a/libs/toolkit/src/runtime/host_runtime_oop_tests.rs
+++ b/libs/toolkit/src/runtime/host_runtime_oop_tests.rs
@@ -193,6 +193,7 @@ async fn e2e_oop_gear_boots_serves_registers_and_shuts_down() {
         drain_timeout: Duration::from_secs(5),
         heartbeat_interval: Duration::from_secs(30),
         healthcheck_timeout: Duration::from_millis(500),
+        labels: std::collections::BTreeMap::new(),
         directory: Arc::clone(&directory) as Arc<dyn DirectoryClient>,
         bearer_authenticator: None,
         internal_authenticator: None,

--- a/libs/toolkit/src/runtime/oop_registration_tests.rs
+++ b/libs/toolkit/src/runtime/oop_registration_tests.rs
@@ -79,6 +79,7 @@ fn info() -> RegisterInstanceInfo {
         version: Some("1.0.0".to_owned()),
         rest_endpoint: Some(ServiceEndpoint::new("http://billing:8080")),
         openapi_spec: Some("{}".to_owned()),
+        labels: std::collections::BTreeMap::new(),
     }
 }
 

--- a/libs/toolkit/src/runtime/oop_serve.rs
+++ b/libs/toolkit/src/runtime/oop_serve.rs
@@ -94,6 +94,10 @@ pub struct OopServeOptions {
     /// [`Healthcheck`](crate::healthcheck::Healthcheck) that exceeds this is
     /// reported `Unhealthy`. Mirrors the `api-gateway` `healthcheck_timeout_ms`.
     pub healthcheck_timeout: Duration,
+    /// Deployment-sourced instance labels registered with the
+    /// directory for targeting via `resolve_by_labels` (e.g. `shard`, `pod`).
+    /// From `oop_http.labels`; empty for untargeted gears.
+    pub labels: std::collections::BTreeMap<String, String>,
     /// Directory client used for self-registration and dependency resolution.
     pub directory: Arc<dyn DirectoryClient>,
     /// Tenant-plane authenticator; when `Some`, `security_context_middleware`
@@ -116,6 +120,7 @@ impl std::fmt::Debug for OopServeOptions {
             .field("drain_timeout", &self.drain_timeout)
             .field("heartbeat_interval", &self.heartbeat_interval)
             .field("healthcheck_timeout", &self.healthcheck_timeout)
+            .field("labels", &self.labels)
             .field("bearer_authenticator", &self.bearer_authenticator.is_some())
             .field(
                 "internal_authenticator",
@@ -639,6 +644,7 @@ impl OopHttpServer {
             version: self.options.version.clone(),
             rest_endpoint: Some(ServiceEndpoint::new(self.options.advertise_uri.clone())),
             openapi_spec: Some(openapi_arc.to_string()),
+            labels: self.options.labels.clone(),
         };
         self.registration_task = Some(tokio::spawn(super::oop_registration::presence_loop(
             Arc::clone(&self.options.directory),

--- a/libs/toolkit/src/runtime/oop_serve_tests.rs
+++ b/libs/toolkit/src/runtime/oop_serve_tests.rs
@@ -366,6 +366,7 @@ async fn e2e_startup_readiness_transition_and_graceful_shutdown() {
         drain_timeout: Duration::from_secs(5),
         heartbeat_interval: Duration::from_secs(30),
         healthcheck_timeout: Duration::from_millis(500),
+        labels: std::collections::BTreeMap::new(),
         directory: Arc::clone(&directory),
         bearer_authenticator: None,
         internal_authenticator: None,
@@ -442,6 +443,7 @@ async fn ephemeral_listen_port_updates_advertise_uri() {
         drain_timeout: Duration::from_secs(5),
         heartbeat_interval: Duration::from_secs(30),
         healthcheck_timeout: Duration::from_millis(500),
+        labels: std::collections::BTreeMap::new(),
         directory: Arc::new(E2eDirectory {
             fail_resolve: AtomicUsize::new(0),
             deregistered: AtomicUsize::new(0),
@@ -488,6 +490,7 @@ async fn user_advertise_uri_is_not_overwritten_by_ephemeral_bind_port() {
         drain_timeout: Duration::from_secs(5),
         heartbeat_interval: Duration::from_secs(30),
         healthcheck_timeout: Duration::from_millis(500),
+        labels: std::collections::BTreeMap::new(),
         directory: Arc::new(E2eDirectory {
             fail_resolve: AtomicUsize::new(0),
             deregistered: AtomicUsize::new(0),
@@ -535,6 +538,7 @@ async fn gear_handler_receives_connect_info_through_fallback() {
         drain_timeout: Duration::from_secs(5),
         heartbeat_interval: Duration::from_secs(30),
         healthcheck_timeout: Duration::from_millis(500),
+        labels: std::collections::BTreeMap::new(),
         directory: Arc::new(E2eDirectory {
             fail_resolve: AtomicUsize::new(0),
             deregistered: AtomicUsize::new(0),

--- a/libs/toolkit/src/topology.rs
+++ b/libs/toolkit/src/topology.rs
@@ -1,0 +1,421 @@
+//! Instance-addressable topology helpers (`cpt-cf-adr-instance-addressable-discovery` §6).
+//!
+//! Toolkit *mechanisms* that targeting consumers (the event-broker dispatcher,
+//! the cluster coordinator) would otherwise each re-implement:
+//!
+//! * [`TopologyView`] — a label-keyed membership view over
+//!   [`resolve_by_labels`](crate::DirectoryClient::resolve_by_labels) with
+//!   refresh and a consistent-hash [`pick`](TopologyView::pick).
+//! * [`NotShardOwner`] — the typed "not the owner" signal for the stale-owner
+//!   correction path.
+//!
+//! Both stay **mechanism**: the gear owns the hash key, the selection *policy*,
+//! and the ownership assignment; these only remove the poll/refresh/hash
+//! boilerplate and standardize the correction protocol.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use toolkit_stable_hash::murmur3_x86_32;
+
+use crate::DirectoryClient;
+use cf_system_sdks::directory::{LabelSelector, ServiceInstanceInfo};
+
+/// RFC-9457 problem-type slug a gear SHOULD use when it surfaces a
+/// [`NotShardOwner`] over HTTP (`cpt-cf-adr-instance-addressable-discovery` §6). The concrete `Problem` / GTS
+/// wiring is owned by the gear's HTTP boundary; this is only the shared slug so
+/// callers and targets agree on the identifier.
+pub const NOT_SHARD_OWNER_PROBLEM_TYPE: &str = "not-shard-owner";
+
+/// The typed "not the owner" rejection of the stale-ownership correction path
+/// (`cpt-cf-adr-instance-addressable-discovery` §6).
+///
+/// A target MUST return this for a shard/partition/lease it no longer owns,
+/// **optionally carrying the current owner's stable label** so the caller can
+/// re-target without a full re-enumeration. The caller MUST treat it as a
+/// **signal to refresh** its ownership map (via `resolve_by_labels`) and retry
+/// against the corrected owner — **not** as a normal application error.
+///
+/// It is carried through [`anyhow::Error`] and recovered by downcast, the same
+/// sentinel pattern as `DirectoryNotFound`, so it survives transport/`?`
+/// boundaries without a bespoke error enum on every call site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NotShardOwner {
+    /// The shard/partition/lease key the caller targeted, for diagnostics.
+    pub requested: String,
+    /// The current owner's stable label(s) (e.g. `{shard: "7"}` or
+    /// `{pod: "ingest-2"}`), if the target knows who took over. When present the
+    /// caller can re-target directly; when `None` it must re-enumerate.
+    pub current_owner: Option<BTreeMap<String, String>>,
+}
+
+impl NotShardOwner {
+    /// A fence with no known current owner — the caller must re-enumerate.
+    #[must_use]
+    pub fn new(requested: impl Into<String>) -> Self {
+        Self {
+            requested: requested.into(),
+            current_owner: None,
+        }
+    }
+
+    /// A fence carrying the current owner's stable label so the caller can
+    /// re-target without a full re-enumeration.
+    #[must_use]
+    pub fn with_owner(
+        requested: impl Into<String>,
+        current_owner: BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            requested: requested.into(),
+            current_owner: Some(current_owner),
+        }
+    }
+
+    /// Recover a [`NotShardOwner`] from an [`anyhow::Error`], if that is what it
+    /// wraps. Callers use this to distinguish the fence (refresh + retry) from a
+    /// genuine application error.
+    #[must_use]
+    pub fn from_anyhow(err: &anyhow::Error) -> Option<&Self> {
+        err.downcast_ref::<Self>()
+    }
+}
+
+impl std::fmt::Display for NotShardOwner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "not the owner of {}", self.requested)?;
+        if let Some(owner) = &self.current_owner {
+            write!(f, " (current owner:")?;
+            for (k, v) in owner {
+                write!(f, " {k}={v}")?;
+            }
+            write!(f, ")")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for NotShardOwner {}
+
+/// A label-keyed membership view over one directory name (`cpt-cf-adr-instance-addressable-discovery` §6).
+///
+/// Holds the latest [`resolve_by_labels`](DirectoryClient::resolve_by_labels)
+/// snapshot for `(name, selector)`; [`refresh`](Self::refresh) re-polls it,
+/// [`instances`](Self::instances) reads it, and [`pick`](Self::pick) does a
+/// consistent-hash selection over the matched set.
+pub struct TopologyView {
+    client: Arc<dyn DirectoryClient>,
+    name: String,
+    selector: LabelSelector,
+    snapshot: parking_lot::RwLock<Vec<ServiceInstanceInfo>>,
+}
+
+impl TopologyView {
+    /// Build a view over `name` filtered by `selector`. The snapshot starts
+    /// empty; call [`refresh`](Self::refresh) to populate it.
+    #[must_use]
+    pub fn new(
+        client: Arc<dyn DirectoryClient>,
+        name: impl Into<String>,
+        selector: LabelSelector,
+    ) -> Self {
+        Self {
+            client,
+            name: name.into(),
+            selector,
+            snapshot: parking_lot::RwLock::new(Vec::new()),
+        }
+    }
+
+    /// Re-poll `resolve_by_labels(name, selector)` and replace the snapshot.
+    ///
+    /// `Ok(empty)` is a valid (not-ready-yet) result and simply stores an empty
+    /// snapshot; only a backend error propagates.
+    ///
+    /// # Errors
+    /// Propagates a directory-backend failure from `resolve_by_labels`.
+    pub async fn refresh(&self) -> Result<()> {
+        let instances = self
+            .client
+            .resolve_by_labels(&self.name, &self.selector)
+            .await?;
+        *self.snapshot.write() = instances;
+        Ok(())
+    }
+
+    /// The current snapshot of matched instances.
+    #[must_use]
+    pub fn instances(&self) -> Vec<ServiceInstanceInfo> {
+        self.snapshot.read().clone()
+    }
+
+    /// Consistent-hash pick of the instance that owns `hash_key` (rendezvous /
+    /// HRW over `instance_id`).
+    ///
+    /// `None` only when the snapshot is empty. Deterministic for a given
+    /// snapshot + key, with ≈1/N of keys remapping when membership changes.
+    /// Picks the *owner* regardless of transient health: if it is down, the
+    /// caller learns at call time and corrects via the stale-owner path
+    /// ([`NotShardOwner`]).
+    #[must_use]
+    pub fn pick(&self, hash_key: &str) -> Option<ServiceInstanceInfo> {
+        self.snapshot
+            .read()
+            .iter()
+            .max_by_key(|inst| rendezvous_score(hash_key, &inst.instance_id))
+            .cloned()
+    }
+}
+
+/// Version tag mixed into the rendezvous framing. Bump only on an intentional,
+/// breaking change to the scoring encoding (it remaps ownership).
+const RENDEZVOUS_HASH_VERSION: u8 = 1;
+
+/// Distinct seeds for the two 32-bit halves that compose the `u64` score.
+const RENDEZVOUS_SEED_HI: u32 = 0x9747_b28c;
+const RENDEZVOUS_SEED_LO: u32 = 0x2545_f491;
+
+/// Rendezvous (HRW) weight for `(key, node)`: a non-cryptographic hash is
+/// sufficient — the property required is a uniform, deterministic ordering, not
+/// collision resistance.
+///
+/// Uses the versioned stable [`murmur3_x86_32`] instead of `std`'s
+/// `DefaultHasher` so the ordering is **identical across toolkit and Rust
+/// versions** (`DefaultHasher` guarantees neither), keeping shard ownership
+/// stable across rebuilds. Inputs are combined with **explicit fixed framing** —
+/// a version tag plus length-prefixed fields — so `(key, node)` boundaries are
+/// unambiguous (e.g. `("ab", "c")` never collides with `("a", "bc")`). Two
+/// differently-seeded 32-bit hashes compose the deterministic `u64` score.
+fn rendezvous_score(key: &str, node: &str) -> u64 {
+    let mut buf = Vec::with_capacity(1 + 16 + key.len() + node.len());
+    buf.push(RENDEZVOUS_HASH_VERSION);
+    buf.extend_from_slice(&(key.len() as u64).to_le_bytes());
+    buf.extend_from_slice(key.as_bytes());
+    buf.extend_from_slice(&(node.len() as u64).to_le_bytes());
+    buf.extend_from_slice(node.as_bytes());
+
+    let hi = murmur3_x86_32(&buf, RENDEZVOUS_SEED_HI);
+    let lo = murmur3_x86_32(&buf, RENDEZVOUS_SEED_LO);
+    (u64::from(hi) << 32) | u64::from(lo)
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use cf_system_sdks::directory::{RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo};
+
+    /// A directory stub whose `list_instances` returns a fixed set (the
+    /// `resolve_by_labels` default filters it).
+    struct StubDirectory {
+        instances: Vec<ServiceInstanceInfo>,
+    }
+
+    fn inst(id: &str, shard: &str) -> ServiceInstanceInfo {
+        ServiceInstanceInfo {
+            gear: "event-broker-ingest".to_owned(),
+            instance_id: id.to_owned(),
+            endpoint: ServiceEndpoint::new(format!("http://{id}:8080")),
+            version: None,
+            rest_endpoint: Some(ServiceEndpoint::new(format!("http://{id}:8080"))),
+            openapi_spec: None,
+            openapi_spec_hash: None,
+            grpc_services: Vec::new(),
+            labels: BTreeMap::from([("shard".to_owned(), shard.to_owned())]),
+        }
+    }
+
+    #[async_trait]
+    impl DirectoryClient for StubDirectory {
+        async fn resolve_grpc_service(&self, _: &str) -> Result<ServiceEndpoint> {
+            unimplemented!()
+        }
+        async fn resolve_rest_service(&self, _: &str) -> Result<ServiceEndpoint> {
+            unimplemented!()
+        }
+        async fn get_openapi_spec(&self, _: &str) -> Result<String> {
+            unimplemented!()
+        }
+        async fn list_instances(&self, _: &str) -> Result<Vec<ServiceInstanceInfo>> {
+            Ok(self.instances.clone())
+        }
+        async fn list_all_instances(&self) -> Result<Vec<ServiceInstanceInfo>> {
+            Ok(self.instances.clone())
+        }
+        async fn register_instance(&self, _: RegisterInstanceInfo) -> Result<()> {
+            unimplemented!()
+        }
+        async fn deregister_instance(&self, _: &str, _: &str) -> Result<()> {
+            unimplemented!()
+        }
+        async fn send_heartbeat(&self, _: &str, _: &str) -> Result<()> {
+            unimplemented!()
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_loads_matched_instances() {
+        let dir = Arc::new(StubDirectory {
+            instances: vec![
+                inst("ingest-0", "0"),
+                inst("ingest-1", "1"),
+                inst("ingest-2", "2"),
+            ],
+        });
+        let view = TopologyView::new(dir, "event-broker-ingest", LabelSelector::new());
+        view.refresh().await.unwrap();
+        assert_eq!(view.instances().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn pick_is_deterministic_and_covers_all_matched() {
+        let dir = Arc::new(StubDirectory {
+            instances: vec![
+                inst("ingest-0", "0"),
+                inst("ingest-1", "1"),
+                inst("ingest-2", "2"),
+            ],
+        });
+        let view = TopologyView::new(dir, "event-broker-ingest", LabelSelector::new());
+        view.refresh().await.unwrap();
+
+        // Deterministic for a given snapshot + key (picks the owner regardless
+        // of health — no serving filter).
+        let a = view.pick("partition-42").unwrap();
+        let b = view.pick("partition-42").unwrap();
+        assert_eq!(a.instance_id, b.instance_id);
+
+        // Different keys spread across the matched set (the owner is one of them).
+        let owners: std::collections::BTreeSet<_> = (0..50)
+            .map(|i| view.pick(&format!("k-{i}")).unwrap().instance_id)
+            .collect();
+        assert!(
+            owners.len() > 1,
+            "hash ring should spread keys across owners"
+        );
+    }
+
+    #[tokio::test]
+    async fn pick_none_when_empty() {
+        let dir = Arc::new(StubDirectory { instances: vec![] });
+        let view = TopologyView::new(dir, "event-broker-ingest", LabelSelector::new());
+        view.refresh().await.unwrap();
+        assert!(view.pick("k").is_none());
+    }
+
+    #[test]
+    fn rendezvous_score_known_answer_vectors() {
+        // Pinned vectors over representative key/node pairs. These MUST stay
+        // stable across toolkit and Rust versions (shard ownership depends on
+        // the ordering); a change here means a deliberate encoding bump
+        // (`RENDEZVOUS_HASH_VERSION`), which remaps ownership.
+        let vectors: &[(&str, &str)] = &[
+            ("", ""),
+            ("partition-42", "ingest-0"),
+            ("partition-42", "ingest-1"),
+            ("k-1", "ingest-2"),
+            ("shard-7", "node-a"),
+        ];
+        let actual: Vec<u64> = vectors
+            .iter()
+            .map(|&(k, n)| rendezvous_score(k, n))
+            .collect();
+        let expected: Vec<u64> = vec![
+            3_576_388_067_079_361_786,
+            15_910_422_322_216_717_070,
+            5_515_605_313_099_864_569,
+            2_581_831_032_155_280_097,
+            15_212_296_452_332_127_228,
+        ];
+        assert_eq!(actual, expected);
+
+        // Explicit framing: field boundaries are unambiguous, so a shared
+        // concatenation ("abc") maps to distinct scores under different splits.
+        assert_ne!(rendezvous_score("ab", "c"), rendezvous_score("a", "bc"));
+    }
+
+    #[test]
+    fn not_shard_owner_is_recoverable_by_downcast() {
+        let owner = BTreeMap::from([("shard".to_owned(), "7".to_owned())]);
+        let err: anyhow::Error = NotShardOwner::with_owner("shard-7", owner.clone()).into();
+        let recovered = NotShardOwner::from_anyhow(&err).expect("downcast");
+        assert_eq!(recovered.requested, "shard-7");
+        assert_eq!(recovered.current_owner.as_ref(), Some(&owner));
+
+        // A different error is not mistaken for the fence.
+        let other = anyhow::anyhow!("boom");
+        assert!(NotShardOwner::from_anyhow(&other).is_none());
+    }
+
+    #[test]
+    fn not_shard_owner_new_has_no_current_owner() {
+        let fence = NotShardOwner::new("partition-3");
+        assert_eq!(fence.requested, "partition-3");
+        assert!(fence.current_owner.is_none());
+    }
+
+    #[test]
+    fn not_shard_owner_display_covers_both_branches() {
+        // Without a known owner: just the requested key.
+        assert_eq!(
+            NotShardOwner::new("shard-9").to_string(),
+            "not the owner of shard-9"
+        );
+
+        // With a known owner: the stable label(s) are appended (BTreeMap orders
+        // keys, so the rendering is deterministic).
+        let owner = BTreeMap::from([
+            ("pod".to_owned(), "ingest-2".to_owned()),
+            ("shard".to_owned(), "7".to_owned()),
+        ]);
+        assert_eq!(
+            NotShardOwner::with_owner("shard-7", owner).to_string(),
+            "not the owner of shard-7 (current owner: pod=ingest-2 shard=7)"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_propagates_backend_error() {
+        struct ErrDirectory;
+
+        #[async_trait]
+        impl DirectoryClient for ErrDirectory {
+            async fn resolve_grpc_service(&self, _: &str) -> Result<ServiceEndpoint> {
+                unimplemented!()
+            }
+            async fn resolve_rest_service(&self, _: &str) -> Result<ServiceEndpoint> {
+                unimplemented!()
+            }
+            async fn get_openapi_spec(&self, _: &str) -> Result<String> {
+                unimplemented!()
+            }
+            async fn list_instances(&self, _: &str) -> Result<Vec<ServiceInstanceInfo>> {
+                anyhow::bail!("directory backend down")
+            }
+            async fn list_all_instances(&self) -> Result<Vec<ServiceInstanceInfo>> {
+                unimplemented!()
+            }
+            async fn register_instance(&self, _: RegisterInstanceInfo) -> Result<()> {
+                unimplemented!()
+            }
+            async fn deregister_instance(&self, _: &str, _: &str) -> Result<()> {
+                unimplemented!()
+            }
+            async fn send_heartbeat(&self, _: &str, _: &str) -> Result<()> {
+                unimplemented!()
+            }
+        }
+
+        let view = TopologyView::new(
+            Arc::new(ErrDirectory),
+            "event-broker-ingest",
+            LabelSelector::new(),
+        );
+        // A backend failure surfaces (rather than being swallowed as empty), and
+        // the snapshot stays empty.
+        assert!(view.refresh().await.is_err());
+        assert!(view.instances().is_empty());
+    }
+}

--- a/libs/toolkit/tests/roles_discovery.rs
+++ b/libs/toolkit/tests/roles_discovery.rs
@@ -1,0 +1,44 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! `cpt-cf-adr-instance-addressable-discovery` section 1: a role-split gear's
+//! closed role set is auto-discovered from its `#[toolkit::gear(roles = [...])]`
+//! declaration via the `DeclaredRoles` inventory, so `OoP` bootstrap can enforce
+//! the role / front-door split with no `main.rs` wiring.
+//!
+//! This test lives in its own binary so the process-global `inventory` set holds
+//! exactly the gear declared here.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use toolkit::{contracts::Gear, gear};
+
+#[derive(Default)]
+#[gear(name = "evbk", roles = ["evbk", "evbk-ingest", "evbk-delivery"])]
+struct RoleSplitGear;
+
+#[async_trait]
+impl Gear for RoleSplitGear {
+    async fn init(&self, _ctx: &toolkit::context::GearCtx) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn macro_emits_roles_const() {
+    assert_eq!(
+        RoleSplitGear::ROLES,
+        &["evbk", "evbk-ingest", "evbk-delivery"]
+    );
+}
+
+#[test]
+fn declared_roles_are_discovered_from_inventory() {
+    // The gear's declared set is discoverable without any `main.rs` forwarding.
+    let roles = toolkit::registry::discovered_role_names();
+    for expected in ["evbk", "evbk-ingest", "evbk-delivery"] {
+        assert!(
+            roles.iter().any(|r| r == expected),
+            "discovered_role_names() should contain {expected:?}, got {roles:?}"
+        );
+    }
+}


### PR DESCRIPTION
Implements the codegen-independent half of `cpt-cf-adr-instance-addressable-discovery`: the raw addressing capability that lets role-split / sharded gears be targeted with plain HTTP/gRPC clients, without a second discovery layer. 
 
Directory SDK (contract shape):
- Add instance `labels` to ServiceInstanceInfo / RegisterInstanceInfo and the directory proto (InstanceInfo), propagated through register + grpc client.
- Add `LabelSelector` (equality-AND, k8s matchLabels style) and `resolve_by_labels` on DirectoryClient; enumerate all instances of a name.
- Add gRPC endpoint targeting over the wire (`InstanceInfo.grpc_services`).
 
Toolkit runtime / bootstrap:
- Wire `oop_http.labels` (AppConfig / APP__OOP_HTTP__LABELS__*) through OopServeOptions to registration.
- Add `topology::TopologyView` (label snapshot + rendezvous/HRW ownership pick) and the `NotShardOwner` stale-ownership correction fence.
- gear_manager round-robin falls back to the not-ready set so the last route is never dropped.
 
Role-qualified names (structural front-door split):
- `#[toolkit::gear(roles = [...])]` declares a gear's closed set of directory names and requires the bare `name` to be a member (compile error otherwise).
- The macro emits a `ROLES` const and self-registers the set into the `DeclaredRoles` inventory; OoP bootstrap auto-discovers and enforces it in `run_oop_with_options`, so enforcement cannot be forgotten in `main.rs`. An explicit `OopRunOptions.role_names` still overrides.
 
Docs: update ADR-0009 / DESIGN / PRD.
 
Deferred: 
- Typed-client targeting
- The directory watch/change-notification stream
- Richer label matching (in/notin/!=, set-based expressions)

Refs: cpt-cf-adr-instance-addressable-discovery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added label-based instance registration, discovery, and filtering.
  - Preserved instance labels and gRPC service endpoints across directory operations.
  - Added topology views with label filtering and deterministic owner selection.
  - Added support for declaring and validating gear roles.
  - Added configurable advertised-URI reachability checks and deployment labels.

- **Bug Fixes**
  - Improved service selection to prefer healthy instances while providing fallback behavior.
  - Preserved metadata during REST endpoint registration and re-registration.

- **Documentation**
  - Updated architecture and product documentation for label-based discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->