### PR TITLE
fix(release): fix dev-dep cycles breaking publish, unify release-plz.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
               - 'Makefile'
               - 'rust-toolchain.toml'
               - '.cargo/**'
+              # Input to `make check-release-config` in the test job: a config-only
+              # edit must still get the release configuration validated.
+              - 'release-plz.toml'
             fips:
               - 'libs/toolkit/**'
               - 'libs/toolkit-http/**'
@@ -212,6 +215,9 @@ jobs:
 
       - name: Validate packaging metadata (readme/license-file paths)
         run: make check-packaging-metadata
+
+      - name: Validate release configuration (publish flags, release-plz.toml)
+        run: make check-release-config
 
       - name: Install Go (required for aws-lc-fips-sys FIPS build)
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0

--- a/Makefile
+++ b/Makefile
@@ -344,6 +344,10 @@ validate-gear-names:
 check-packaging-metadata:
 	@$(PYTHON) tools/scripts/check_packaging_metadata.py
 
+## Validate that examples/apps/tools are unpublishable and release-plz.toml matches the workspace
+check-release-config:
+	@$(PYTHON) tools/scripts/check_release_config.py
+
 # -------- Code security checks --------
 
 .PHONY: deny fips-policy security

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -36,23 +36,89 @@ Workflows:
 
 ### What gets published
 
-Publishing is controlled by Cargo manifests:
+Publishing is controlled by Cargo manifests, and by them alone — `release-plz.toml` has
+no say in it:
 - crates with `publish = false` are **never published**
-- crates without `publish = false` are **publishable** (subject to crates.io rules)
+- so are crates with no `version` field at all: cargo refuses to publish those, and
+  reports them exactly like the explicit form (`gears/bss/**` relies on this today)
+- everything else is **publishable** (subject to crates.io rules)
+
+A crate that is not publishable is skipped by release-plz completely — no version bump,
+no tag, no changelog, no release. It therefore needs no entry in `release-plz.toml`, and
+adding one is dead config.
 
 This repo is configured so that:
-- `apps/**` and `examples/**` are **not** publishable (we set `publish = false`)
+- `apps/**`, `examples/**` and `tools/**` are **not** publishable (we set `publish = false`)
 - `libs/**` and `gears/**` are publishable as intended
+
+That first rule is enforced, not just documented: `make check-release-config` fails if a
+crate under those directories is publishable, and CI runs it on every build (see
+[`ci.yml`](../.github/workflows/ci.yml)). Forgetting `publish = false` in a new example is
+otherwise invisible until the crate is on crates.io, where a publish cannot be undone.
+
+### What gets a changelog and a GitHub Release
+
+Publishing is one thing; the changelog section and the GitHub Release page that come with
+it are configured separately, in [`release-plz.toml`](../release-plz.toml), by path:
+
+- **`gears/**`** — gears, their SDKs and their plugins each get their own section in the
+  root [`CHANGELOG.md`](../CHANGELOG.md) and their own GitHub Release. This is what the
+  `[workspace]` defaults in `release-plz.toml` give them, so **a new gear needs no entry
+  in that file**.
+- **`libs/**`** — the framework is published and tagged as usual, but folded into the
+  single `cf-gears-toolkit` release: no changelog section, no Release page of its own.
+  Every such crate is listed explicitly, so **a new `libs/**` crate does need one entry**
+  (`changelog_update = false`, `git_release_enable = false`).
+
+Per-crate git tags (`<crate>-v<version>`) are created for every published crate under
+either rule — `git_tag_enable` is left at its default and never set in this repo.
+
+`make check-release-config` also enforces this half: a missing `libs/**` entry, an entry
+for a `gears/**` crate, an entry for an unpublishable or no-longer-existing crate, or a
+flag set to the wrong value all fail the build. An omitted entry is not inert — the crate
+silently starts producing its own changelog and releases.
+
+Known rough edge: release-plz parses the root `CHANGELOG.md` to build a release body, and
+one shared file for ~80 independently versioned crates is ambiguous — when two crates
+have released the same version number, the parse fails and that release body comes out
+empty (`WARN … multiple release notes for 'X'` in the release job log). The fix, if this
+starts to matter, is a changelog file per crate via `changelog_path` in a `[[package]]`
+section; it is deliberately not done today.
 
 ### Versioning policy (as implemented)
 
-- **Framework (`libs/toolkit-*`)**: share a single version via `version.workspace = true` and the root workspace version (`Cargo.toml` → `[workspace.package] version`).
-- **System SDKs (`libs/system-sdks/**`)**: each crate has its own explicit version.
-- **Gears (`gears/**`)**: each gear and each `*-sdk` has its own explicit version.
+Every crate carries its own explicit `version` in its `Cargo.toml`; nothing inherits a
+version from the workspace (the root `[workspace.package]` has no `version` field, and
+`version.workspace = true` is used nowhere). release-plz bumps each one independently
+based on that crate's commits.
+
+Crates that share a version number do so because they are released together in practice,
+not because Cargo enforces it.
 
 ### Dependency ordering
 
 release-plz publishes crates in the correct order for intra-workspace dependencies.
+
+One case it cannot order away: a **dev-dependency cycle**, where `A` regular-depends on
+`B` and `B` dev-depends on `A`. Cargo permits the cycle, and `B` is published first (it is
+`A`'s dependency), but `cargo package` still resolves `B`'s dev-dependencies against
+crates.io — so a versioned dev-dep on `A` demands a release of `A` that does not exist
+yet, and the release fails with:
+
+```
+error: failed to prepare local package for uploading
+  failed to select a version for the requirement `A = "^x.y.z"`
+```
+
+Declare such a dev-dependency **path-only, with no version** — not `workspace = true`,
+which carries one. Cargo drops path-only dev-dependencies from the published manifest, so
+the cycle never reaches crates.io. `make check-release-config` enforces this too: a
+versioned dev-dep is allowed only on a crate that is also a (transitive) normal dependency,
+because that is the only case where release-plz guarantees it is already published.
+Existing examples:
+[`libs/toolkit-contract`](../libs/toolkit-contract/Cargo.toml),
+[`libs/toolkit-odata-macros`](../libs/toolkit-odata-macros/Cargo.toml),
+[`gears/system/cluster/cluster`](../gears/system/cluster/cluster/Cargo.toml).
 
 ### Safety checks
 

--- a/examples/toolkit/api-contracts/api-contracts-consumer/Cargo.toml
+++ b/examples/toolkit/api-contracts/api-contracts-consumer/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 repository.workspace = true
 description = "api-contracts example — consumer gear that resolves PaymentApi from another gear via ClientHub"
 rust-version.workspace = true
+publish = false
 
 [features]
 default = []

--- a/examples/toolkit/api-contracts/api-contracts-sdk/Cargo.toml
+++ b/examples/toolkit/api-contracts/api-contracts-sdk/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 repository.workspace = true
 description = "SDK for the api-contracts example module — PaymentApi contract, models, and errors"
 rust-version.workspace = true
+publish = false
 
 [features]
 default = []

--- a/examples/toolkit/api-contracts/api-contracts/Cargo.toml
+++ b/examples/toolkit/api-contracts/api-contracts/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 repository.workspace = true
 description = "api-contracts example module — PaymentApi with local and HTTP transport"
 rust-version.workspace = true
+publish = false
 
 [features]
 default = []

--- a/libs/toolkit-contract/Cargo.toml
+++ b/libs/toolkit-contract/Cargo.toml
@@ -121,7 +121,11 @@ uuid = { workspace = true, features = ["v4"] }
 # (feature = "rest-server") references `::toolkit::api::{OperationBuilder,
 # OpenApiRegistry}`, so exercising that codegen in this crate's own tests needs
 # `toolkit` + `utoipa` (for the `ToSchema` bound on request/response DTOs).
-toolkit = { workspace = true }
+# Path-only, no version on purpose — not `workspace = true`, which would carry one:
+# cargo drops a path-only dev-dependency from the published manifest. With a version,
+# publishing this crate demands that exact `toolkit` release from crates.io, and it is
+# published *after* us (it depends on this crate), so the release fails.
+toolkit = { package = "cf-gears-toolkit", path = "../toolkit" }
 utoipa = { workspace = true }
 # otel_propagation.rs (feature = "otel"): builds an in-process (no exporter)
 # SdkTracerProvider to prove the generated client span's trace_id propagates

--- a/libs/toolkit-odata-macros/Cargo.toml
+++ b/libs/toolkit-odata-macros/Cargo.toml
@@ -27,5 +27,11 @@ heck = { workspace = true }
 
 [dev-dependencies]
 trybuild = { workspace = true }
-toolkit-odata = { workspace = true }
+# Dev-only cycle (Cargo permits dev-dependency cycles): `toolkit-odata` regular-depends
+# on this crate, and this crate's trybuild/UI tests expand the derives against it.
+# Path-only, no version on purpose — not `workspace = true`, which would carry one:
+# cargo drops a path-only dev-dependency from the published manifest. With a version,
+# publishing this crate demands that exact `toolkit-odata` release from crates.io, and it
+# is published *after* us (it depends on this crate), so the release fails.
+toolkit-odata = { package = "cf-gears-toolkit-odata", path = "../toolkit-odata" }
 uuid = { workspace = true, features = ["v7"] }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,7 +1,24 @@
 [workspace]
-# Keep the defaults simple and explicit. We rely on Cargo manifests for:
-# - which crates are publishable (`publish = false` disables)
-# - per-crate versioning (every crate has its own explicit `version = ...`)
+# Two different questions, decided in two different places — do not conflate them:
+#
+# - *Is a crate published at all?* Decided by its Cargo manifest alone (`publish = false`
+#   disables it). release-plz skips such a crate entirely — no version bump, no tag, no
+#   changelog, no release — so it needs no entry in this file. Adding one is dead config.
+# - *What does a published crate get on top of the publish?* Decided here: a section in
+#   CHANGELOG.md (`changelog_update`) and a GitHub Release page (`git_release_enable`).
+#
+# The rule for the second question, by path:
+#
+# - `gears/**` (gears, their SDKs, their plugins) — own changelog section, own GitHub
+#   Release. That is exactly what the defaults below give, so a new gear needs NO entry
+#   in this file.
+# - `libs/**` (the framework) — published and tagged, but folded into the single
+#   `cf-gears-toolkit` release: no changelog section, no Release page of its own. Each
+#   one is listed below, so a new `libs/**` crate DOES need one entry here.
+#
+# Per-crate versions come from the manifests (every crate has an explicit `version`).
+# Per-crate git tags are created for every published crate under either rule —
+# `git_tag_enable` is left at its default and is not set anywhere in this file.
 #
 # NOTE: release-plz may temporarily checkout commits while computing diffs.
 # Some repos can end up "dirty" due to generated/normalized files, so we allow it.
@@ -10,6 +27,10 @@ allow_dirty = true
 # Label the release PR so it is easy to spot in the PR list. No workflow filters on it:
 # the publish job decides what to release by comparing manifests against crates.io.
 pr_labels = ["release-plz"]
+
+# Defaults, i.e. the `gears/**` behaviour. These are also release-plz's own defaults;
+# kept explicit because they are load-bearing here — they are what every unlisted crate
+# inherits.
 changelog_update = true
 git_release_enable = true
 
@@ -62,9 +83,15 @@ body = """
 {% endmacro -%}
 """
 
-# ToolKit Framework - unified release
-# Only cf-gears-toolkit gets changelog entries and GitHub releases
-# All other cf-gears-toolkit-* crates are published to crates.io but without separate changelog/releases
+# ─────────────────────────────────────────────────────────────────────────────
+# Framework — everything under `libs/**`.
+#
+# `cf-gears-toolkit` carries the framework's changelog and its GitHub Release; every
+# other `libs/**` crate is published and tagged but folded into it. Keep this list in
+# sync with the publishable crates under `libs/**` — an omission is not inert, the crate
+# silently starts producing its own changelog section and Release page.
+# ─────────────────────────────────────────────────────────────────────────────
+
 [[package]]
 name = "cf-gears-toolkit"
 changelog_update = true
@@ -72,6 +99,16 @@ git_release_enable = true
 
 [[package]]
 name = "cf-gears-toolkit-auth"
+changelog_update = false
+git_release_enable = false
+
+[[package]]
+name = "cf-gears-toolkit-canonical-errors"
+changelog_update = false
+git_release_enable = false
+
+[[package]]
+name = "cf-gears-toolkit-canonical-errors-macro"
 changelog_update = false
 git_release_enable = false
 
@@ -86,15 +123,39 @@ changelog_update = false
 git_release_enable = false
 
 [[package]]
-name = "cf-gears-toolkit-macros"
+name = "cf-gears-toolkit-gateway"
 changelog_update = false
 git_release_enable = false
 
 [[package]]
-name = "cf-gears-toolkit-macros-tests"
+name = "cf-gears-toolkit-gts"
 changelog_update = false
 git_release_enable = false
-publish = false
+
+[[package]]
+name = "cf-gears-toolkit-gts-macros"
+changelog_update = false
+git_release_enable = false
+
+[[package]]
+name = "cf-gears-toolkit-http"
+changelog_update = false
+git_release_enable = false
+
+[[package]]
+name = "cf-gears-toolkit-http-middleware"
+changelog_update = false
+git_release_enable = false
+
+[[package]]
+name = "cf-gears-toolkit-k8s-auth"
+changelog_update = false
+git_release_enable = false
+
+[[package]]
+name = "cf-gears-toolkit-macros"
+changelog_update = false
+git_release_enable = false
 
 [[package]]
 name = "cf-gears-toolkit-node-info"
@@ -122,6 +183,11 @@ changelog_update = false
 git_release_enable = false
 
 [[package]]
+name = "cf-gears-toolkit-stable-hash"
+changelog_update = false
+git_release_enable = false
+
+[[package]]
 name = "cf-gears-toolkit-transport-grpc"
 changelog_update = false
 git_release_enable = false
@@ -131,17 +197,37 @@ name = "cf-gears-toolkit-utils"
 changelog_update = false
 git_release_enable = false
 
+# Contract layer (libs/toolkit-contract*) — same unified-release rule as the rest of the
+# framework.
 [[package]]
-name = "cf-gears-toolkit-gts"
+name = "cf-gears-toolkit-contract"
 changelog_update = false
 git_release_enable = false
 
 [[package]]
-name = "cf-gears-toolkit-gts-macros"
+name = "cf-gears-toolkit-contract-macros"
 changelog_update = false
 git_release_enable = false
 
-# System SDK libraries - published to crates.io but without separate changelog/releases
+[[package]]
+name = "cf-gears-toolkit-contract-protogen"
+changelog_update = false
+git_release_enable = false
+
+# TLS/FIPS support crates (libs/rustls-*). Framework infrastructure, so they follow the
+# `libs/**` rule. Flip these two to `true` if they should ever get their own release
+# notes — they are the only judgement call in this list.
+[[package]]
+name = "cf-gears-rustls-corecrypto-provider"
+changelog_update = false
+git_release_enable = false
+
+[[package]]
+name = "cf-gears-rustls-fips-shim"
+changelog_update = false
+git_release_enable = false
+
+# System SDK libraries (libs/system-sdks/**).
 [[package]]
 name = "cf-gears-system-sdks"
 changelog_update = false
@@ -151,132 +237,3 @@ git_release_enable = false
 name = "cf-gears-system-sdk-directory"
 changelog_update = false
 git_release_enable = false
-
-# System gears and their SDKs - published to crates.io but without separate changelog/releases
-[[package]]
-name = "cf-gears-api-gateway"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-grpc-hub"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-file-parser"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-nodes-registry"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-nodes-registry-sdk"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-gear-orchestrator"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-types-registry"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-types-registry-sdk"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-simple-user-settings"
-publish = false
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-simple-user-settings-sdk"
-publish = false
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-resource-group-sdk"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-resource-group"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-tenant-resolver-sdk"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-tenant-resolver"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-authn-resolver-sdk"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-authn-resolver"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-authz-resolver-sdk"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-authz-resolver"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-oagw-sdk"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-oagw"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-credstore-sdk"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-credstore"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-mini-chat-sdk"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-mini-chat"
-changelog_update = false
-git_release_enable = false
-
-[[package]]
-name = "cf-gears-model-registry-sdk"
-changelog_update = false
-git_release_enable = false
-

--- a/tools/scripts/check_release_config.py
+++ b/tools/scripts/check_release_config.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""
+Validate the release configuration: who may be published, and who gets a
+changelog section and a GitHub Release.
+
+Three invariants, all of which have broken a real release before:
+
+1. Nothing under `examples/`, `apps/` or `tools/` may be publishable. Those are
+   demos, the dev server and repo tooling; a missing `publish = false` in a new
+   example's Cargo.toml is invisible until release-plz pushes it to crates.io,
+   where a publish cannot be undone.
+
+2. `release-plz.toml` must agree with the workspace, per the path rule
+   documented at the top of that file:
+     - `libs/**` (the framework) is folded into the single `cf-gears-toolkit`
+       release, so every publishable `libs/**` crate needs an entry with
+       `changelog_update = false` / `git_release_enable = false`. An omission is
+       not inert: the crate inherits the `[workspace]` defaults and silently
+       starts writing its own changelog section and its own Release page.
+     - `gears/**` gets its own changelog section and Release from those same
+       defaults, so it must have no entry at all.
+     - A crate with `publish = false` in its manifest is skipped by release-plz
+       entirely, so an entry for it is dead config.
+
+3. A dev-dependency that closes a cycle must be path-only, with no version.
+   Cargo allows the cycle (`A` regular-depends on `B`, `B` dev-depends on `A`)
+   and publishes `B` first, but `cargo package` still resolves `B`'s
+   dev-dependencies against crates.io — so a versioned dev-dep on `A` demands a
+   release of `A` that does not exist yet, and the release dies with
+   "failed to select a version for the requirement". Path-only dev-deps are
+   dropped from the published manifest, so the cycle never reaches crates.io.
+   Note that `workspace = true` is not path-only: it carries the version from
+   `[workspace.dependencies]`.
+
+All checks are static — no cargo invocation — so this is cheap enough to run on
+every CI build.
+
+Exit codes:
+  0 - Configuration is consistent
+  1 - One or more violations
+"""
+
+import sys
+import tomllib
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from check_packaging_metadata import find_manifests, is_publishable, parse_manifest
+
+# Top-level directories whose crates must never be publishable.
+NEVER_PUBLISHABLE_DIRS = ("examples", "apps", "tools")
+
+# The one crate that carries the framework's changelog and GitHub Release; the
+# rest of `libs/**` is folded into it.
+FRAMEWORK_RELEASE_CRATE = "cf-gears-toolkit"
+
+# Flags a folded-in `libs/**` crate must set, and the values it must set them to.
+FOLDED_IN_FLAGS = {"changelog_update": False, "git_release_enable": False}
+
+
+def is_release_target(package: dict) -> bool:
+    """True if cargo would let this crate be published.
+
+    Two independent ways to be unpublishable, both of which occur in this repo:
+    an explicit `publish = false`, and an omitted `version` — cargo refuses to
+    publish a versionless package, and `cargo metadata` reports it as
+    `publish: []` just like the explicit form. `gears/bss/**` relies on the
+    latter today, so checking only the `publish` field would misjudge it.
+    """
+    return is_publishable(package) and "version" in package
+
+
+def collect_crates(workspace_root: Path) -> Tuple[Dict[str, dict], List[Tuple[Path, str]]]:
+    """Map crate name -> {area, publishable, rel_path} for every manifest found.
+
+    Returns the map plus a list of `(manifest_path, message)` parse errors.
+    """
+    crates: Dict[str, dict] = {}
+    parse_errors: List[Tuple[Path, str]] = []
+    for manifest_path in find_manifests(workspace_root):
+        try:
+            data = parse_manifest(manifest_path.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError as exc:
+            parse_errors.append((manifest_path, str(exc)))
+            continue
+        package = data.get("package")
+        if package is None:
+            continue  # virtual manifest (the workspace root)
+        name = package.get("name")
+        if not isinstance(name, str):
+            continue
+        rel_path = manifest_path.relative_to(workspace_root)
+        crates[name] = {
+            "area": rel_path.parts[0],
+            "publishable": is_release_target(package),
+            "rel_path": rel_path,
+            "data": data,
+        }
+    return crates, parse_errors
+
+
+def resolve_dep(alias: str, spec, ws_deps: dict) -> Tuple[str, bool]:
+    """Resolve a dependency entry to `(real crate name, carries a version)`.
+
+    The table key is an alias when the entry renames the crate (`package = "..."`),
+    and `workspace = true` defers both the name and the version to the shared
+    `[workspace.dependencies]` table.
+    """
+    if isinstance(spec, dict) and spec.get("workspace") is True:
+        shared = ws_deps.get(alias)
+        if isinstance(shared, dict):
+            return shared.get("package", alias), "version" in shared
+        return alias, True  # bare `dep = "1.2"` in the shared table
+    if isinstance(spec, dict):
+        return spec.get("package", alias), "version" in spec
+    return alias, True  # bare `dep = "1.2"`
+
+
+def iter_deps(data: dict, table_names: Tuple[str, ...]):
+    """Yield `(table_label, alias, spec)` from the given dependency tables,
+    including their target-specific variants (`[target.'cfg(...)'.<table>]`)."""
+    containers = [("", data)]
+    targets = data.get("target")
+    if isinstance(targets, dict):
+        containers += [
+            (f"target.{cfg}.", tables) for cfg, tables in targets.items() if isinstance(tables, dict)
+        ]
+    for prefix, container in containers:
+        for table_name in table_names:
+            table = container.get(table_name)
+            if isinstance(table, dict):
+                for alias, spec in table.items():
+                    yield f"{prefix}{table_name}", alias, spec
+
+
+def normal_dep_graph(crates: Dict[str, dict], ws_deps: dict) -> Dict[str, set]:
+    """Direct normal/build dependency edges between publishable crates.
+
+    Dev-dependencies are excluded on purpose: they are what this graph is used to
+    judge, and Cargo permits cycles through them.
+    """
+    nodes = {name for name, info in crates.items() if info["publishable"]}
+    edges = {name: set() for name in nodes}
+    for name in nodes:
+        for _, alias, spec in iter_deps(crates[name]["data"], ("dependencies", "build-dependencies")):
+            dep, _ = resolve_dep(alias, spec, ws_deps)
+            if dep in nodes and dep != name:
+                edges[name].add(dep)
+    return edges
+
+
+def check_dev_dep_cycles(crates: Dict[str, dict], ws_deps: dict) -> List[str]:
+    """Versioned dev-deps on a workspace crate that may not be published yet.
+
+    release-plz publishes in dependency order, so a crate's own (transitive)
+    normal dependencies are guaranteed to be on crates.io by the time it is
+    published. Nothing guarantees that for anything else — least of all for a
+    crate that depends on *us*, which is published strictly later. A dev-dep
+    carrying a version therefore has to point at a real normal dependency;
+    anything else must be path-only so cargo strips it before upload.
+    """
+    edges = normal_dep_graph(crates, ws_deps)
+    problems: List[str] = []
+    for name in sorted(edges):
+        # Everything guaranteed to be published before `name`.
+        published_first, stack = set(), [name]
+        while stack:
+            for dep in edges[stack.pop()]:
+                if dep not in published_first:
+                    published_first.add(dep)
+                    stack.append(dep)
+
+        info = crates[name]
+        for label, alias, spec in iter_deps(info["data"], ("dev-dependencies",)):
+            dep, has_version = resolve_dep(alias, spec, ws_deps)
+            if dep not in edges or not has_version or dep in published_first:
+                continue
+            reason = (
+                "this very crate"
+                if dep == name
+                else f"`{dep}`, which is not a normal dependency of it"
+            )
+            problems.append(
+                f"{info['rel_path']}: [{label}] `{alias}` carries a version and points at "
+                f"{reason}, so that release need not be on crates.io yet when this crate is "
+                f"published -> declare it path-only: no version, and not `workspace = true`"
+            )
+    return problems
+
+
+def check_never_publishable(crates: Dict[str, dict]) -> List[str]:
+    """Crates under examples/apps/tools that are missing `publish = false`."""
+    return [
+        f"{info['rel_path']}: crate `{name}` is publishable -> add `publish = false`"
+        for name, info in sorted(crates.items())
+        if info["area"] in NEVER_PUBLISHABLE_DIRS and info["publishable"]
+    ]
+
+
+def check_release_plz(config: dict, crates: Dict[str, dict]) -> List[str]:
+    """`release-plz.toml` entries vs the workspace, per the documented path rule."""
+    problems: List[str] = []
+    entries = config.get("package")
+    entries = entries if isinstance(entries, list) else []
+
+    seen: Dict[str, int] = {}
+    for entry in entries:
+        name = entry.get("name")
+        if not isinstance(name, str):
+            problems.append("release-plz.toml: a [[package]] entry has no `name`")
+            continue
+        seen[name] = seen.get(name, 0) + 1
+        if seen[name] == 2:
+            problems.append(f"release-plz.toml: duplicate entry for `{name}`")
+
+        info = crates.get(name)
+        if info is None:
+            problems.append(
+                f"release-plz.toml: entry for `{name}`, which is not a crate in this "
+                f"workspace -> stale, remove it"
+            )
+            continue
+        if not info["publishable"]:
+            problems.append(
+                f"release-plz.toml: entry for `{name}`, which has `publish = false` in "
+                f"{info['rel_path']} -> release-plz skips it anyway, remove the entry"
+            )
+            continue
+        if "publish" in entry:
+            problems.append(
+                f"release-plz.toml: entry for `{name}` sets `publish` -> the Cargo "
+                f"manifest is the only source of truth for that, remove the key"
+            )
+        if info["area"] == "gears":
+            problems.append(
+                f"release-plz.toml: entry for `{name}` ({info['rel_path']}) -> crates "
+                f"under gears/** inherit the [workspace] defaults, remove the entry"
+            )
+
+    for name, info in sorted(crates.items()):
+        if info["area"] != "libs" or not info["publishable"]:
+            continue
+        entry = next((e for e in entries if e.get("name") == name), None)
+        if entry is None:
+            problems.append(
+                f"release-plz.toml: no entry for `{name}` ({info['rel_path']}) -> it "
+                f"would inherit the [workspace] defaults and get its own changelog "
+                f"section and GitHub Release"
+            )
+            continue
+        expected = (
+            {"changelog_update": True, "git_release_enable": True}
+            if name == FRAMEWORK_RELEASE_CRATE
+            else FOLDED_IN_FLAGS
+        )
+        for flag, want in expected.items():
+            got = entry.get(flag)
+            if got is not want:
+                problems.append(
+                    f"release-plz.toml: `{name}` has {flag} = "
+                    f"{'unset' if got is None else str(got).lower()}, expected "
+                    f"{str(want).lower()}"
+                )
+    return problems
+
+
+def main() -> int:
+    workspace_root = Path(__file__).parent.parent.parent
+
+    crates, parse_errors = collect_crates(workspace_root)
+    if not crates:
+        print(f"Error: no crates found under {workspace_root}", file=sys.stderr)
+        return 1
+
+    config_path = workspace_root / "release-plz.toml"
+    try:
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        print(f"Error: cannot read {config_path.name}: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        root_manifest = parse_manifest((workspace_root / "Cargo.toml").read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        print(f"Error: cannot read the root Cargo.toml: {exc}", file=sys.stderr)
+        return 1
+    ws_deps = root_manifest.get("workspace", {}).get("dependencies")
+    ws_deps = ws_deps if isinstance(ws_deps, dict) else {}
+
+    groups = [
+        ("Crates that must never be published", check_never_publishable(crates)),
+        ("release-plz.toml disagrees with the workspace", check_release_plz(config, crates)),
+        ("Dev-dependencies that break `cargo publish`", check_dev_dep_cycles(crates, ws_deps)),
+    ]
+    if parse_errors:
+        groups.append(
+            (
+                "Manifests that could not be parsed",
+                [f"{path.relative_to(workspace_root)}: {message}" for path, message in parse_errors],
+            )
+        )
+
+    total = sum(len(problems) for _, problems in groups)
+    if total:
+        print("=" * 80, file=sys.stderr)
+        print("RELEASE CONFIGURATION VIOLATIONS DETECTED", file=sys.stderr)
+        print("=" * 80, file=sys.stderr)
+        for header, problems in groups:
+            if not problems:
+                continue
+            print(file=sys.stderr)
+            print(f"{header}:", file=sys.stderr)
+            print(file=sys.stderr)
+            for problem in problems:
+                print(f"  [X] {problem}", file=sys.stderr)
+        print(file=sys.stderr)
+        print("=" * 80, file=sys.stderr)
+        print(f"Summary: {len(crates)} crates checked, {total} violation(s)", file=sys.stderr)
+        print("The rules live at the top of release-plz.toml.", file=sys.stderr)
+        print("=" * 80, file=sys.stderr)
+        return 1
+
+    publishable = sum(1 for info in crates.values() if info["publishable"])
+    print(
+        f"OK: {len(crates)} crates checked "
+        f"({publishable} publishable), release-plz.toml is consistent"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- toolkit-contract and toolkit-odata-macros dev-deps back onto toolkit / toolkit-odata are now path-only, matching the existing convention (was breaking release-plz release with "failed to select a version")
- disable examples/toolkit/api-contracts publishing
- release-plz.toml: libs/** aggregates under cf-gears-toolkit (changelog_update/git_release_enable = false), gears/** inherits workspace defaults (own changelog + release), drop dead publish=false overrides already set in Cargo.toml
- add check_release_config.py + `make check-release-config` in CI to catch publishable examples/apps/tools, release-plz.toml drift, and dev-dep version cycles

  Signed-off-by: MikeFalcon77 <3686170+MikeFalcon77@users.noreply.github.com>