### PR TITLE
feat(toolkit): label-based selection with projected serving state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,6 +2320,7 @@ dependencies = [
  "cf-gears-toolkit-macros",
  "cf-gears-toolkit-security",
  "cf-gears-toolkit-transport-grpc",
+ "http",
  "inventory",
  "secrecy",
  "serde",

--- a/docs/arch/toolkit-oop/ADR/0009-cpt-cf-adr-instance-addressable-discovery.md
+++ b/docs/arch/toolkit-oop/ADR/0009-cpt-cf-adr-instance-addressable-discovery.md
@@ -59,13 +59,6 @@ axis is solved by directory **labels + targeted resolution**. Concretely, today 
 We need to decide how (and whether) the platform supports targeting a specific instance, and where that lives
 relative to the directory contract and the REST contract-codegen client-wiring layer.
 
-> **This ADR is the platform's single service-discovery layer.** The cluster gear's in-SDK
-> `ServiceDiscoveryV1` (instance registration, serving intent, metadata filtering, TTL heartbeat, and topology
-> watch as a follow-up) is **superseded** by the directory and its capability consolidated here so there is exactly **one**
-> source of topology truth. The actual code removal is **out of scope for this ADR** - it is executed by the
-> cluster gear's own decomposition as a separate, coordinated change; this ADR is the *design* that replaces
-> it. See [Relationship to cluster `ServiceDiscoveryV1`](#relationship-to-cluster-servicediscoveryv1).
-
 ## Decision Drivers
 
 * **Correctness of split gears must be structural, not flag-dependent** - a role-split or sharded gear must
@@ -174,7 +167,14 @@ Add **one** targeted lookup to `DirectoryClient`, backed by selection in `GearMa
 clients:
 
 * `resolve_by_labels(name, selector)` - the set of instances of `name` matching a `LabelSelector` (see §6),
-  each carrying its `instance_id`, `labels`, readiness state, and endpoints.
+  each carrying its `instance_id`, `labels`, endpoints, and live serving `state` (`InstanceState`, §6). The
+  set is **not** health-filtered; the projected `state` is what lets the caller apply its own liveness policy
+  from a single resolve. It is likewise **not endpoint-filtered**: a matched instance that has not (yet)
+  advertised an endpoint is still returned with its `endpoint` / `rest_endpoint` **absent** (`None`, never an
+  empty-URI sentinel) - this is *no-endpoint, not an error*, leaving the caller to fall back or pick another
+  transport rather than silently hiding a match. The same holds for the underlying per-name enumeration
+  (`list_instances`); only the edge snapshot `list_all_instances`, which needs a dialable URI to reverse-proxy,
+  drops endpoint-less entries.
 
 There is deliberately **no** `resolve_instance(gear, instance_id)`. The only live `instance_id` a caller can
 hold comes from a prior `resolve_by_labels` result (which already carries the endpoint), so a
@@ -301,9 +301,15 @@ deployment profile (ADR-0001):
 reachable by *other* gears - never a bind-only address (`localhost` / `0.0.0.0`), nor a shared Service VIP for a
 targeted role. Because the bootstrap's own default rewrites an unspecified bind address to loopback
 (`libs/toolkit/src/bootstrap/oop.rs`), a silently-registered loopback endpoint is a registered-but-unreachable
-instance in multi-host Profile 2 and in Profile 3. The runtime therefore **MUST fail fast**: in OoP multi-host
-Profile 2 and in Profile 3, bootstrap **MUST refuse to start** when `advertise_uri` is unset or resolves to
-loopback / `0.0.0.0`, rather than registering it. (Single-node Profile 2 over UDS and Profile 1 are exempt.) Profile 2 uses the worker's configured UDS path or bound `host:port`; Profile 3 derives from the
+instance in multi-host Profile 2 and in Profile 3. The runtime therefore **fails fast**: the OoP HTTP bootstrap
+(`validate_advertise_uri` in `libs/toolkit/src/bootstrap/oop.rs`) **refuses to start** when the resolved
+`advertise_uri` is a loopback / unspecified host (`127.0.0.1`, `::1`, `localhost`, `0.0.0.0`, `[::]`). This
+also catches an *unset* `advertise_uri` **when the value derived from `listen_addr` is itself
+loopback/unspecified** (e.g. an unspecified `0.0.0.0` bind, which the default rewrites to loopback); an unset
+`advertise_uri` on a routable bind derives a routable endpoint and is accepted. The
+single-host / local-dev exemption is an explicit opt-out (`oop_http.allow_loopback_advertise = true`) the
+operator must consciously set; single-node Profile 2 over UDS (a non-HTTP endpoint) and Profile 1 (in-process,
+never reaches this check) are exempt structurally. Profile 2 uses the worker's configured UDS path or bound `host:port`; Profile 3 derives from the
 Kubernetes **downward API** - the stable per-pod FQDN `$(HOSTNAME).<service>.$(POD_NAMESPACE).svc` (+ container
 port) for targeted role-names, or the Service DNS name for a load-balanced front-door name. **Prefer stable DNS names /
 socket paths over raw IPs** (pod IPs churn on reschedule): `advertise_uri` is only the **routable transport
@@ -321,8 +327,8 @@ There is one targeted lookup (§2); its cardinality and health contract, and the
 contract, are:
 
 * **`resolve_by_labels(name, selector)` -> a set (array)** - effectively `list_instances(name)` filtered by the
-  selector, returning each match's `instance_id`, `labels`, readiness state, and endpoints (gRPC
-  `endpoint` and/or `rest_endpoint`). The selector is a **`LabelSelector` struct** wrapping a **map of equality
+  selector, returning each match's `instance_id`, `labels`, endpoints (gRPC
+  `endpoint` and/or `rest_endpoint`), and live serving `state` (`InstanceState`). The selector is a **`LabelSelector` struct** wrapping a **map of equality
   requirements matched with AND semantics** (Kubernetes `matchLabels` style): an instance matches only if it
   carries **every** requested `key=value` pair (e.g. `shard=7`); an empty selector matches
   all instances of the name. Passing a **struct rather than a bare map** keeps future filters (e.g.
@@ -348,16 +354,21 @@ contract, are:
 * **Empty-set semantics**: zero matches is `Ok(empty)`, kept distinct from a
   directory-backend error - preserving the not-found vs. failure contract of ADR-0005, so an empty result reads
   as "not ready yet," not "outage."
-* **Health contract (decision):** every lookup annotates each returned instance with its readiness state
-  (`InstanceState`: `Registered` / `Ready` / `Healthy` / `Quarantined` / `Draining`; only `Ready` / `Healthy`
-  are **serving**, the rest are **not-ready**). This is the **directory's annotation of a resolution result** and
-  is **derived from** the instance's readiness signal ([ADR-0005](0005-cpt-cf-adr-eventual-readiness.md)), not a
-  second health system; it is *not* the same enum as ADR-0005's readiness-probe `state`. Mapping to ADR-0005:
+* **Health contract (decision):** the two lookup modes handle health differently. **Name-based resolution**
+  (`resolve_rest_service` / `resolve_grpc_service`) selects over each instance's readiness state
+  (`InstanceState`: `Registered` / `Ready` / `Healthy` / `Quarantined` / `Draining` / `Unknown`; only
+  `Ready` / `Healthy` are **serving**, the rest are **not-ready**), **derived from** the instance's readiness
+  signal ([ADR-0005](0005-cpt-cf-adr-eventual-readiness.md)), not a second health system (it is *not* the same
+  enum as ADR-0005's readiness-probe `state`). Mapping to ADR-0005:
   `Ready`/`Healthy` correspond to ADR-0005 `Ready`/`Degraded` (serving / `200`); `Registered` to `Starting`
   (registered, deps not yet resolved); `Quarantined` to a failing readiness probe (`Unhealthy`->`Starting`); and
-  `Draining` to `Draining`. A caller can thus always distinguish **no match** (`Ok(empty)`)
-  from **matched-but-not-ready**. The two modes share these error semantics and differ only in health
-  *filtering*:
+  `Draining` to `Draining`. `Unknown` is the **safe default** for a state that could not be determined: the proto
+  `UNSPECIFIED` discriminant and any unrecognised (forward-compat) wire value decode to `Unknown` rather than
+  silently reading as `Registered`. It is **non-serving** and carries no ADR-0005 mapping; it exists only so an
+  undeterminable state can never be mistaken for a known one. **`resolve_by_labels`**, by contrast, does **not** filter on health: it returns
+  the full matched set with each instance's `state` **annotated** (`InstanceState`), leaving the caller to
+  apply its own liveness policy. Both modes preserve the **no match** (`Ok(empty)`) vs backend-error
+  distinction; they differ in health *filtering*:
   * **Name round-robin** (`resolve_rest_service` / `resolve_grpc_service`) rotates over the resolved name,
     **preferring** serving (`Ready` / `Healthy`) instances but, when none are serving, **falling back to RR
     over the full not-ready set - `Quarantined` *and* `Draining` included**. Draining instances are
@@ -366,11 +377,12 @@ contract, are:
     resolves to a quarantined endpoint, and a name whose instances are **all `Draining`** likewise resolves to a
     draining endpoint. `None` is returned **only** when the candidate set is **empty** - i.e. no instance
     registered under the name exposes the requested endpoint at all - never merely because every instance is
-    not-ready. *(One transport asymmetry - gRPC service-scoped resolution does **not** yet fall back and instead
-    returns `None` when none are serving - is tracked in Implementation notes.)*
+    not-ready. Both transports share this fallback: `resolve_rest_service` and `resolve_grpc_service` prefer
+    serving instances and fall back to the not-ready set, returning `None` only on an empty candidate set.
   * **`resolve_by_labels(name, selector)`** returns the **full** matching set **regardless of health**, each
-    entry carrying its readiness state; an all-unhealthy match is still `Ok(non-empty)`, distinct from
-    `Ok(empty)` and from a backend error.
+    entry carrying its `state` (`InstanceState`) so the caller can filter; a matched-but-unhealthy instance is
+    still returned (`Ok(non-empty)`, distinct from `Ok(empty)` and from a backend error), and applying the
+    liveness policy is the caller's responsibility.
 
 * **Stale-ownership correction path (required contract).** A poll-refreshed shard/owner map (§2) is inherently
   stale between refreshes, so ownership is **not** established by the directory result alone - it must be
@@ -408,21 +420,15 @@ REST contract codegen. This ADR fixes the **contract shape** (Layer 1) so it can
 with that codegen's directory edits (which also modify `ServiceInstanceInfo` / `grpc/client.rs`) rather than in
 a merge scramble.
 
-**Relationship to the event-broker's current primitive.** event-broker ADR-0007 (Accepted) has
-`domain/cluster.rs` resolve the cluster gear's `ServiceDiscoveryV1` via `ClientHub` under the `evbk` prefix -
-so the broker has a *working* targeting primitive today. That primitive is exactly the cluster
-`ServiceDiscoveryV1` this ADR **supersedes and replaces** (see [Relationship to cluster
-`ServiceDiscoveryV1`](#relationship-to-cluster-servicediscoveryv1)); Layer 1 is therefore not "unblocking
-something new" but **the successor substrate** the broker's dispatcher->ingest targeting must move onto once
-cluster discovery is retired (by the cluster gear's own decomposition, not this ADR). The broker's
-decomposition already assumes one binary with mode-selected wiring, so its `ingest` / `delivery` modes register
-their **role-qualified directory names** (§1) - no `entrypoint` marker is needed, and the wrong-role failure
-mode is structurally impossible.
+**Relationship to the event-broker's targeting.** `event-broker` runs its internal `dispatcher -> ingest` /
+`delivery` targeting on this directory: Layer 1 is the substrate that targeting sits on. The broker's
+decomposition assumes one binary with mode-selected wiring, so its `ingest` / `delivery` modes register their
+**role-qualified directory names** (§1) - no `entrypoint` marker is needed, and the wrong-role failure mode is
+structurally impossible.
 
-**Watch / change-notification (required follow-up, owned here).** The cluster `ServiceDiscoveryV1` being
-removed included a **topology `watch`** (unfiltered `Joined`/`Left`/`Updated` stream). Because this ADR is that
-capability's single successor, a directory-level change-notification API is a **required follow-up owned by
-this design** (not the cluster gear), so removing cluster discovery is not a silent regression. It is
+**Watch / change-notification (required follow-up, owned here).** The directory does not yet expose a
+**topology `watch`** (a `Joined`/`Left`/`Updated` change-notification stream). Because this ADR is the single
+service-discovery layer, that directory-level API is a **required follow-up owned by this design**. It is
 sequenced *after* Layer 1 (poll + the §6 fencing contract already make correctness *specified*); watch is a
 convergence-latency optimization, not a correctness prerequisite. Until it lands, consumers poll
 `list_instances` / `resolve_by_labels`.
@@ -463,9 +469,10 @@ convergence-latency optimization, not a correctness prerequisite. Until it lands
 
 * Design review: `labels` and `resolve_by_labels` are additive; name-based resolution is **unchanged** (roles
   are separate names, not filtered instances).
-* Fail-fast test (§5): in OoP multi-host Profile 2 / Profile 3, bootstrap **refuses to start** when
-  `advertise_uri` is unset or loopback / `0.0.0.0` (no registered-but-unreachable instance); single-node UDS and
-  Profile 1 start normally.
+* Fail-fast test (§5): the OoP HTTP bootstrap **refuses to start** when the resolved `advertise_uri` is unset or
+  a loopback / unspecified host (no registered-but-unreachable instance), unless
+  `oop_http.allow_loopback_advertise = true` is set for single-host / local-dev; single-node UDS and Profile 1
+  (in-process) start normally. Covered by `validate_advertise_uri` unit tests.
 * Integration test (targeting, Profile 2/3 - see §5 coverage owner): distinct-`shard` instances of one name
   resolve deterministically via `resolve_by_labels` while a plain resolve round-robins; for a role-split gear
   (e.g. `event-broker`) resolving `event-broker` reaches only `dispatcher`, and `event-broker-ingest` /
@@ -475,9 +482,16 @@ convergence-latency optimization, not a correctness prerequisite. Until it lands
   "not the owner" response; the caller refreshes via `resolve_by_labels` and re-targets the current owner; the
   optional carried owner label short-circuits the re-enumeration.
 * Integration test (health, §6): name-based RR falls back to unhealthy when none are healthy (a non-empty name
-  never yields `None`); `resolve_by_labels` includes unhealthy matches annotated with `InstanceState`.
-* Integration test (enumeration): `list_instances` / `ListAllInstances` return **every** instance including
-  REST-only roles, round-tripping `labels` / `rest_endpoint` / `openapi_spec` (see Implementation
+  never yields `None`); `resolve_by_labels` includes unhealthy matches, each annotated with its `state`
+  (`InstanceState`) so the caller owns the liveness policy.
+* Integration test (enumeration): the per-gear and cross-gear paths differ on endpoint-less instances. Per-gear
+  `list_instances` (and `resolve_by_labels`) **include endpoint-less matches** (`endpoint: None`, never an
+  empty-URI sentinel) so the caller can fall back, and round-trip `labels` / `rest_endpoint` and the
+  `openapi_spec` **hash** - **never the document** - so a multi-instance response stays bounded regardless of
+  spec size. The broad cross-gear `ListAllInstances` edge snapshot instead includes **only instances with a
+  dialable endpoint** (gRPC or REST), dropping endpoint-less ones since it needs a URI to route; it carries each
+  instance's `rest_endpoint` but **omits `labels`** (the edge routes by name, not labels) and inlines only the
+  `openapi_spec` **hash**. Every path fetches the document out-of-band via `GetOpenApiSpec` (see Implementation
   notes).
 * Reconciliation review: the Layer 1 additions merge cleanly with the REST-codegen and edge directory changes.
 
@@ -536,41 +550,6 @@ convergence-latency optimization, not a correctness prerequisite. Until it lands
 
 ## More Information
 
-### Relationship to cluster `ServiceDiscoveryV1`
-
-**This ADR supersedes and absorbs the cluster gear's `ServiceDiscoveryV1`; the code removal is executed by the
-cluster gear's own decomposition as a separate, coordinated change, not by this ADR.** There is **one**
-service-discovery layer - the directory - not a directory layer plus a competing cluster layer. The prior
-concern that this ADR added a "second, weaker discovery layer next to a merged one" is resolved by
-*consolidation*: the cluster in-SDK discovery primitive
-(`gears/system/cluster/cluster-sdk/src/discovery/`, its default/standalone/Postgres backends, conformance
-suite, GTS specs, and wiring) will be **retired** by that decomposition work, after which the cluster gear
-keeps only its other three backend traits (cache, distributed lock, leader election). The dependency direction
-is therefore **not** inverted - cluster is not a shipped provider this ADR races; its discovery capability is
-the thing being consolidated here. The event-broker `domain/cluster.rs` `ServiceDiscoveryV1` handle and every
-cluster-side user are retired by that decomposition; until the directory replacement (Layer 1) lands the
-capability still exists in cluster, so there is **no functional gap** during the transition.
-
-Concept mapping (cluster -> directory):
-
-| Cluster `ServiceDiscoveryV1`                             | Directory (this ADR)                                             |
-|----------------------------------------------------------|------------------------------------------------------------------|
-| `ServiceRegistration.metadata: HashMap<String,String>`   | `labels` map on `InstanceInfo` / `ServiceInstanceInfo` (§2)      |
-| `DiscoveryFilter` (AND-conjoined `MetaMatch::{Equals,OneOf}`) | `resolve_by_labels` `LabelSelector` (equality-AND; `OneOf`/expressions are the deferred `matchExpressions`, §6) |
-| `InstanceState::{Enabled, Disabled}` (serving intent)    | readiness state on results (`Registered`/`Ready`/`Healthy`/`Quarantined`/`Draining`, §6) - `Draining` == cluster `Disabled` |
-| `StateFilter::{Enabled, Disabled, Any}` (server-side serving-state filter) | **caller-side** health filtering (§6) - `resolve_by_labels` returns the full set annotated with readiness state; there is no server-side `only_serving` flag |
-| `ServiceHandle::set_state` (runtime serving-intent flip / drain) | no dedicated intent-flip RPC; an instance signals `Draining` through **readiness** (ADR-0005), which name round-robin de-prefers (§6) - the deliberate "intent, not health" split (cluster ADR-008) is folded into the readiness axis |
-| `ServiceHandle::update_metadata` (runtime metadata mutation) | no dedicated update RPC; label changes ride **re-registration** (labels MUST survive re-registration, §2 / Implementation notes) |
-| `ServiceDiscoveryV1::scoped(prefix)` (name sub-namespacing) | not carried over - the directory uses flat, manifest-declared role-qualified names (§1); coordination-namespace scoping is a cluster-internal concern, not a directory primitive |
-| TTL heartbeat / lapse                                    | directory registration + heartbeat loop (§5) / readiness gating (ADR-0005) |
-| `ServiceDiscoveryBackend::watch` (topology stream)       | change-notification **follow-up owned here** (§7, Consequences) - poll `list_instances` / `resolve_by_labels` until it lands; **not** a cluster-scoped layer |
-
-**Boundary (why this is the directory's job, not a gear's):** the directory is a **toolkit-level** primitive
-that every gear (and the edge) already depends on; a gear cannot be the source of topology truth the toolkit
-resolves against without a dependency inversion (the toolkit cannot depend on a gear). Consolidating discovery
-here keeps a single source of truth **and** the correct layering; the cluster gear becomes a *consumer* of this
-layer for its coordinator's shard/leader targeting, like any other gear.
-
 ### Cross-references & required amendments
 
 **Sibling ADRs / PRD.** Some of these are true **amendments** (this ADR changes a shape they assert), not just
@@ -628,7 +607,9 @@ item, an ordering dependency not in the tree today** (enumerated in Consequences
 specified by amending ADR-0003 / ADR-0007 rather than a new ADR, those two move from *references* to
 *amendments*. This ADR is **additive on top of that edge** (`labels` ride on the `InstanceInfo` the edge
 extends; role exclusion is structural), so Layer 1 must merge **after** / reconcile with that edge
-implementation, extending its `ListAllInstances` mapper to carry `labels`.
+implementation. Labels ride on `InstanceInfo` for the per-name paths (`list_instances` /
+`resolve_by_labels`); the `ListAllInstances` edge snapshot deliberately omits them (it routes by name - see
+Implementation notes), so its mapper is **not** extended to carry `labels`.
 
 ### Implementation notes
 
@@ -648,18 +629,29 @@ item above, not the current ADR-0007):
 * **Selector collision + missing service (decision).** `resolve_by_labels` returns the full set (§6) and the
   caller breaks ties. If a matched instance does not advertise the requested `service_name`, it is treated as
   no-endpoint (not an error), leaving the caller to fall back or pick another transport.
-* **Targeted resolve must not reuse RR's fallback-to-unhealthy.** The REST `pick_*` helpers fall back to
+* **Targeted resolve must not reuse RR's fallback-to-unhealthy.** The name-based `pick_*` helpers fall back to
   unhealthy instances when none are healthy; a targeted resolve must instead return matched-but-not-ready (§6).
-  The gRPC `pick_service_round_robin` does **not** currently fall back (returns `None`) - align it with the
-  REST helpers so name-based RR has one health contract across transports (§6).
+  Name-based RR shares one health contract across transports: both `pick_service_round_robin` (gRPC) and the
+  REST helpers prefer serving instances and fall back to the not-ready set (§6).
 * **New fields must survive re-registration.** `labels` must be threaded through the idempotent-refresh path
   (`RegisterInstanceInfo` -> `GearInstance` -> `GearManager::register_instance` / `with_metadata_of`), or a
   periodic self-heal re-register would silently drop them.
 * **Enumeration must include every instance, including REST-only roles (decision).** Today
   `LocalDirectoryClient::list_instances` skips instances with no gRPC service, dropping REST-only roles. Both it
-  and the edge's `ListAllInstances` MUST enumerate **all** instances regardless of transport and
-  preserve full metadata (`labels`, `rest_endpoint`, `openapi_spec`), so filtering and edge operate on complete
-  data.
+  and the edge's `ListAllInstances` MUST enumerate **all** instances regardless of transport - a REST-only
+  instance is projected from its `rest_endpoint`; only a genuinely endpoint-less instance is skipped. Metadata
+  is **scoped to what each path's consumer needs**, not blanket-preserved:
+  * **`list_instances(name)`** (and `resolve_by_labels`) carry per-name `labels` and `rest_endpoint` (their
+    consumers filter on labels), plus the `openapi_spec` **hash** - but **not the document**. Inlining the full
+    document here would let one multi-instance response carry N copies of a large spec (N shards of a gear), so
+    every such path is spec-free: the hash lets a consumer detect a spec change and fetch the document
+    out-of-band via `GetOpenApiSpec` (one spec, one message). This matches the `ListAllInstances` bounding
+    rule below rather than contradicting it.
+  * **`ListAllInstances`** (the broad cross-gear snapshot the edge polls) carries every instance and its
+    `rest_endpoint`, but **omits `labels`** (the edge routes by name, never by label) and inlines only the
+    `openapi_spec` **hash**, not the document: the edge detects a spec change from the hash and fetches the
+    document out-of-band via `GetOpenApiSpec`, keeping the polled payload bounded. Labels stay on the paths that
+    consume them (`list_instances` / `resolve_by_labels`), so this omission loses no capability.
 
 ## Traceability
 

--- a/gears/system/api-gateway/src/proxy.rs
+++ b/gears/system/api-gateway/src/proxy.rs
@@ -442,14 +442,11 @@ mod tests {
 
     async fn register(dir: &dyn DirectoryClient, gear: &str, uri: &str, spec: String) -> String {
         let instance_id = uuid::Uuid::new_v4().to_string();
-        dir.register_instance(RegisterInstanceInfo {
-            gear: gear.to_owned(),
-            instance_id: instance_id.clone(),
-            grpc_services: vec![],
-            version: None,
-            rest_endpoint: Some(ServiceEndpoint::new(uri)),
-            openapi_spec: Some(spec),
-        })
+        dir.register_instance(
+            RegisterInstanceInfo::new(gear, instance_id.clone())
+                .with_rest_endpoint(ServiceEndpoint::new(uri))
+                .with_openapi_spec(spec),
+        )
         .await
         .unwrap();
         instance_id
@@ -519,14 +516,11 @@ mod tests {
         // The same instance re-publishes a changed document: /add removed,
         // /sub added. Because each poll re-fetches and fully rebuilds, the next
         // sync reflects the new document exactly (not a stale union of both).
-        dir.register_instance(RegisterInstanceInfo {
-            gear: "calc".to_owned(),
-            instance_id: id.clone(),
-            grpc_services: vec![],
-            version: None,
-            rest_endpoint: Some(ServiceEndpoint::new("http://calc:8080")),
-            openapi_spec: Some(public_spec("calc", "/calc/v1/sub")),
-        })
+        dir.register_instance(
+            RegisterInstanceInfo::new("calc", id.clone())
+                .with_rest_endpoint(ServiceEndpoint::new("http://calc:8080"))
+                .with_openapi_spec(public_spec("calc", "/calc/v1/sub")),
+        )
         .await
         .unwrap();
 
@@ -579,17 +573,13 @@ mod tests {
         let dir: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(Arc::clone(&mgr)));
 
         // gRPC-only gear: no REST endpoint / spec -> not proxied.
-        dir.register_instance(RegisterInstanceInfo {
-            gear: "worker".to_owned(),
-            instance_id: uuid::Uuid::new_v4().to_string(),
-            grpc_services: vec![(
-                "worker.Svc".to_owned(),
-                ServiceEndpoint::new("http://worker:7000"),
-            )],
-            version: None,
-            rest_endpoint: None,
-            openapi_spec: None,
-        })
+        dir.register_instance(
+            RegisterInstanceInfo::new("worker", uuid::Uuid::new_v4().to_string())
+                .with_grpc_services(vec![(
+                    "worker.Svc".to_owned(),
+                    ServiceEndpoint::new("http://worker:7000"),
+                )]),
+        )
         .await
         .unwrap();
 
@@ -608,14 +598,10 @@ mod tests {
         // The gear advertises a REST endpoint but never published an OpenAPI
         // document. Since the slim discovery snapshot carries no spec, the edge
         // tries to fetch it via `get_openapi_spec`, which fails -> not proxied.
-        dir.register_instance(RegisterInstanceInfo {
-            gear: "specless".to_owned(),
-            instance_id: uuid::Uuid::new_v4().to_string(),
-            grpc_services: vec![],
-            version: None,
-            rest_endpoint: Some(ServiceEndpoint::new("http://specless:8080")),
-            openapi_spec: None,
-        })
+        dir.register_instance(
+            RegisterInstanceInfo::new("specless", uuid::Uuid::new_v4().to_string())
+                .with_rest_endpoint(ServiceEndpoint::new("http://specless:8080")),
+        )
         .await
         .unwrap();
 
@@ -887,14 +873,11 @@ mod tests {
         assert_eq!(applies.load(Ordering::SeqCst), 1);
 
         // Re-publish a changed document for the same instance.
-        dir.register_instance(RegisterInstanceInfo {
-            gear: "calc".to_owned(),
-            instance_id: id,
-            grpc_services: vec![],
-            version: None,
-            rest_endpoint: Some(ServiceEndpoint::new("http://calc:8080")),
-            openapi_spec: Some(public_spec("calc", "/calc/v1/sub")),
-        })
+        dir.register_instance(
+            RegisterInstanceInfo::new("calc", id)
+                .with_rest_endpoint(ServiceEndpoint::new("http://calc:8080"))
+                .with_openapi_spec(public_spec("calc", "/calc/v1/sub")),
+        )
         .await
         .unwrap();
 
@@ -949,16 +932,10 @@ mod tests {
     }
 
     fn instance_with_hash(gear: &str, uri: &str, hash: Option<&str>) -> ServiceInstanceInfo {
-        ServiceInstanceInfo {
-            gear: gear.to_owned(),
-            instance_id: "inst-1".to_owned(),
-            endpoint: ServiceEndpoint::new(uri),
-            version: None,
-            rest_endpoint: Some(ServiceEndpoint::new(uri)),
-            openapi_spec: None,
-            openapi_spec_hash: hash.map(ToOwned::to_owned),
-            grpc_services: Vec::new(),
-        }
+        ServiceInstanceInfo::new(gear, "inst-1")
+            .with_endpoint(Some(ServiceEndpoint::new(uri)))
+            .with_rest_endpoint(Some(ServiceEndpoint::new(uri)))
+            .with_openapi_spec_hash(hash.map(ToOwned::to_owned))
     }
 
     #[test]

--- a/gears/system/gear-orchestrator/Cargo.toml
+++ b/gears/system/gear-orchestrator/Cargo.toml
@@ -33,6 +33,7 @@ toolkit-k8s-auth = { workspace = true, optional = true }
 secrecy = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true, features = ["transport"] }
+http = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/gears/system/gear-orchestrator/src/server.rs
+++ b/gears/system/gear-orchestrator/src/server.rs
@@ -12,14 +12,17 @@ use toolkit_security::{
 };
 use toolkit_transport_grpc::extract_internal_token_grpc;
 
+use cf_system_sdks::directory::labels::is_valid_label_segment;
 use cf_system_sdks::directory::{
     DeregisterInstanceRequest, DirectoryClient, DirectoryInvalidArgument, DirectoryNotFound,
     DirectoryService, DirectoryServiceServer, GetOpenApiSpecRequest, GetOpenApiSpecResponse,
-    HeartbeatRequest, InstanceInfo, ListAllInstancesRequest, ListAllInstancesResponse,
-    ListInstancesRequest, ListInstancesResponse, RegisterInstanceInfo, RegisterInstanceRequest,
-    ResolveGrpcServiceRequest, ResolveGrpcServiceResponse, ResolveRestServiceRequest,
-    ResolveRestServiceResponse, ServiceEndpoint, ServiceInstanceInfo,
+    HeartbeatRequest, InstanceInfo, InstanceState, LabelSelector, ListAllInstancesRequest,
+    ListAllInstancesResponse, ListInstancesRequest, ListInstancesResponse, ProtoInstanceState,
+    RegisterInstanceInfo, RegisterInstanceRequest, ResolveGrpcServiceRequest,
+    ResolveGrpcServiceResponse, ResolveRestServiceRequest, ResolveRestServiceResponse,
+    ServiceEndpoint, ServiceInstanceInfo,
 };
+use std::collections::BTreeMap;
 
 /// Map a lookup failure onto a gRPC status, keeping "not registered" distinct
 /// from "the lookup itself failed".
@@ -105,6 +108,7 @@ impl DirectoryService for DirectoryServiceImpl {
     ) -> Result<Response<ResolveGrpcServiceResponse>, Status> {
         self.authenticate_peer(request.metadata()).await?;
         let service_name = request.into_inner().service_name;
+        validate_lookup_name("service_name", &service_name)?;
 
         let endpoint = self
             .api
@@ -123,6 +127,7 @@ impl DirectoryService for DirectoryServiceImpl {
     ) -> Result<Response<ResolveRestServiceResponse>, Status> {
         self.authenticate_peer(request.metadata()).await?;
         let gear_name = request.into_inner().gear_name;
+        validate_lookup_name("gear_name", &gear_name)?;
 
         let endpoint = self
             .api
@@ -141,6 +146,7 @@ impl DirectoryService for DirectoryServiceImpl {
     ) -> Result<Response<GetOpenApiSpecResponse>, Status> {
         self.authenticate_peer(request.metadata()).await?;
         let gear_name = request.into_inner().gear_name;
+        validate_lookup_name("gear_name", &gear_name)?;
 
         let openapi_spec = self
             .api
@@ -156,13 +162,34 @@ impl DirectoryService for DirectoryServiceImpl {
         request: Request<ListInstancesRequest>,
     ) -> Result<Response<ListInstancesResponse>, Status> {
         self.authenticate_peer(request.metadata()).await?;
-        let gear_name = request.into_inner().gear_name;
+        let req = request.into_inner();
+        let gear_name = req.gear_name;
+        validate_lookup_name("gear_name", &gear_name)?;
+        let selector = LabelSelector::from_match_labels(
+            req.match_labels.into_iter().collect::<BTreeMap<_, _>>(),
+        );
+        // Validate the caller-supplied selector against the same rules stored
+        // labels obey: a malformed selector can never match a valid label, and
+        // echoing it back is unsafe for the same reason register-time labels
+        // are screened.
+        cf_system_sdks::directory::validate_selector(&selector)
+            .map_err(|e| Status::invalid_argument(e.to_string()))?;
 
-        let instances = self
+        // Enumerate once and filter by the selector (an empty selector matches
+        // all). The response is always spec-free: only the `openapi_spec_hash`
+        // rides along, and the full document is fetched out-of-band via
+        // `GetOpenApiSpec`. This bounds every multi-instance response regardless
+        // of spec size, matching `resolve_by_labels` / `list_all_instances`
+        // (ADR-0009); the hash still lets a consumer detect a spec change.
+        let mut instances = self
             .api
             .list_instances(&gear_name)
             .await
-            .map_err(|e| Status::internal(e.to_string()))?;
+            .map_err(|e| lookup_status(&e))?;
+        instances.retain(|inst| selector.matches(&inst.labels));
+        for inst in &mut instances {
+            inst.openapi_spec = None;
+        }
 
         let resp = ListInstancesResponse {
             instances: instances
@@ -179,20 +206,24 @@ impl DirectoryService for DirectoryServiceImpl {
         _request: Request<ListAllInstancesRequest>,
     ) -> Result<Response<ListAllInstancesResponse>, Status> {
         self.authenticate_peer(_request.metadata()).await?;
-        let mut instances = self
+        let instances = self
             .api
             .list_all_instances()
             .await
-            .map_err(|e| Status::internal(e.to_string()))?;
-
-        for inst in &mut instances {
-            inst.openapi_spec = None;
-        }
+            .map_err(|e| lookup_status(&e))?;
 
         let resp = ListAllInstancesResponse {
             instances: instances
                 .into_iter()
-                .map(domain_instance_to_proto)
+                // `openapi_spec` and `labels` are both omitted from the broad
+                // cross-gear snapshot; `without_labels` is the shared transform
+                // (see the `list_all_instances` trait doc). The spec is dropped
+                // here too — it is never inlined into this snapshot.
+                .map(|inst| domain_instance_to_proto(inst.without_labels()))
+                .map(|mut proto| {
+                    proto.openapi_spec = None;
+                    proto
+                })
                 .collect(),
         };
 
@@ -206,6 +237,27 @@ impl DirectoryService for DirectoryServiceImpl {
         self.authenticate_peer(request.metadata()).await?;
         let req = request.into_inner();
 
+        validate_identity(&req.gear_name, &req.instance_id)?;
+        validate_labels(&req.labels)?;
+        for (idx, svc) in req.grpc_services.iter().enumerate() {
+            // Identify the service by index, never by interpolating the
+            // caller-controlled `service_name` into the (reflected) status
+            // context. The name is validated as a label segment first so an
+            // invalid one is rejected before storage or discovery.
+            if !is_valid_label_segment(&svc.service_name) {
+                return Err(Status::invalid_argument(format!(
+                    "grpc service #{idx}: service name contains invalid characters"
+                )));
+            }
+            validate_endpoint_uri(&format!("grpc service #{idx}"), &svc.endpoint_uri)?;
+        }
+        if let Some(uri) = &req.rest_endpoint_uri {
+            validate_endpoint_uri("rest endpoint", uri)?;
+        }
+        if let Some(spec) = &req.openapi_spec {
+            validate_openapi_spec(spec)?;
+        }
+
         // Parse endpoints from GrpcServiceEndpoint messages
         let grpc_services = req
             .grpc_services
@@ -213,23 +265,23 @@ impl DirectoryService for DirectoryServiceImpl {
             .map(|svc| (svc.service_name, ServiceEndpoint::new(svc.endpoint_uri)))
             .collect();
 
-        let info = RegisterInstanceInfo {
-            gear: req.gear_name,
-            instance_id: req.instance_id,
-            grpc_services,
-            version: if req.version.is_empty() {
-                None
-            } else {
-                Some(req.version)
-            },
-            rest_endpoint: req.rest_endpoint_uri.map(ServiceEndpoint::new),
-            openapi_spec: req.openapi_spec,
-        };
+        let mut info = RegisterInstanceInfo::new(req.gear_name, req.instance_id)
+            .with_grpc_services(grpc_services)
+            .with_labels(req.labels.into_iter().collect());
+        if !req.version.is_empty() {
+            info = info.with_version(req.version);
+        }
+        if let Some(uri) = req.rest_endpoint_uri {
+            info = info.with_rest_endpoint(ServiceEndpoint::new(uri));
+        }
+        if let Some(spec) = req.openapi_spec {
+            info = info.with_openapi_spec(spec);
+        }
 
         self.api
             .register_instance(info)
             .await
-            .map_err(|e| Status::internal(format!("Failed to register instance: {e}")))?;
+            .map_err(|e| lookup_status(&e))?;
 
         Ok(Response::new(()))
     }
@@ -241,10 +293,11 @@ impl DirectoryService for DirectoryServiceImpl {
         self.authenticate_peer(request.metadata()).await?;
         let req = request.into_inner();
 
+        validate_identity(&req.gear_name, &req.instance_id)?;
         self.api
             .deregister_instance(&req.gear_name, &req.instance_id)
             .await
-            .map_err(|e| Status::internal(format!("Failed to deregister instance: {e}")))?;
+            .map_err(|e| lookup_status(&e))?;
 
         Ok(Response::new(()))
     }
@@ -253,10 +306,11 @@ impl DirectoryService for DirectoryServiceImpl {
         self.authenticate_peer(request.metadata()).await?;
         let req = request.into_inner();
 
+        validate_identity(&req.gear_name, &req.instance_id)?;
         self.api
             .send_heartbeat(&req.gear_name, &req.instance_id)
             .await
-            .map_err(|e| Status::internal(format!("Failed to send heartbeat: {e}")))?;
+            .map_err(|e| lookup_status(&e))?;
 
         Ok(Response::new(()))
     }
@@ -267,12 +321,189 @@ fn domain_instance_to_proto(i: ServiceInstanceInfo) -> InstanceInfo {
     InstanceInfo {
         gear_name: i.gear,
         instance_id: i.instance_id,
-        endpoint_uri: i.endpoint.uri,
+        endpoint_uri: i.endpoint.map(|ep| ep.uri).unwrap_or_default(),
         version: i.version.unwrap_or_default(),
         rest_endpoint_uri: i.rest_endpoint.map(|ep| ep.uri),
         openapi_spec: i.openapi_spec,
         openapi_spec_hash: i.openapi_spec_hash,
+        labels: i.labels.into_iter().collect(),
+        state: domain_state_to_proto(i.state) as i32,
     }
+}
+
+/// Map the domain [`InstanceState`] onto the proto `InstanceState` enum so a
+/// label-targeted caller can apply its own health policy from one resolve.
+fn domain_state_to_proto(state: InstanceState) -> ProtoInstanceState {
+    match state {
+        InstanceState::Registered => ProtoInstanceState::Registered,
+        InstanceState::Ready => ProtoInstanceState::Ready,
+        InstanceState::Healthy => ProtoInstanceState::Healthy,
+        InstanceState::Quarantined => ProtoInstanceState::Quarantined,
+        InstanceState::Draining => ProtoInstanceState::Draining,
+        InstanceState::Unknown => ProtoInstanceState::Unspecified,
+    }
+}
+
+/// Upper bound on a single registrant-supplied endpoint URI. Endpoint URIs are
+/// echoed verbatim to every `resolve_*` / `list_*` consumer, so they are
+/// bounded and screened for control characters at the trust boundary.
+const MAX_ENDPOINT_URI_LEN: usize = 2048;
+
+/// Upper bound on a registrant-supplied `OpenAPI` document. Like endpoint URIs and
+/// labels, the spec is echoed to consumers - returned verbatim by
+/// `GetOpenApiSpec`, inlined into `list_instances` (when requested), and turned
+/// into a public route table by the edge - so it is bounded at the trust
+/// boundary rather than stored unbounded. This is a size guard only; structural
+/// `OpenAPI`/JSON validation is tracked separately by
+/// `cpt-cf-binding-fr-openapi-validation`. The cap sits well under the default
+/// 4 MiB gRPC message size so several specs can still be inlined in one
+/// `list_instances` response.
+const MAX_OPENAPI_SPEC_LEN: usize = 1024 * 1024;
+
+/// Schemes accepted for a registered endpoint URI.
+///
+/// Both endpoint consumers speak HTTP transports only: gRPC service endpoints
+/// are dialed via tonic's `Endpoint::from_shared` (default TCP connector) and
+/// REST endpoints are reverse-proxied by the `api-gateway` forwarder, which
+/// parses them as an `http::Uri` and forwards over `http`/`https`. No consumer
+/// connects over a Unix domain socket, so `unix` (and every other scheme) is
+/// rejected here rather than stored and handed back to a consumer that cannot
+/// dial it.
+const SUPPORTED_ENDPOINT_SCHEMES: [&str; 2] = ["http", "https"];
+
+/// Reject an endpoint URI that is empty, over [`MAX_ENDPOINT_URI_LEN`], carries
+/// ASCII control/whitespace characters, is syntactically malformed, is missing
+/// its scheme or authority, or uses a scheme no endpoint consumer can dial (see
+/// [`SUPPORTED_ENDPOINT_SCHEMES`]).
+///
+/// The URI originates from an untrusted registrant and is later handed back to
+/// every discovery consumer, so screening it here keeps a malformed,
+/// undialable, or injection-style value from being stored and propagated. The
+/// URI is parsed with the same [`http::Uri`] parser the gRPC transport and REST
+/// proxy use, so a value accepted here is one those consumers can also parse.
+fn validate_endpoint_uri(context: &str, uri: &str) -> Result<(), Status> {
+    if uri.is_empty() {
+        return Err(Status::invalid_argument(format!(
+            "{context}: empty endpoint URI"
+        )));
+    }
+    if uri.len() > MAX_ENDPOINT_URI_LEN {
+        return Err(Status::invalid_argument(format!(
+            "{context}: endpoint URI too long: {} (max {MAX_ENDPOINT_URI_LEN})",
+            uri.len()
+        )));
+    }
+    if uri
+        .chars()
+        .any(|c| c.is_ascii_control() || c.is_whitespace())
+    {
+        return Err(Status::invalid_argument(format!(
+            "{context}: endpoint URI contains control or whitespace characters"
+        )));
+    }
+    let parsed = uri.parse::<http::Uri>().map_err(|err| {
+        Status::invalid_argument(format!("{context}: malformed endpoint URI: {err}"))
+    })?;
+    let scheme = parsed.scheme_str().ok_or_else(|| {
+        Status::invalid_argument(format!("{context}: endpoint URI is missing a scheme"))
+    })?;
+    if !SUPPORTED_ENDPOINT_SCHEMES.contains(&scheme) {
+        return Err(Status::invalid_argument(format!(
+            "{context}: unsupported endpoint scheme '{scheme}' (expected one of \
+             {SUPPORTED_ENDPOINT_SCHEMES:?})"
+        )));
+    }
+    let authority = parsed.authority().ok_or_else(|| {
+        Status::invalid_argument(format!("{context}: endpoint URI missing authority (host)"))
+    })?;
+    if authority.as_str().contains('@') {
+        return Err(Status::invalid_argument(format!(
+            "{context}: endpoint URI must not contain userinfo ('@')"
+        )));
+    }
+    if parsed.host().is_none_or(str::is_empty) {
+        return Err(Status::invalid_argument(format!(
+            "{context}: endpoint URI missing host"
+        )));
+    }
+    Ok(())
+}
+
+/// Reject a registrant-supplied `OpenAPI` document over [`MAX_OPENAPI_SPEC_LEN`].
+///
+/// The spec originates from an untrusted registrant and is later echoed to
+/// discovery consumers - returned verbatim by `GetOpenApiSpec`, inlined into
+/// `list_instances`, and rendered into the edge's public route table - so an
+/// unbounded value would let a single registrant inflate every such response.
+/// This bounds size only; structural `OpenAPI`/JSON validation is the separate
+/// `cpt-cf-binding-fr-openapi-validation`.
+fn validate_openapi_spec(spec: &str) -> Result<(), Status> {
+    if spec.len() > MAX_OPENAPI_SPEC_LEN {
+        return Err(Status::invalid_argument(format!(
+            "openapi spec too long: {} bytes (max {MAX_OPENAPI_SPEC_LEN})",
+            spec.len()
+        )));
+    }
+    Ok(())
+}
+
+/// Reject a registrant whose labels violate the directory's label rules.
+///
+/// The rules themselves live in the directory SDK
+/// ([`cf_system_sdks::directory::labels`]) so every boundary a label can enter
+/// through — this gRPC front-end, the in-process store, and a gear's own
+/// start-up — enforces them identically. Here we only adapt the shared
+/// [`LabelValidationError`] onto a gRPC `Status`. The registrant is remote and
+/// untrusted, so this runs before the map is stored and echoed on every
+/// `list_instances` / `resolve_by_labels` response; the error message never
+/// interpolates the offending (caller-controlled) key/value.
+fn validate_labels(labels: &std::collections::HashMap<String, String>) -> Result<(), Status> {
+    cf_system_sdks::directory::labels::validate_label_pairs(
+        labels.len(),
+        labels.iter().map(|(k, v)| (k.as_str(), v.as_str())),
+    )
+    .map_err(|e| Status::invalid_argument(e.to_string()))
+}
+
+/// Reject a lookup key (gear or service name) that is blank or violates the
+/// segment charset.
+///
+/// This is the **same** screen `register_instance` applies on write, run here on
+/// the read RPCs so both ends of the contract agree on what a valid name is: a
+/// malformed name is `InvalidArgument` on lookup and register alike, while a
+/// valid-but-unknown name stays a clean not-found — never conflated with a
+/// caller bug. `context` is a static field label, so the offending
+/// (caller-controlled) value is never interpolated into the message.
+fn validate_lookup_name(context: &str, name: &str) -> Result<(), Status> {
+    if name.trim().is_empty() {
+        return Err(Status::invalid_argument(format!(
+            "{context} must not be empty"
+        )));
+    }
+    if !is_valid_label_segment(name) {
+        return Err(Status::invalid_argument(format!(
+            "{context} contains invalid characters"
+        )));
+    }
+    Ok(())
+}
+
+/// Reject a registrant whose `(gear_name, instance_id)` identity is malformed.
+///
+/// A blank/malformed gear name or an `instance_id` that is not a UUID is a
+/// client error, not a server fault: validating it at the trust boundary returns
+/// `InvalidArgument` (so the caller's presence loop stops retrying a
+/// permanently-invalid request) instead of surfacing as a bare
+/// `anyhow!("Invalid instance_id ...")` mislabelled `Internal` from deeper in
+/// the store. The gear-name charset screen ([`validate_lookup_name`]) also
+/// rejects control / whitespace / reflected characters before storage, since the
+/// name is echoed on every discovery response.
+fn validate_identity(gear_name: &str, instance_id: &str) -> Result<(), Status> {
+    validate_lookup_name("gear_name", gear_name)?;
+    if uuid::Uuid::parse_str(instance_id).is_err() {
+        return Err(Status::invalid_argument("instance_id must be a valid UUID"));
+    }
+    Ok(())
 }
 
 /// Create a `DirectoryService` server with the given API implementation and
@@ -293,6 +524,9 @@ mod tests {
     #![allow(clippy::unwrap_used)]
     use super::*;
     use cf_system_sdks::directory::GrpcServiceEndpoint;
+    use cf_system_sdks::directory::labels::{
+        MAX_LABEL_KEY_LEN, MAX_LABEL_VALUE_LEN, MAX_LABELS, is_valid_label_segment,
+    };
     use toolkit::directory::LocalDirectoryClient;
     use toolkit::runtime::GearManager;
     use uuid::Uuid;
@@ -301,6 +535,233 @@ mod tests {
         let manager = Arc::new(GearManager::new());
         let api: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(manager));
         DirectoryServiceImpl::with_authenticator(api, None)
+    }
+
+    #[tokio::test]
+    async fn register_rejects_oversized_labels() {
+        let svc = service();
+
+        // Too many entries.
+        let many: std::collections::HashMap<String, String> = (0..=MAX_LABELS)
+            .map(|i| (format!("k{i}"), "v".to_owned()))
+            .collect();
+        let err = svc
+            .register_instance(Request::new(RegisterInstanceRequest {
+                gear_name: "billing".to_owned(),
+                instance_id: Uuid::new_v4().to_string(),
+                labels: many,
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+        // Over-long value.
+        let long: std::collections::HashMap<String, String> =
+            [("shard".to_owned(), "x".repeat(MAX_LABEL_VALUE_LEN + 1))].into();
+        let err = svc
+            .register_instance(Request::new(RegisterInstanceRequest {
+                gear_name: "billing".to_owned(),
+                instance_id: Uuid::new_v4().to_string(),
+                labels: long,
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+        // A request exactly at the limits still registers.
+        let at_limit: std::collections::HashMap<String, String> = [(
+            "k".repeat(MAX_LABEL_KEY_LEN),
+            "v".repeat(MAX_LABEL_VALUE_LEN),
+        )]
+        .into();
+        svc.register_instance(Request::new(RegisterInstanceRequest {
+            gear_name: "billing".to_owned(),
+            instance_id: Uuid::new_v4().to_string(),
+            labels: at_limit,
+            ..Default::default()
+        }))
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn register_rejects_malformed_endpoint_uri() {
+        let svc = service();
+
+        // Control/whitespace character in a gRPC endpoint URI.
+        let err = svc
+            .register_instance(Request::new(RegisterInstanceRequest {
+                gear_name: "billing".to_owned(),
+                instance_id: Uuid::new_v4().to_string(),
+                grpc_services: vec![GrpcServiceEndpoint {
+                    service_name: "billing.Service".to_owned(),
+                    endpoint_uri: "http://billing:9000\n".to_owned(),
+                }],
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+        // Empty REST endpoint URI.
+        let err = svc
+            .register_instance(Request::new(RegisterInstanceRequest {
+                gear_name: "billing".to_owned(),
+                instance_id: Uuid::new_v4().to_string(),
+                rest_endpoint_uri: Some(String::new()),
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn validate_endpoint_uri_accepts_supported_schemes() {
+        // The transports every endpoint consumer can actually dial.
+        validate_endpoint_uri("grpc", "http://billing:9000").unwrap();
+        validate_endpoint_uri("rest", "https://billing.svc:8443").unwrap();
+        // Path/query are tolerated (consumers keep only scheme + authority).
+        validate_endpoint_uri("rest", "https://billing.svc/ignored?x=1").unwrap();
+    }
+
+    #[test]
+    fn validate_endpoint_uri_rejects_malformed_syntax() {
+        // Not parseable as a URI at all.
+        let err = validate_endpoint_uri("grpc", "http://[::1").unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn validate_endpoint_uri_rejects_missing_components() {
+        // No scheme (bare origin-form path).
+        let err = validate_endpoint_uri("grpc", "/billing/v1").unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        // Supported scheme but no authority (host).
+        let err = validate_endpoint_uri("rest", "http:///path").unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn validate_endpoint_uri_rejects_userinfo() {
+        // A `user@host` authority parses, but every consumer dials the host
+        // after the `@` while the stored value reads as the userinfo prefix, so
+        // a trusted-looking `http://billing@evil.com` would redirect traffic.
+        for uri in [
+            "http://billing@evil.com:9000",
+            "https://billing@evil.com",
+            "http://user:pass@evil.com",
+        ] {
+            let err = validate_endpoint_uri("grpc", uri).unwrap_err();
+            assert_eq!(
+                err.code(),
+                tonic::Code::InvalidArgument,
+                "expected {uri} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_endpoint_uri_rejects_hostless_authority() {
+        // Authority present but no host (`http://:8080`) is undialable.
+        let err = validate_endpoint_uri("rest", "http://:8080").unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn validate_endpoint_uri_rejects_unsupported_schemes() {
+        // No endpoint consumer speaks these transports.
+        for uri in [
+            "ftp://billing:21",
+            "ws://billing:9000",
+            "file:///etc/passwd",
+        ] {
+            let err = validate_endpoint_uri("grpc", uri).unwrap_err();
+            assert_eq!(
+                err.code(),
+                tonic::Code::InvalidArgument,
+                "expected {uri} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_endpoint_uri_rejects_unix_until_consumers_support_uds() {
+        // Neither the tonic gRPC channel (default TCP connector) nor the
+        // api-gateway forwarder can dial a Unix domain socket, so a `unix://`
+        // endpoint is rejected at the trust boundary. Flip this to an accept
+        // (and extend SUPPORTED_ENDPOINT_SCHEMES) once every consumer supports
+        // UDS.
+        let err = validate_endpoint_uri("rest", "unix:///run/billing.sock").unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn register_rejects_unsupported_endpoint_scheme() {
+        let svc = service();
+        let err = svc
+            .register_instance(Request::new(RegisterInstanceRequest {
+                gear_name: "billing".to_owned(),
+                instance_id: Uuid::new_v4().to_string(),
+                rest_endpoint_uri: Some("ftp://billing:21".to_owned()),
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn validate_openapi_spec_bounds_length() {
+        // At the cap passes; one byte over is rejected. The spec is echoed to
+        // every consumer, so an oversized value is refused at registration.
+        validate_openapi_spec(&"x".repeat(MAX_OPENAPI_SPEC_LEN)).unwrap();
+        let err = validate_openapi_spec(&"x".repeat(MAX_OPENAPI_SPEC_LEN + 1)).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn register_rejects_oversized_openapi_spec() {
+        let svc = service();
+        let err = svc
+            .register_instance(Request::new(RegisterInstanceRequest {
+                gear_name: "billing".to_owned(),
+                instance_id: Uuid::new_v4().to_string(),
+                rest_endpoint_uri: Some("http://billing:8080".to_owned()),
+                openapi_spec: Some("x".repeat(MAX_OPENAPI_SPEC_LEN + 1)),
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn list_all_instances_omits_labels() {
+        let svc = service();
+        svc.register_instance(Request::new(RegisterInstanceRequest {
+            gear_name: "billing".to_owned(),
+            instance_id: Uuid::new_v4().to_string(),
+            rest_endpoint_uri: Some("http://billing:8080".to_owned()),
+            labels: [("shard".to_owned(), "a".to_owned())].into(),
+            ..Default::default()
+        }))
+        .await
+        .unwrap();
+
+        let all = svc
+            .list_all_instances(Request::new(ListAllInstancesRequest {}))
+            .await
+            .unwrap()
+            .into_inner()
+            .instances;
+        assert_eq!(all.len(), 1);
+        assert!(
+            all[0].labels.is_empty(),
+            "cross-gear list_all snapshot must not carry labels"
+        );
     }
 
     #[tokio::test]
@@ -318,6 +779,7 @@ mod tests {
             version: "1.0.0".to_owned(),
             rest_endpoint_uri: Some("http://billing:8080".to_owned()),
             openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
+            ..Default::default()
         }))
         .await
         .unwrap();
@@ -346,6 +808,7 @@ mod tests {
         let listed = svc
             .list_instances(Request::new(ListInstancesRequest {
                 gear_name: "billing".to_owned(),
+                ..Default::default()
             }))
             .await
             .unwrap()
@@ -413,14 +876,12 @@ mod tests {
 
         // Register a REST endpoint + OpenAPI spec.
         client
-            .register_instance(RegisterInstanceInfo {
-                gear: "billing".to_owned(),
-                instance_id: Uuid::new_v4().to_string(),
-                grpc_services: vec![],
-                version: Some("1.0.0".to_owned()),
-                rest_endpoint: Some(ServiceEndpoint::http("billing", 8080)),
-                openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
-            })
+            .register_instance(
+                RegisterInstanceInfo::new("billing", Uuid::new_v4().to_string())
+                    .with_version("1.0.0")
+                    .with_rest_endpoint(ServiceEndpoint::http("billing", 8080))
+                    .with_openapi_spec("{\"openapi\":\"3.1.0\"}"),
+            )
             .await
             .unwrap();
 
@@ -448,6 +909,7 @@ mod tests {
                 version: "1.0.0".to_owned(),
                 rest_endpoint_uri: Some(format!("http://{gear}:{port}")),
                 openapi_spec: Some(format!("{{\"openapi\":\"3.1.0\",\"x\":\"{gear}\"}}")),
+                ..Default::default()
             }))
             .await
             .unwrap();
@@ -501,7 +963,9 @@ mod tests {
             .unwrap()
             .local_addr()
             .unwrap();
-        tokio::spawn(async move {
+        // Abort the server on test exit so it does not outlive the test with the
+        // ephemeral port still bound.
+        let server = tokio::spawn(async move {
             Server::builder()
                 .add_service(grpc_service)
                 .serve(addr)
@@ -537,14 +1001,12 @@ mod tests {
         .await
         .unwrap();
         authed
-            .register_instance(RegisterInstanceInfo {
-                gear: "billing".to_owned(),
-                instance_id: Uuid::new_v4().to_string(),
-                grpc_services: vec![],
-                version: Some("1.0.0".to_owned()),
-                rest_endpoint: Some(ServiceEndpoint::http("billing", 8080)),
-                openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
-            })
+            .register_instance(
+                RegisterInstanceInfo::new("billing", Uuid::new_v4().to_string())
+                    .with_version("1.0.0")
+                    .with_rest_endpoint(ServiceEndpoint::http("billing", 8080))
+                    .with_openapi_spec("{\"openapi\":\"3.1.0\"}"),
+            )
             .await
             .expect("authenticated register should succeed");
         let all = authed
@@ -553,5 +1015,403 @@ mod tests {
             .expect("authenticated list");
         assert_eq!(all.len(), 1);
         assert_eq!(all[0].gear, "billing");
+
+        server.abort();
+    }
+
+    #[test]
+    fn domain_state_maps_to_proto_over_all_variants() {
+        // Each domain state maps to its proto counterpart; Unknown collapses to
+        // the UNSPECIFIED wire sentinel. Guards against a silent all-Registered
+        // or swapped-variant regression.
+        for (domain, proto) in [
+            (InstanceState::Registered, ProtoInstanceState::Registered),
+            (InstanceState::Ready, ProtoInstanceState::Ready),
+            (InstanceState::Healthy, ProtoInstanceState::Healthy),
+            (InstanceState::Quarantined, ProtoInstanceState::Quarantined),
+            (InstanceState::Draining, ProtoInstanceState::Draining),
+            (InstanceState::Unknown, ProtoInstanceState::Unspecified),
+        ] {
+            assert_eq!(domain_state_to_proto(domain), proto);
+        }
+    }
+
+    /// The projected `state` field is real: a freshly registered instance reads
+    /// `Registered`, and after a heartbeat it reads `Healthy` in the
+    /// `list_instances` response.
+    #[tokio::test]
+    async fn list_instances_projects_live_state() {
+        let svc = service();
+        let instance_id = Uuid::new_v4().to_string();
+
+        svc.register_instance(Request::new(RegisterInstanceRequest {
+            gear_name: "billing".to_owned(),
+            instance_id: instance_id.clone(),
+            rest_endpoint_uri: Some("http://billing:8080".to_owned()),
+            ..Default::default()
+        }))
+        .await
+        .unwrap();
+
+        let state_of = |svc: &DirectoryServiceImpl| {
+            let svc = svc.clone();
+            async move {
+                svc.list_instances(Request::new(ListInstancesRequest {
+                    gear_name: "billing".to_owned(),
+                    ..Default::default()
+                }))
+                .await
+                .unwrap()
+                .into_inner()
+                .instances[0]
+                    .state
+            }
+        };
+
+        assert_eq!(
+            state_of(&svc).await,
+            ProtoInstanceState::Registered as i32,
+            "a freshly registered instance is not yet serving"
+        );
+
+        svc.heartbeat(Request::new(HeartbeatRequest {
+            gear_name: "billing".to_owned(),
+            instance_id,
+        }))
+        .await
+        .unwrap();
+
+        assert_eq!(
+            state_of(&svc).await,
+            ProtoInstanceState::Healthy as i32,
+            "a heartbeat transitions the instance to Healthy"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_rejects_malformed_identity() {
+        let svc = service();
+
+        // Non-UUID instance_id.
+        let err = svc
+            .register_instance(Request::new(RegisterInstanceRequest {
+                gear_name: "billing".to_owned(),
+                instance_id: "not-a-uuid".to_owned(),
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+        // Empty gear name.
+        let err = svc
+            .register_instance(Request::new(RegisterInstanceRequest {
+                gear_name: String::new(),
+                instance_id: Uuid::new_v4().to_string(),
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn register_rejects_labels_with_disallowed_charset() {
+        let svc = service();
+        // A control character in a label value must be rejected (and never
+        // reflected into the returned Status).
+        let err = svc
+            .register_instance(Request::new(RegisterInstanceRequest {
+                gear_name: "billing".to_owned(),
+                instance_id: Uuid::new_v4().to_string(),
+                labels: [("shard".to_owned(), "1\r\n2".to_owned())].into(),
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(
+            !err.message().contains('\n'),
+            "raw label value must not be echoed into the status message"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_rejects_gear_name_with_disallowed_charset() {
+        let svc = service();
+        let err = svc
+            .register_instance(Request::new(RegisterInstanceRequest {
+                gear_name: "bad\r\nname".to_owned(),
+                instance_id: Uuid::new_v4().to_string(),
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(
+            !err.message().contains('\n'),
+            "raw gear name must not be echoed into the status message"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_rejects_grpc_service_name_with_disallowed_charset() {
+        let svc = service();
+        let err = svc
+            .register_instance(Request::new(RegisterInstanceRequest {
+                gear_name: "billing".to_owned(),
+                instance_id: Uuid::new_v4().to_string(),
+                grpc_services: vec![GrpcServiceEndpoint {
+                    service_name: "bad\r\nservice".to_owned(),
+                    endpoint_uri: "http://127.0.0.1:50051".to_owned(),
+                }],
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(
+            !err.message().contains('\n'),
+            "raw service name must not be echoed into the status message"
+        );
+    }
+
+    #[tokio::test]
+    async fn lookup_rpcs_reject_malformed_name_with_invalid_argument() {
+        let svc = service();
+
+        // Both ends of the contract agree: a malformed name is InvalidArgument
+        // on the read RPCs, not a silent not-found the caller reads as "not
+        // started yet". The raw (caller-controlled) name is never reflected.
+        let rest = svc
+            .resolve_rest_service(Request::new(ResolveRestServiceRequest {
+                gear_name: "bad\r\nname".to_owned(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(rest.code(), tonic::Code::InvalidArgument);
+        assert!(!rest.message().contains('\n'));
+
+        let grpc = svc
+            .resolve_grpc_service(Request::new(ResolveGrpcServiceRequest {
+                service_name: "bad\r\nservice".to_owned(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(grpc.code(), tonic::Code::InvalidArgument);
+
+        let spec = svc
+            .get_open_api_spec(Request::new(GetOpenApiSpecRequest {
+                gear_name: "bad name".to_owned(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(spec.code(), tonic::Code::InvalidArgument);
+
+        let list = svc
+            .list_instances(Request::new(ListInstancesRequest {
+                gear_name: String::new(),
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(list.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn lookup_rpcs_report_valid_unknown_name_as_not_found() {
+        let svc = service();
+
+        // A valid-but-unregistered name stays a clean not-found — distinct from
+        // the InvalidArgument a malformed name earns above.
+        let rest = svc
+            .resolve_rest_service(Request::new(ResolveRestServiceRequest {
+                gear_name: "billing".to_owned(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(rest.code(), tonic::Code::NotFound);
+
+        // A valid unknown name still lists cleanly (empty), not an error.
+        let list = svc
+            .list_instances(Request::new(ListInstancesRequest {
+                gear_name: "billing".to_owned(),
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+        assert!(list.into_inner().instances.is_empty());
+    }
+
+    #[test]
+    // The `naïve` literal is intentional: it exercises rejection of a non-ASCII
+    // segment, which is exactly what this charset test asserts.
+    #[allow(clippy::non_ascii_literal)]
+    fn label_segment_charset_rules() {
+        for ok in ["shard", "1", "role-a", "a.b_c", "v1.2.3"] {
+            assert!(is_valid_label_segment(ok), "{ok} should be valid");
+        }
+        for bad in ["", "-lead", "trail_", ".dot", "a=b", "a b", "a\tb", "naïve"] {
+            assert!(!is_valid_label_segment(bad), "{bad} should be invalid");
+        }
+    }
+
+    /// The `list_instances` label-selector branch: a non-empty `match_labels`
+    /// returns only matching instances, spec-free; a selector matching nothing
+    /// returns an empty list.
+    #[tokio::test]
+    async fn list_instances_with_match_labels_filters_and_strips_spec() {
+        let svc = service();
+
+        // Two instances of the same gear on different shards, both with specs.
+        for shard in ["1", "2"] {
+            svc.register_instance(Request::new(RegisterInstanceRequest {
+                gear_name: "ingest".to_owned(),
+                instance_id: Uuid::new_v4().to_string(),
+                version: "1.0.0".to_owned(),
+                rest_endpoint_uri: Some(format!("http://ingest-{shard}:8080")),
+                openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
+                labels: [("shard".to_owned(), shard.to_owned())].into(),
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+        }
+
+        // A selector pins exactly one shard, returned spec-free.
+        let matched = svc
+            .list_instances(Request::new(ListInstancesRequest {
+                gear_name: "ingest".to_owned(),
+                match_labels: [("shard".to_owned(), "1".to_owned())].into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner()
+            .instances;
+        assert_eq!(
+            matched.len(),
+            1,
+            "selector must return only the matching shard"
+        );
+        assert_eq!(
+            matched[0].labels.get("shard").map(String::as_str),
+            Some("1")
+        );
+        assert!(
+            matched[0].openapi_spec.is_none(),
+            "label-resolve path must strip the OpenAPI document"
+        );
+
+        // A selector matching nothing returns an empty list (not an error).
+        let none = svc
+            .list_instances(Request::new(ListInstancesRequest {
+                gear_name: "ingest".to_owned(),
+                match_labels: [("shard".to_owned(), "99".to_owned())].into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner()
+            .instances;
+        assert!(none.is_empty(), "no instance carries shard=99");
+
+        // Every `list_instances` response is spec-free (empty selector matches
+        // all): the document is never inlined, but the hash still rides along so
+        // a consumer can detect a spec change and fetch it via GetOpenApiSpec.
+        let all_spec_free = svc
+            .list_instances(Request::new(ListInstancesRequest {
+                gear_name: "ingest".to_owned(),
+                match_labels: std::collections::HashMap::new(),
+            }))
+            .await
+            .unwrap()
+            .into_inner()
+            .instances;
+        assert_eq!(all_spec_free.len(), 2, "empty selector matches every shard");
+        assert!(
+            all_spec_free.iter().all(|i| i.openapi_spec.is_none()),
+            "list_instances must never inline the OpenAPI document"
+        );
+        assert!(
+            all_spec_free.iter().all(|i| i.openapi_spec_hash.is_some()),
+            "list_instances must still carry the spec hash"
+        );
+    }
+
+    /// End-to-end over gRPC via `DirectoryClient`: `resolve_by_labels` returns
+    /// only the instances whose labels satisfy the selector, and each carries
+    /// no inline `OpenAPI` document.
+    #[tokio::test]
+    async fn grpc_resolve_by_labels_returns_only_matching_spec_free() {
+        use cf_system_sdks::directory::{DirectoryGrpcClient, LabelSelector};
+        use tonic::transport::Server;
+
+        let manager = Arc::new(GearManager::new());
+        let api: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(manager));
+        let grpc_service = make_directory_service(api, None);
+
+        let addr = std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap();
+        let server = tokio::spawn(async move {
+            Server::builder()
+                .add_service(grpc_service)
+                .serve(addr)
+                .await
+                .unwrap();
+        });
+
+        let client: Arc<dyn DirectoryClient> = Arc::new(
+            DirectoryGrpcClient::connect(format!("http://{addr}"))
+                .await
+                .unwrap(),
+        );
+
+        // Two shards of the same gear; each publishes an OpenAPI document.
+        for shard in ["1", "2"] {
+            client
+                .register_instance(
+                    RegisterInstanceInfo::new("ingest", Uuid::new_v4().to_string())
+                        .with_rest_endpoint(ServiceEndpoint::http(&format!("ingest-{shard}"), 8080))
+                        .with_openapi_spec("{\"openapi\":\"3.1.0\"}")
+                        .with_labels([("shard".to_owned(), shard.to_owned())].into()),
+                )
+                .await
+                .unwrap();
+        }
+
+        // Selector pins shard 1: exactly one match, spec-free over the wire.
+        let matched = client
+            .resolve_by_labels("ingest", &LabelSelector::new().with("shard", "1"))
+            .await
+            .unwrap();
+        assert_eq!(matched.len(), 1);
+        assert_eq!(
+            matched[0].labels.get("shard").map(String::as_str),
+            Some("1")
+        );
+        assert!(
+            matched[0].openapi_spec.is_none(),
+            "resolve_by_labels must not carry the OpenAPI document"
+        );
+
+        // A selector matching nothing yields an empty set (not an error).
+        let none = client
+            .resolve_by_labels("ingest", &LabelSelector::new().with("shard", "99"))
+            .await
+            .unwrap();
+        assert!(none.is_empty());
+
+        let all = client
+            .resolve_by_labels("ingest", &LabelSelector::new())
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 2, "empty selector matches every shard");
+        assert!(
+            all.iter().all(|i| i.openapi_spec.is_none()),
+            "empty-selector resolve_by_labels must not carry the OpenAPI document"
+        );
+
+        server.abort();
     }
 }

--- a/gears/system/grpc-hub/src/gear.rs
+++ b/gears/system/grpc-hub/src/gear.rs
@@ -521,10 +521,12 @@ impl GrpcHub {
                     .map(|i| i.service_name.to_owned())
                     .collect();
 
-                let info = cf_system_sdks::directory::RegisterInstanceInfo {
-                    gear: gear_data.gear_name.clone(),
-                    instance_id: instance_id.clone(),
-                    grpc_services: service_names
+                let info = cf_system_sdks::directory::RegisterInstanceInfo::new(
+                    gear_data.gear_name.clone(),
+                    instance_id.clone(),
+                )
+                .with_grpc_services(
+                    service_names
                         .iter()
                         .map(|n| {
                             (
@@ -533,10 +535,8 @@ impl GrpcHub {
                             )
                         })
                         .collect(),
-                    version: Some(env!("CARGO_PKG_VERSION").to_owned()),
-                    rest_endpoint: None,
-                    openapi_spec: None,
-                };
+                )
+                .with_version(env!("CARGO_PKG_VERSION"));
 
                 directory.register_instance(info).await?;
                 tracing::info!(

--- a/libs/system-sdks/sdks/directory/proto/v1/directory.proto
+++ b/libs/system-sdks/sdks/directory/proto/v1/directory.proto
@@ -64,6 +64,16 @@ message GetOpenApiSpecResponse {
 
 message ListInstancesRequest {
   string gear_name = 1;
+  map<string, string> match_labels = 2;
+}
+
+enum InstanceState {
+  INSTANCE_STATE_UNSPECIFIED = 0;
+  INSTANCE_STATE_REGISTERED = 1;
+  INSTANCE_STATE_READY = 2;
+  INSTANCE_STATE_HEALTHY = 3;
+  INSTANCE_STATE_QUARANTINED = 4;
+  INSTANCE_STATE_DRAINING = 5;
 }
 
 message InstanceInfo {
@@ -74,6 +84,8 @@ message InstanceInfo {
   optional string rest_endpoint_uri = 5;
   optional string openapi_spec = 6;
   optional string openapi_spec_hash = 7;
+  map<string, string> labels = 8;
+  InstanceState state = 9;
 }
 
 message ListInstancesResponse {
@@ -99,6 +111,7 @@ message RegisterInstanceRequest {
   string version = 4;
   optional string rest_endpoint_uri = 5;
   optional string openapi_spec = 6;
+  map<string, string> labels = 7;
 }
 
 message DeregisterInstanceRequest {

--- a/libs/system-sdks/sdks/directory/src/api.rs
+++ b/libs/system-sdks/sdks/directory/src/api.rs
@@ -4,9 +4,10 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
+use std::collections::BTreeMap;
 
 /// Represents an endpoint where a service can be reached
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct ServiceEndpoint {
     pub uri: String,
 }
@@ -37,40 +38,220 @@ impl ServiceEndpoint {
     }
 }
 
+/// Label-equality selector over instance labels (k8s `matchLabels` style).
+///
+/// Matching is equality-AND: an instance matches iff it carries **every**
+/// `(key, value)` pair in `match_labels`. An empty selector matches every
+/// instance. This is the selector consumed by
+/// [`DirectoryClient::resolve_by_labels`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct LabelSelector {
+    /// Required label equalities; all must match.
+    pub match_labels: BTreeMap<String, String>,
+}
+
+impl LabelSelector {
+    /// An empty selector (matches every instance).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a selector from an existing `matchLabels` map.
+    #[must_use]
+    pub fn from_match_labels(match_labels: BTreeMap<String, String>) -> Self {
+        Self { match_labels }
+    }
+
+    /// Add one required label equality, returning `self` for chaining.
+    #[must_use]
+    pub fn with(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.match_labels.insert(key.into(), value.into());
+        self
+    }
+
+    /// Whether this selector constrains nothing (matches every instance).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.match_labels.is_empty()
+    }
+
+    /// Whether `labels` satisfies every required equality in this selector.
+    #[must_use]
+    pub fn matches(&self, labels: &BTreeMap<String, String>) -> bool {
+        self.match_labels
+            .iter()
+            .all(|(k, v)| labels.get(k) == Some(v))
+    }
+}
+
+/// Serving state of a directory instance, projected from the directory's live
+/// registration/heartbeat tracking.
+///
+/// Only [`Ready`](Self::Ready) / [`Healthy`](Self::Healthy) are **serving**;
+/// [`Draining`](Self::Draining) is a graceful shutdown (callers should avoid
+/// sending new work) and [`Quarantined`](Self::Quarantined) is stale (missed
+/// heartbeats). [`Registered`](Self::Registered) is the pre-serving baseline.
+/// Exposed on [`ServiceInstanceInfo`] so [`DirectoryClient::resolve_by_labels`]
+/// callers can apply their own health policy from a single resolve.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum InstanceState {
+    /// Registered but not yet serving (no heartbeat / readiness signal).
+    #[default]
+    Registered,
+    /// Dependencies resolved and marked ready.
+    Ready,
+    /// Serving and heartbeating.
+    Healthy,
+    /// Missed its heartbeat deadline; not serving, pending eviction.
+    Quarantined,
+    /// Gracefully shutting down; upstreams should stop routing new work.
+    Draining,
+    /// State could not be determined.
+    Unknown,
+}
+
+impl InstanceState {
+    /// Whether an instance in this state should receive new traffic
+    /// (`Ready` / `Healthy`). All other states are non-serving.
+    #[must_use]
+    pub fn is_serving(self) -> bool {
+        matches!(self, InstanceState::Ready | InstanceState::Healthy)
+    }
+}
+
 /// Information about a service instance
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct ServiceInstanceInfo {
     /// Gear name this instance belongs to
     pub gear: String,
     /// Unique instance identifier
     pub instance_id: String,
     /// Primary endpoint for the instance
-    pub endpoint: ServiceEndpoint,
+    pub endpoint: Option<ServiceEndpoint>,
     /// Optional version string
     pub version: Option<String>,
-    /// Optional REST endpoint (HTTP base URL) for this instance.
-    /// Not all gears expose a REST API.
+    /// REST endpoint (HTTP base URL) for this instance, or `None` if the gear
+    /// exposes no REST API. This is the address the edge reverse-proxy actually
+    /// dials for REST routing.
     pub rest_endpoint: Option<ServiceEndpoint>,
     /// Optional `OpenAPI` spec (JSON) this instance published, if any.
     pub openapi_spec: Option<String>,
     /// Stable content token for the published `OpenAPI` spec, if any.
     pub openapi_spec_hash: Option<String>,
-    /// Map of gRPC service name to endpoint published by this instance.
+    /// Published gRPC services as `(service name, endpoint)` pairs.
     ///
+    /// Kept as an ordered list rather than a map so it round-trips a repeated
+    /// proto field without reordering; service names are unique per instance.
     /// Carried back by `list_instances` so a subsequent `register_instance`
     /// (which replaces the entry wholesale) can augment — rather than clobber —
     /// the previously-registered gRPC services when adding a REST endpoint.
     pub grpc_services: Vec<(String, ServiceEndpoint)>,
+    /// Stable addressing labels published by this instance (k8s `matchLabels`
+    /// style). Used by [`DirectoryClient::resolve_by_labels`] to select shards
+    /// or peers within a directory name.
+    pub labels: BTreeMap<String, String>,
+    /// Live serving state, so a `resolve_by_labels` caller can apply its own
+    /// health policy without a second call. Defaults to
+    /// [`InstanceState::Registered`].
+    pub state: InstanceState,
+}
+
+impl ServiceInstanceInfo {
+    /// Start a projection for `gear` / `instance_id` with no primary endpoint
+    /// and no optional metadata. Chain the `with_*` builders to populate it.
+    /// `#[non_exhaustive]` means callers must use this builder rather than a
+    /// struct literal, so future fields stay additive.
+    #[must_use]
+    pub fn new(gear: impl Into<String>, instance_id: impl Into<String>) -> Self {
+        Self {
+            gear: gear.into(),
+            instance_id: instance_id.into(),
+            ..Self::default()
+        }
+    }
+
+    /// Set the primary endpoint (`None` for an instance with no primary
+    /// endpoint).
+    #[must_use]
+    pub fn with_endpoint(mut self, endpoint: Option<ServiceEndpoint>) -> Self {
+        self.endpoint = endpoint;
+        self
+    }
+
+    /// Set the optional version string.
+    #[must_use]
+    pub fn with_version(mut self, version: Option<String>) -> Self {
+        self.version = version;
+        self
+    }
+
+    /// Set the optional REST endpoint.
+    #[must_use]
+    pub fn with_rest_endpoint(mut self, rest_endpoint: Option<ServiceEndpoint>) -> Self {
+        self.rest_endpoint = rest_endpoint;
+        self
+    }
+
+    /// Set the optional `OpenAPI` spec (JSON).
+    #[must_use]
+    pub fn with_openapi_spec(mut self, openapi_spec: Option<String>) -> Self {
+        self.openapi_spec = openapi_spec;
+        self
+    }
+
+    /// Set the optional `OpenAPI` spec content token.
+    #[must_use]
+    pub fn with_openapi_spec_hash(mut self, openapi_spec_hash: Option<String>) -> Self {
+        self.openapi_spec_hash = openapi_spec_hash;
+        self
+    }
+
+    /// Set the published gRPC services.
+    #[must_use]
+    pub fn with_grpc_services(mut self, grpc_services: Vec<(String, ServiceEndpoint)>) -> Self {
+        self.grpc_services = grpc_services;
+        self
+    }
+
+    /// Set the stable addressing labels.
+    #[must_use]
+    pub fn with_labels(mut self, labels: BTreeMap<String, String>) -> Self {
+        self.labels = labels;
+        self
+    }
+
+    /// Set the live serving state.
+    #[must_use]
+    pub fn with_state(mut self, state: InstanceState) -> Self {
+        self.state = state;
+        self
+    }
+
+    /// Drop the stable addressing labels, returning `self`.
+    ///
+    /// The shared transform every [`DirectoryClient::list_all_instances`]
+    /// implementation applies so the cross-gear snapshot omits labels
+    /// identically across transports — see that method's doc for why.
+    #[must_use]
+    pub fn without_labels(mut self) -> Self {
+        self.labels.clear();
+        self
+    }
 }
 
 /// Information for registering a new gear instance
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct RegisterInstanceInfo {
     /// Gear name
     pub gear: String,
     /// Unique instance identifier
     pub instance_id: String,
-    /// Map of gRPC service name to endpoint
+    /// Published gRPC services as `(service name, endpoint)` pairs (service
+    /// names are unique per instance; ordered to mirror the proto repeated
+    /// field rather than reordered into a map).
     pub grpc_services: Vec<(String, ServiceEndpoint)>,
     /// Optional version string
     pub version: Option<String>,
@@ -78,6 +259,65 @@ pub struct RegisterInstanceInfo {
     pub rest_endpoint: Option<ServiceEndpoint>,
     /// Optional `OpenAPI` spec (JSON) published by the gear.
     pub openapi_spec: Option<String>,
+    /// Stable addressing labels for this instance (k8s `matchLabels` style).
+    pub labels: BTreeMap<String, String>,
+}
+
+impl RegisterInstanceInfo {
+    /// Start a registration for `gear` / `instance_id` with no endpoints,
+    /// version, spec, or labels. Chain the `with_*` builders to populate it.
+    #[must_use]
+    pub fn new(gear: impl Into<String>, instance_id: impl Into<String>) -> Self {
+        Self {
+            gear: gear.into(),
+            instance_id: instance_id.into(),
+            ..Self::default()
+        }
+    }
+
+    /// Set the published gRPC services.
+    #[must_use]
+    pub fn with_grpc_services(mut self, grpc_services: Vec<(String, ServiceEndpoint)>) -> Self {
+        self.grpc_services = grpc_services;
+        self
+    }
+
+    /// Set the version string.
+    #[must_use]
+    pub fn with_version(mut self, version: impl Into<String>) -> Self {
+        self.version = Some(version.into());
+        self
+    }
+
+    /// Set the REST endpoint (HTTP base URL).
+    #[must_use]
+    pub fn with_rest_endpoint(mut self, rest_endpoint: ServiceEndpoint) -> Self {
+        self.rest_endpoint = Some(rest_endpoint);
+        self
+    }
+
+    /// Set the published `OpenAPI` spec (JSON).
+    #[must_use]
+    pub fn with_openapi_spec(mut self, openapi_spec: impl Into<String>) -> Self {
+        self.openapi_spec = Some(openapi_spec.into());
+        self
+    }
+
+    /// Set the stable addressing labels.
+    ///
+    /// Re-registration replaces the directory entry wholesale, but an **empty**
+    /// label set is treated as "preserve the stored labels", not "clear them"
+    /// (see `GearManager::with_metadata_of`): the periodic self-heal and REST
+    /// augmentation re-register without labels and must not erase a shard's
+    /// identity. A non-empty set replaces the stored one. Clearing labels
+    /// outright is therefore intentionally not expressible — an instance's
+    /// labels are its static shard/peer identity for its lifetime; changing
+    /// them means restarting with new configuration.
+    #[must_use]
+    pub fn with_labels(mut self, labels: BTreeMap<String, String>) -> Self {
+        self.labels = labels;
+        self
+    }
 }
 
 /// A resolved gRPC service and the endpoint it is reachable at.
@@ -171,8 +411,75 @@ pub trait DirectoryClient: Send + Sync {
     /// Retrieve the `OpenAPI` spec (JSON) published by a gear.
     async fn get_openapi_spec(&self, gear_name: &str) -> Result<String>;
 
-    /// List all service instances for a given gear
+    /// List all service instances for a given gear.
+    ///
+    /// Entries are **spec-free**: only the `openapi_spec_hash` is carried, never
+    /// the full `openapi_spec` document, so a multi-instance response stays
+    /// bounded regardless of spec size. Callers fetch the document out-of-band
+    /// via [`get_openapi_spec`](Self::get_openapi_spec); the hash lets a consumer
+    /// detect a spec change without inlining N copies of the document.
+    ///
+    /// An endpoint-less instance is still returned (`endpoint`/`rest_endpoint` =
+    /// `None`, never an empty-URI sentinel): *no-endpoint, not an error*. Only
+    /// [`list_all_instances`](Self::list_all_instances), which needs a dialable
+    /// URI, drops such entries.
     async fn list_instances(&self, gear: &str) -> Result<Vec<ServiceInstanceInfo>>;
+
+    /// Resolve instances of `gear` whose labels satisfy `selector`.
+    ///
+    /// Matching is equality-AND (k8s `matchLabels`): an instance matches iff
+    /// it carries **every** `(key, value)` pair in the selector; an empty
+    /// selector matches every instance of the name.
+    ///
+    /// The returned set is **not** health-filtered — matched instances are
+    /// returned regardless of readiness/heartbeat state, each carrying its
+    /// `instance_id`, `labels`, endpoints, and live
+    /// [`state`](ServiceInstanceInfo::state). Applying liveness policy (e.g.
+    /// keeping only [`InstanceState::is_serving`]) is the caller's
+    /// responsibility.
+    ///
+    /// Nor is it **endpoint-filtered**: a matched instance that advertises no
+    /// endpoint yet is still returned (`endpoint`/`rest_endpoint` = `None`) —
+    /// *no-endpoint, not an error* — so the caller can fall back rather than
+    /// have the match silently hidden.
+    ///
+    /// Returned entries are **spec-free** on every implementation — the full
+    /// `openapi_spec` document is omitted (only its hash is carried), so the
+    /// polled resolve payload stays bounded; the caller fetches documents via
+    /// [`get_openapi_spec`](Self::get_openapi_spec). This holds regardless of
+    /// whether the selector is empty. The default body enumerates via
+    /// [`list_instances`](Self::list_instances), filters in-process, and drops
+    /// the spec; transport-backed clients (e.g. the gRPC client) override it to
+    /// push the selector server-side and request spec-free entries over the
+    /// wire.
+    ///
+    /// Label-based selection is effectively **out-of-process only**. Labels are
+    /// published from the `OoP` serve path's configuration (`oop_http.labels`);
+    /// the in-process registration path (grpc-hub start phase /
+    /// `run_directory_register_phase`) has no label source, so an in-process
+    /// gear carries no labels and a non-empty selector never matches it. This
+    /// matches the deployment model: shards/peers are distinct instances
+    /// (separate pods/processes), which is inherently the `OoP` topology.
+    async fn resolve_by_labels(
+        &self,
+        gear: &str,
+        selector: &LabelSelector,
+    ) -> Result<Vec<ServiceInstanceInfo>> {
+        // cancel-safe: the single await precedes any mutation; cancelling here
+        // just drops the in-flight list and leaves no partial state.
+        let instances = self.list_instances(gear).await?;
+        Ok(instances
+            .into_iter()
+            .filter(|i| selector.matches(&i.labels))
+            // Spec-free entries, matching the documented contract and the
+            // transport-backed overrides: the label-resolve path never inlines
+            // the OpenAPI document (the hash still rides along).
+            .map(|mut i| {
+                i.openapi_spec = None;
+                i
+            })
+            .collect())
+    }
 
     /// List every service instance across all registered gears.
     ///
@@ -182,6 +489,12 @@ pub trait DirectoryClient: Send + Sync {
     /// backing store holds a stored specification. The edge fetches a gear's
     /// document once, on first discovery, via
     /// [`get_openapi_spec`](Self::get_openapi_spec).
+    ///
+    /// The returned instances also do **not** carry `labels`: every
+    /// implementation applies [`ServiceInstanceInfo::without_labels`] so the
+    /// snapshot omits them identically regardless of transport. Labels drive
+    /// the targeted [`resolve_by_labels`](Self::resolve_by_labels) path, not
+    /// this snapshot.
     async fn list_all_instances(&self) -> Result<Vec<ServiceInstanceInfo>>;
 
     /// Register a new gear instance with the directory
@@ -217,23 +530,19 @@ mod tests {
 
     #[test]
     fn test_register_instance_info() {
-        let info = RegisterInstanceInfo {
-            gear: "test_gear".to_owned(),
-            instance_id: "instance1".to_owned(),
-            grpc_services: vec![(
+        let info = RegisterInstanceInfo::new("test_gear", "instance1")
+            .with_grpc_services(vec![(
                 "test.Service".to_owned(),
                 ServiceEndpoint::http("127.0.0.1", 8001),
-            )],
-            version: Some("1.0.0".to_owned()),
-            rest_endpoint: None,
-            openapi_spec: None,
-        };
+            )])
+            .with_version("1.0.0");
 
         assert_eq!(info.gear, "test_gear");
         assert_eq!(info.instance_id, "instance1");
         assert_eq!(info.grpc_services.len(), 1);
         assert!(info.rest_endpoint.is_none());
         assert!(info.openapi_spec.is_none());
+        assert!(info.labels.is_empty());
     }
 
     #[test]
@@ -243,6 +552,7 @@ mod tests {
             instance_id: "instance1".to_owned(),
             grpc_services: vec![],
             version: Some("2.0.0".to_owned()),
+            labels: BTreeMap::new(),
             rest_endpoint: Some(ServiceEndpoint::http("billing", 8080)),
             openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
         };
@@ -253,5 +563,113 @@ mod tests {
             concat!("http", "://billing:8080")
         );
         assert!(info.openapi_spec.is_some());
+    }
+
+    fn labels(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn label_selector_equality_and_matches() {
+        let selector = LabelSelector::new()
+            .with("shard", "7")
+            .with("role", "ingest");
+
+        // Superset of the required labels matches.
+        assert!(selector.matches(&labels(&[
+            ("shard", "7"),
+            ("role", "ingest"),
+            ("extra", "x"),
+        ])));
+        // Missing one required key fails.
+        assert!(!selector.matches(&labels(&[("shard", "7")])));
+        // Wrong value on a required key fails.
+        assert!(!selector.matches(&labels(&[("shard", "8"), ("role", "ingest")])));
+    }
+
+    #[test]
+    fn empty_label_selector_matches_everything() {
+        let selector = LabelSelector::new();
+        assert!(selector.is_empty());
+        assert!(selector.matches(&BTreeMap::new()));
+        assert!(selector.matches(&labels(&[("shard", "7")])));
+    }
+
+    struct StaticDirectory {
+        instances: Vec<ServiceInstanceInfo>,
+    }
+
+    #[async_trait]
+    impl DirectoryClient for StaticDirectory {
+        async fn resolve_grpc_service(&self, service_name: &str) -> Result<ServiceEndpoint> {
+            Err(DirectoryNotFound::new(format!("service {service_name}")).into())
+        }
+        async fn resolve_rest_service(&self, gear_name: &str) -> Result<ServiceEndpoint> {
+            Err(DirectoryNotFound::new(format!("gear {gear_name}")).into())
+        }
+        async fn get_openapi_spec(&self, gear_name: &str) -> Result<String> {
+            Err(DirectoryNotFound::new(format!("spec {gear_name}")).into())
+        }
+        async fn list_instances(&self, gear: &str) -> Result<Vec<ServiceInstanceInfo>> {
+            Ok(self
+                .instances
+                .iter()
+                .filter(|i| i.gear == gear)
+                .cloned()
+                .collect())
+        }
+        async fn list_all_instances(&self) -> Result<Vec<ServiceInstanceInfo>> {
+            Ok(self.instances.clone())
+        }
+        async fn register_instance(&self, _info: RegisterInstanceInfo) -> Result<()> {
+            Ok(())
+        }
+        async fn deregister_instance(&self, _gear: &str, _instance_id: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn send_heartbeat(&self, _gear: &str, _instance_id: &str) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn instance(id: &str, labels_pairs: &[(&str, &str)]) -> ServiceInstanceInfo {
+        ServiceInstanceInfo {
+            gear: "worker".to_owned(),
+            instance_id: id.to_owned(),
+            labels: labels(labels_pairs),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_by_labels_default_filters_by_equality_and() {
+        let dir = StaticDirectory {
+            instances: vec![
+                instance("a", &[("shard", "7")]),
+                instance("b", &[("shard", "8")]),
+                instance("c", &[("shard", "7"), ("role", "ingest")]),
+            ],
+        };
+
+        let selector = LabelSelector::new().with("shard", "7");
+        let mut matched = dir
+            .resolve_by_labels("worker", &selector)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|i| i.instance_id)
+            .collect::<Vec<_>>();
+        matched.sort();
+        assert_eq!(matched, vec!["a".to_owned(), "c".to_owned()]);
+
+        // An empty selector returns every instance of the name.
+        let all = dir
+            .resolve_by_labels("worker", &LabelSelector::new())
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 3);
     }
 }

--- a/libs/system-sdks/sdks/directory/src/grpc/client.rs
+++ b/libs/system-sdks/sdks/directory/src/grpc/client.rs
@@ -7,10 +7,12 @@ use async_trait::async_trait;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 
+use crate::ProtoInstanceState;
 use crate::api::{
-    DirectoryClient, DirectoryInvalidArgument, DirectoryNotFound, RegisterInstanceInfo,
-    ServiceEndpoint, ServiceInstanceInfo,
+    DirectoryClient, DirectoryInvalidArgument, DirectoryNotFound, InstanceState, LabelSelector,
+    RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo,
 };
+use std::collections::BTreeMap;
 use toolkit_transport_grpc::InternalAuthInterceptor;
 use toolkit_transport_grpc::client::{GrpcClientConfig, connect_with_retry};
 
@@ -49,15 +51,18 @@ fn lookup_error(resource: &str, status: &tonic::Status) -> anyhow::Error {
 
 /// Map a mutating RPC's `tonic::Status`, preserving the code in the message.
 ///
-/// These calls have no not-found semantics worth typing, but a bare
-/// `"gRPC call failed"` hides whether the directory was unreachable
-/// (`Unavailable`) or rejected the request (`Internal`).
+/// A bare `"gRPC call failed"` hides whether the directory was unreachable
+/// (`Unavailable`, transient) or rejected the request (`InvalidArgument`,
+/// permanent). `InvalidArgument` is typed as [`DirectoryInvalidArgument`] so a
+/// caller retrying a mutation (e.g. the presence loop) can distinguish a
+/// permanent rejection — which retrying can never fix — from a transient one.
 fn call_error(op: &str, status: &tonic::Status) -> anyhow::Error {
-    anyhow::anyhow!(
-        "directory {op} failed: gRPC {:?}: {}",
-        status.code(),
-        status.message()
-    )
+    match status.code() {
+        tonic::Code::InvalidArgument => {
+            DirectoryInvalidArgument::new(status.message().to_owned()).into()
+        }
+        code => anyhow::anyhow!("directory {op} failed: gRPC {code:?}: {}", status.message()),
+    }
 }
 
 /// gRPC client for Directory API
@@ -225,6 +230,7 @@ impl DirectoryClient for DirectoryGrpcClient {
         let mut client = self.inner.clone();
         let request = tonic::Request::new(ListInstancesRequest {
             gear_name: gear.to_owned(),
+            match_labels: std::collections::HashMap::new(),
         });
 
         let response = client
@@ -242,6 +248,47 @@ impl DirectoryClient for DirectoryGrpcClient {
         Ok(instances)
     }
 
+    async fn resolve_by_labels(
+        &self,
+        gear: &str,
+        selector: &LabelSelector,
+    ) -> Result<Vec<ServiceInstanceInfo>> {
+        // Push the selector server-side so the directory returns only matching
+        // instances. Every `list_instances` response is spec-free (only the
+        // `openapi_spec_hash` rides along; the document is fetched via
+        // `GetOpenApiSpec`), so an empty (match-all) selector never leaks a full
+        // OpenAPI document over the wire.
+        //
+        // cancel-safe: the single await is the unary `list_instances` RPC, which
+        // precedes any local state change; cancelling it just drops the in-flight
+        // response and leaves nothing partially applied.
+        let mut client = self.inner.clone();
+        let match_labels = selector
+            .match_labels
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        let request = tonic::Request::new(ListInstancesRequest {
+            gear_name: gear.to_owned(),
+            match_labels,
+        });
+
+        let response = client
+            .list_instances(request)
+            .await
+            .map_err(|e| lookup_error(&format!("instances of gear {gear}"), &e))?;
+
+        let instances = response
+            .into_inner()
+            .instances
+            .into_iter()
+            .map(proto_instance_to_domain)
+            .filter(|i| selector.matches(&i.labels))
+            .collect();
+
+        Ok(instances)
+    }
+
     async fn list_all_instances(&self) -> Result<Vec<ServiceInstanceInfo>> {
         let mut client = self.inner.clone();
         let response = client
@@ -254,7 +301,7 @@ impl DirectoryClient for DirectoryGrpcClient {
             .instances
             .into_iter()
             .map(|proto| {
-                let mut info = proto_instance_to_domain(proto);
+                let mut info = proto_instance_to_domain(proto).without_labels();
                 info.openapi_spec = None;
                 info
             })
@@ -283,6 +330,7 @@ impl DirectoryClient for DirectoryGrpcClient {
             version: info.version.unwrap_or_default(),
             rest_endpoint_uri: info.rest_endpoint.map(|ep| ep.uri),
             openapi_spec: info.openapi_spec,
+            labels: info.labels.into_iter().collect(),
         };
 
         client
@@ -331,7 +379,11 @@ fn proto_instance_to_domain(proto: InstanceInfo) -> ServiceInstanceInfo {
     ServiceInstanceInfo {
         gear: proto.gear_name,
         instance_id: proto.instance_id,
-        endpoint: ServiceEndpoint::new(proto.endpoint_uri),
+        endpoint: if proto.endpoint_uri.is_empty() {
+            None
+        } else {
+            Some(ServiceEndpoint::new(proto.endpoint_uri))
+        },
         version: if proto.version.is_empty() {
             None
         } else {
@@ -340,11 +392,48 @@ fn proto_instance_to_domain(proto: InstanceInfo) -> ServiceInstanceInfo {
         rest_endpoint: proto.rest_endpoint_uri.map(ServiceEndpoint::new),
         openapi_spec: proto.openapi_spec,
         openapi_spec_hash: proto.openapi_spec_hash,
-        // The list-instances proto response does not break the instance down
-        // per gRPC service, so nothing to carry back over the OoP directory
-        // transport. The in-process `LocalDirectoryClient` populates this from
-        // the live `GearInstance`.
+        // The `InstanceInfo` proto message carries no per-service gRPC
+        // breakdown, so nothing to reconstruct over the OoP directory transport;
+        // only the in-process `LocalDirectoryClient` populates this (from the
+        // live `GearInstance`). No consumer reads `grpc_services` off a
+        // gRPC-obtained instance today — a single gRPC endpoint is available via
+        // the primary `endpoint`. When a label-targeted gRPC client needs the
+        // full per-service map remotely (the TopologyView work), add a
+        // `repeated GrpcServiceEndpoint grpc_services` field to `InstanceInfo`.
         grpc_services: Vec::new(),
+        // Stable addressing labels cross the wire (ordering is normalized into a
+        // BTreeMap for deterministic selector matching).
+        labels: proto.labels.into_iter().collect::<BTreeMap<_, _>>(),
+        // Live serving state so label-targeted callers can filter on health.
+        state: proto_state_to_domain(proto.state),
+    }
+}
+
+/// Map the proto `InstanceState` (an open enum carried as `i32`) onto the
+/// domain [`InstanceState`].
+///
+/// `UNSPECIFIED` (a peer that never set the field, e.g. an older server) and
+/// any discriminant this build does not recognise map to the non-serving
+/// [`InstanceState::Unknown`] — kept distinct from
+/// [`InstanceState::Registered`] so "the state is unknown" is not silently read
+/// as a known pre-serving baseline. An unrecognised discriminant is logged so
+/// the version skew is observable rather than swallowed.
+fn proto_state_to_domain(state: i32) -> InstanceState {
+    match ProtoInstanceState::try_from(state) {
+        Ok(ProtoInstanceState::Ready) => InstanceState::Ready,
+        Ok(ProtoInstanceState::Healthy) => InstanceState::Healthy,
+        Ok(ProtoInstanceState::Quarantined) => InstanceState::Quarantined,
+        Ok(ProtoInstanceState::Draining) => InstanceState::Draining,
+        Ok(ProtoInstanceState::Registered) => InstanceState::Registered,
+        Ok(ProtoInstanceState::Unspecified) => InstanceState::Unknown,
+        Err(_) => {
+            tracing::warn!(
+                raw_state = state,
+                "directory returned an unrecognised InstanceState discriminant; \
+                 treating as Unknown (non-serving)"
+            );
+            InstanceState::Unknown
+        }
     }
 }
 
@@ -391,17 +480,25 @@ mod tests {
             rest_endpoint_uri: Some("http://calc:8080".to_owned()),
             openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
             openapi_spec_hash: None,
+            labels: [("shard".to_owned(), "7".to_owned())].into_iter().collect(),
+            state: ProtoInstanceState::Healthy as i32,
         };
         let domain = proto_instance_to_domain(proto);
         assert_eq!(domain.gear, "calc");
+        assert_eq!(domain.state, InstanceState::Healthy);
         assert_eq!(domain.instance_id, "calc-1");
-        assert_eq!(domain.endpoint.uri, "http://calc:8080");
+        assert_eq!(
+            domain.endpoint.as_ref().map(|e| e.uri.as_str()),
+            Some("http://calc:8080")
+        );
         assert_eq!(domain.version.as_deref(), Some("1.2.3"));
         assert_eq!(
             domain.rest_endpoint.map(|e| e.uri),
             Some("http://calc:8080".to_owned())
         );
         assert!(domain.openapi_spec.is_some());
+        // Labels cross the wire and land in a BTreeMap for deterministic matching.
+        assert_eq!(domain.labels.get("shard"), Some(&"7".to_owned()));
     }
 
     #[test]
@@ -414,11 +511,69 @@ mod tests {
             rest_endpoint_uri: None,
             openapi_spec: None,
             openapi_spec_hash: None,
+            labels: std::collections::HashMap::new(),
+            state: ProtoInstanceState::Unspecified as i32,
         };
         let domain = proto_instance_to_domain(proto);
+        // A non-empty proto endpoint_uri maps to `Some`.
+        assert_eq!(
+            domain.endpoint.as_ref().map(|e| e.uri.as_str()),
+            Some("http://worker:7000")
+        );
         // An empty proto version string maps to `None` rather than an empty string.
         assert!(domain.version.is_none());
         assert!(domain.rest_endpoint.is_none());
         assert!(domain.openapi_spec.is_none());
+        assert!(domain.labels.is_empty());
+        // An unset proto state (`UNSPECIFIED`) maps to the non-serving Unknown
+        // sentinel — distinct from the pre-serving Registered baseline.
+        assert_eq!(domain.state, InstanceState::Unknown);
+        assert!(!domain.state.is_serving());
+    }
+
+    #[test]
+    fn proto_instance_maps_empty_endpoint_to_none() {
+        // proto3 carries an absent primary endpoint as an empty string; it must
+        // map back to `None`, not an empty-URI sentinel a dialer could mistake
+        // for a real address.
+        let proto = InstanceInfo {
+            gear_name: "grpc-only".to_owned(),
+            instance_id: "g-1".to_owned(),
+            endpoint_uri: String::new(),
+            version: String::new(),
+            rest_endpoint_uri: None,
+            openapi_spec: None,
+            openapi_spec_hash: None,
+            labels: std::collections::HashMap::new(),
+            state: ProtoInstanceState::Ready as i32,
+        };
+        let domain = proto_instance_to_domain(proto);
+        assert!(
+            domain.endpoint.is_none(),
+            "an empty proto endpoint_uri must map to None"
+        );
+    }
+
+    #[test]
+    fn proto_state_unspecified_and_unrecognised_map_to_unknown() {
+        // `UNSPECIFIED` (peer never set the field) and any discriminant this
+        // build does not know (e.g. a newer server) both collapse to the
+        // non-serving Unknown sentinel rather than being read as Registered.
+        assert_eq!(
+            proto_state_to_domain(ProtoInstanceState::Unspecified as i32),
+            InstanceState::Unknown
+        );
+        assert_eq!(proto_state_to_domain(9999), InstanceState::Unknown);
+        assert!(!proto_state_to_domain(9999).is_serving());
+
+        // Known discriminants still map through unchanged.
+        assert_eq!(
+            proto_state_to_domain(ProtoInstanceState::Registered as i32),
+            InstanceState::Registered
+        );
+        assert_eq!(
+            proto_state_to_domain(ProtoInstanceState::Healthy as i32),
+            InstanceState::Healthy
+        );
     }
 }

--- a/libs/system-sdks/sdks/directory/src/grpc/mod.rs
+++ b/libs/system-sdks/sdks/directory/src/grpc/mod.rs
@@ -19,6 +19,9 @@ pub mod directory {
 // Re-export common types for DirectoryService
 pub use directory::directory_service_client::DirectoryServiceClient;
 pub use directory::directory_service_server::{DirectoryService, DirectoryServiceServer};
+// The generated `InstanceState` enum is re-exported under an alias so it does
+// not collide with the domain `api::InstanceState` at the crate root.
+pub use directory::InstanceState as ProtoInstanceState;
 pub use directory::{
     DeregisterInstanceRequest, GetOpenApiSpecRequest, GetOpenApiSpecResponse, GrpcServiceEndpoint,
     HeartbeatRequest, InstanceInfo, ListAllInstancesRequest, ListAllInstancesResponse,

--- a/libs/system-sdks/sdks/directory/src/labels.rs
+++ b/libs/system-sdks/sdks/directory/src/labels.rs
@@ -1,0 +1,252 @@
+//! Shared validation for directory labels and label selectors.
+//!
+//! Labels are the single mechanism for shard/peer targeting
+//! ([`resolve_by_labels`](crate::DirectoryClient::resolve_by_labels)), so their
+//! rules must be enforced identically at **every** boundary a label can enter
+//! the system through — not just the gRPC `RegisterInstance` front-end:
+//!
+//! - the gRPC server (remote, untrusted registrants);
+//! - the in-process store ([`LocalDirectoryClient`](crate::DirectoryClient), so
+//!   a second transport or an in-process bug cannot smuggle an invalid label
+//!   past the checks);
+//! - a gear's own start-up, so a mis-configured label fails fast rather than
+//!   being rejected later by the directory.
+//!
+//! Centralising the rules here makes this module the single source of truth;
+//! each boundary maps [`LabelValidationError`] onto its own error type.
+
+use std::collections::BTreeMap;
+
+use crate::LabelSelector;
+
+/// Maximum number of labels on a single instance. Unbounded labels bloat
+/// directory memory and every downstream list/resolve payload.
+pub const MAX_LABELS: usize = 64;
+/// Maximum length of a label key (mirrors the Kubernetes label convention).
+pub const MAX_LABEL_KEY_LEN: usize = 63;
+/// Maximum length of a label value (mirrors the Kubernetes label convention).
+pub const MAX_LABEL_VALUE_LEN: usize = 63;
+
+/// A label set or selector violated the directory's label rules.
+///
+/// The offending key/value is **never** carried in the message: labels are
+/// caller-controlled and interpolating them would reflect arbitrary bytes into
+/// an error string that is logged and returned over the wire.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LabelValidationError {
+    /// More than [`MAX_LABELS`] entries.
+    TooMany {
+        /// The offending count.
+        count: usize,
+    },
+    /// A label key was empty or longer than [`MAX_LABEL_KEY_LEN`].
+    KeyLength,
+    /// A label value was longer than [`MAX_LABEL_VALUE_LEN`].
+    ValueLength,
+    /// A label key was outside the allowed charset.
+    KeyCharset,
+    /// A label value was outside the allowed charset.
+    ValueCharset,
+}
+
+impl std::fmt::Display for LabelValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LabelValidationError::TooMany { count } => {
+                write!(f, "too many labels: {count} (max {MAX_LABELS})")
+            }
+            LabelValidationError::KeyLength => write!(
+                f,
+                "a label key has length out of range (1..={MAX_LABEL_KEY_LEN})"
+            ),
+            LabelValidationError::ValueLength => write!(
+                f,
+                "a label value has length out of range (0..={MAX_LABEL_VALUE_LEN})"
+            ),
+            LabelValidationError::KeyCharset => write!(
+                f,
+                "a label key contains characters outside the allowed set \
+                 (ASCII alphanumeric, '-', '_', '.'; must start and end alphanumeric)"
+            ),
+            LabelValidationError::ValueCharset => write!(
+                f,
+                "a label value contains characters outside the allowed set \
+                 (ASCII alphanumeric, '-', '_', '.'; must start and end alphanumeric)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LabelValidationError {}
+
+/// Whether `s` is a valid label key/value segment: ASCII alphanumeric plus
+/// `-`, `_`, `.`, beginning and ending with an alphanumeric character (the
+/// Kubernetes label convention). Rejects CR/LF, control characters, `=`,
+/// quotes, whitespace, and arbitrary non-ASCII — none of which any label
+/// consumer needs and all of which are unsafe to echo/store.
+#[must_use]
+pub fn is_valid_label_segment(s: &str) -> bool {
+    let mut chars = s.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_alphanumeric() {
+        return false;
+    }
+    let mut last = first;
+    for c in chars {
+        if !(c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.')) {
+            return false;
+        }
+        last = c;
+    }
+    last.is_ascii_alphanumeric()
+}
+
+/// Validate a single `(key, value)` label pair against the charset/length rules.
+///
+/// An empty value is permitted (Kubernetes convention); a non-empty one must
+/// satisfy the same charset/boundary rules as a key.
+///
+/// # Errors
+/// Returns a [`LabelValidationError`] describing the first violated rule.
+pub fn validate_label_pair(key: &str, value: &str) -> Result<(), LabelValidationError> {
+    if key.is_empty() || key.len() > MAX_LABEL_KEY_LEN {
+        return Err(LabelValidationError::KeyLength);
+    }
+    if !is_valid_label_segment(key) {
+        return Err(LabelValidationError::KeyCharset);
+    }
+    if value.len() > MAX_LABEL_VALUE_LEN {
+        return Err(LabelValidationError::ValueLength);
+    }
+    if !value.is_empty() && !is_valid_label_segment(value) {
+        return Err(LabelValidationError::ValueCharset);
+    }
+    Ok(())
+}
+
+/// Validate a label set: count bound plus per-pair charset/length rules.
+///
+/// Generic over the pair iterator so both the domain [`BTreeMap`] and the proto
+/// `HashMap` can be validated without an intermediate allocation. `count` is
+/// the total number of labels (checked against [`MAX_LABELS`] before iterating).
+///
+/// # Errors
+/// Returns a [`LabelValidationError`] describing the first violated rule.
+pub fn validate_label_pairs<'a, I>(count: usize, pairs: I) -> Result<(), LabelValidationError>
+where
+    I: IntoIterator<Item = (&'a str, &'a str)>,
+{
+    if count > MAX_LABELS {
+        return Err(LabelValidationError::TooMany { count });
+    }
+    for (k, v) in pairs {
+        validate_label_pair(k, v)?;
+    }
+    Ok(())
+}
+
+/// Validate a domain label map (the store/start-up boundary convenience).
+///
+/// # Errors
+/// Returns a [`LabelValidationError`] describing the first violated rule.
+pub fn validate_labels(labels: &BTreeMap<String, String>) -> Result<(), LabelValidationError> {
+    validate_label_pairs(
+        labels.len(),
+        labels.iter().map(|(k, v)| (k.as_str(), v.as_str())),
+    )
+}
+
+/// Validate a [`LabelSelector`]: its `match_labels` must satisfy the same rules
+/// as a stored label set (an over-long or malformed selector could never match
+/// a valid label anyway, and echoing it back is unsafe for the same reason).
+///
+/// # Errors
+/// Returns a [`LabelValidationError`] describing the first violated rule.
+pub fn validate_selector(selector: &LabelSelector) -> Result<(), LabelValidationError> {
+    validate_labels(&selector.match_labels)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn accepts_well_formed_labels_and_empty_values() {
+        assert!(validate_labels(&map(&[("shard", "7"), ("role", "ingest")])).is_ok());
+        // Empty value is permitted (Kubernetes convention).
+        assert!(validate_labels(&map(&[("canary", "")])).is_ok());
+        // Exactly at the length limits is accepted.
+        let at_limit = map(&[(
+            "k".repeat(MAX_LABEL_KEY_LEN).as_str(),
+            "v".repeat(MAX_LABEL_VALUE_LEN).as_str(),
+        )]);
+        assert!(validate_labels(&at_limit).is_ok());
+    }
+
+    #[test]
+    fn rejects_too_many_labels() {
+        let many: BTreeMap<String, String> = (0..=MAX_LABELS)
+            .map(|i| (format!("k{i}"), "v".to_owned()))
+            .collect();
+        assert_eq!(
+            validate_labels(&many),
+            Err(LabelValidationError::TooMany {
+                count: MAX_LABELS + 1
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_bad_lengths() {
+        assert_eq!(
+            validate_labels(&map(&[("", "v")])),
+            Err(LabelValidationError::KeyLength)
+        );
+        let long_key = "k".repeat(MAX_LABEL_KEY_LEN + 1);
+        assert_eq!(
+            validate_labels(&map(&[(long_key.as_str(), "v")])),
+            Err(LabelValidationError::KeyLength)
+        );
+        let long_val = "v".repeat(MAX_LABEL_VALUE_LEN + 1);
+        assert_eq!(
+            validate_labels(&map(&[("shard", long_val.as_str())])),
+            Err(LabelValidationError::ValueLength)
+        );
+    }
+
+    #[test]
+    // The `über` literal is intentional: it exercises rejection of a non-ASCII
+    // key, which is exactly what this charset test asserts.
+    #[allow(clippy::non_ascii_literal)]
+    fn rejects_disallowed_charset_without_echoing_input() {
+        for bad in ["bad key", "bad=key", "bad\nkey", "-lead", "trail-", "über"] {
+            let err = validate_labels(&map(&[(bad, "v")])).unwrap_err();
+            assert_eq!(err, LabelValidationError::KeyCharset);
+            // The offending input must never be reflected in the message.
+            assert!(!err.to_string().contains(bad));
+        }
+        let err = validate_labels(&map(&[("shard", "bad value")])).unwrap_err();
+        assert_eq!(err, LabelValidationError::ValueCharset);
+    }
+
+    #[test]
+    fn selector_reuses_label_rules() {
+        let ok = LabelSelector::new().with("shard", "7");
+        assert!(validate_selector(&ok).is_ok());
+
+        let bad = LabelSelector::new().with("bad key", "7");
+        assert_eq!(
+            validate_selector(&bad),
+            Err(LabelValidationError::KeyCharset)
+        );
+    }
+}

--- a/libs/system-sdks/sdks/directory/src/lib.rs
+++ b/libs/system-sdks/sdks/directory/src/lib.rs
@@ -8,10 +8,15 @@
 mod api;
 #[cfg(feature = "grpc")]
 mod grpc;
+pub mod labels;
 
 pub use api::{
-    DirectoryClient, DirectoryInvalidArgument, DirectoryNotFound, GrpcServiceInfo,
-    RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo,
+    DirectoryClient, DirectoryInvalidArgument, DirectoryNotFound, GrpcServiceInfo, InstanceState,
+    LabelSelector, RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo,
 };
 #[cfg(feature = "grpc")]
 pub use grpc::*;
+pub use labels::{
+    LabelValidationError, MAX_LABEL_KEY_LEN, MAX_LABEL_VALUE_LEN, MAX_LABELS, validate_labels,
+    validate_selector,
+};

--- a/libs/toolkit/src/bootstrap/config/mod.rs
+++ b/libs/toolkit/src/bootstrap/config/mod.rs
@@ -165,6 +165,13 @@ pub struct OopHttpConfig {
     /// unspecified host (`0.0.0.0`) rewritten to `127.0.0.1`.
     #[serde(default)]
     pub advertise_uri: Option<String>,
+    /// Allow a loopback / unspecified `advertise_uri` (`127.0.0.1`, `::1`,
+    /// `localhost`, `0.0.0.0`, `[::]`). Off by default: such an endpoint is
+    /// registered-but-unreachable in multi-host Profile 2 / Profile 3, so
+    /// bootstrap fails fast (`cpt-cf-adr-instance-addressable-discovery`).
+    /// Set `true` only for single-host / local-dev.
+    #[serde(default)]
+    pub allow_loopback_advertise: bool,
     /// Platform-plane (`InternalAuthenticator`) configuration. When present it
     /// drives both the *inbound* HTTP validator on the gear's own routes and
     /// the *outbound* credential attached to the gear's `DirectoryService`
@@ -173,6 +180,19 @@ pub struct OopHttpConfig {
     /// feature.
     #[serde(default)]
     pub internal_auth: Option<toolkit_security::InternalAuthConfig>,
+    /// Stable addressing labels (k8s `matchLabels` style) advertised with this
+    /// instance's directory registration, for label-based instance selection
+    /// (`DirectoryClient::resolve_by_labels`).
+    ///
+    /// Sourced from config (`oop_http.labels.<key>`) or the environment
+    /// (`APP__OOP_HTTP__LABELS__<KEY>`). A bare-numeric env *value* (e.g. a
+    /// `StatefulSet` ordinal injected as `APP__OOP_HTTP__LABELS__SHARD=7`) is
+    /// coerced to a string here rather than aborting the config load. Note:
+    /// environment-sourced keys are still lower-cased by the config loader, so
+    /// keys that must preserve case or contain `.`/`-` should be set in the
+    /// config file rather than via env.
+    #[serde(default, deserialize_with = "de_labels_scalar_to_string")]
+    pub labels: std::collections::BTreeMap<String, String>,
 }
 
 fn default_drain_timeout_secs() -> u64 {
@@ -181,6 +201,50 @@ fn default_drain_timeout_secs() -> u64 {
 
 fn default_healthcheck_timeout_ms() -> u64 {
     500
+}
+
+/// Deserialize a label map, coercing scalar values (numbers, booleans) to
+/// strings.
+///
+/// The environment layer parses a bare-numeric value like
+/// `APP__OOP_HTTP__LABELS__SHARD=7` into an integer, which would otherwise fail
+/// to deserialize into a `String` and abort the entire `AppConfig::load_layered`
+/// — precisely on the path a k8s `StatefulSet` ordinal is injected. Accepting the
+/// scalar and rendering it as a string keeps that value load-able as a label.
+fn de_labels_scalar_to_string<'de, D>(
+    deserializer: D,
+) -> Result<std::collections::BTreeMap<String, String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+
+    // Ordering matters for `untagged`: a string input matches `Str`; an integer
+    // matches `I64`/`U64` before `F64`, so `7` renders as `"7"` not `"7.0"`.
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Scalar {
+        Str(String),
+        Bool(bool),
+        I64(i64),
+        U64(u64),
+        F64(f64),
+    }
+
+    let raw = std::collections::BTreeMap::<String, Scalar>::deserialize(deserializer)?;
+    Ok(raw
+        .into_iter()
+        .map(|(k, v)| {
+            let value = match v {
+                Scalar::Str(s) => s,
+                Scalar::Bool(b) => b.to_string(),
+                Scalar::I64(i) => i.to_string(),
+                Scalar::U64(u) => u.to_string(),
+                Scalar::F64(f) => f.to_string(),
+            };
+            (k, value)
+        })
+        .collect())
 }
 
 impl ConfigProvider for AppConfig {
@@ -1455,6 +1519,26 @@ mod tests {
 
         // Gears bag is empty by default
         assert!(config.gears.is_empty());
+    }
+
+    #[test]
+    fn oop_http_labels_coerce_numeric_and_bool_values_to_strings() {
+        // A bare-numeric env value (e.g. `APP__OOP_HTTP__LABELS__SHARD=7`) is
+        // parsed as an integer by the env layer; it must load as a string
+        // label rather than aborting the config parse.
+        let cfg: OopHttpConfig = serde_json::from_value(serde_json::json!({
+            "listen_addr": "0.0.0.0:8080",
+            "labels": {
+                "shard": 7,
+                "role": "ingest",
+                "canary": true,
+            }
+        }))
+        .expect("numeric/bool label values must deserialize");
+
+        assert_eq!(cfg.labels.get("shard").map(String::as_str), Some("7"));
+        assert_eq!(cfg.labels.get("role").map(String::as_str), Some("ingest"));
+        assert_eq!(cfg.labels.get("canary").map(String::as_str), Some("true"));
     }
 
     // `#[serial]`: calls load_layered, which reads the APP__ env layer; serialize
@@ -3027,6 +3111,49 @@ vendor:
                 assert_eq!(v.api_token, "from_env");
             },
         );
+    }
+
+    #[test]
+    #[serial]
+    fn test_oop_http_labels_from_yaml_and_env() {
+        let tmp = tempdir().unwrap();
+        let cfg_path = tmp.path().join("cfg.yaml");
+        let yaml = r#"
+server:
+  home_dir: "~/.test_oop_labels"
+oop_http:
+  listen_addr: "0.0.0.0:8080"
+  labels:
+    role: "ingest"
+"#;
+        fs::write(&cfg_path, yaml).unwrap();
+
+        // Env layer adds a second label. Env keys are lower-cased by the loader,
+        // so `ZONE` lands as `zone`.
+        with_var("APP__OOP_HTTP__LABELS__ZONE", Some("us-east-1"), || {
+            let config = AppConfig::load_layered(&cfg_path).unwrap();
+            let oop = config.oop_http.expect("oop_http present");
+            assert_eq!(oop.labels.get("role"), Some(&"ingest".to_owned()));
+            assert_eq!(
+                oop.labels.get("zone"),
+                Some(&"us-east-1".to_owned()),
+                "APP__OOP_HTTP__LABELS__ZONE should populate labels[zone]"
+            );
+        });
+
+        // A bare-numeric env value (e.g. a StatefulSet ordinal injected as
+        // `APP__OOP_HTTP__LABELS__SHARD=7`) is coerced to its string
+        // representation by `de_labels_scalar_to_string` rather than failing the
+        // config load, so numeric-looking labels can be set via the environment.
+        with_var("APP__OOP_HTTP__LABELS__SHARD", Some("7"), || {
+            let config = AppConfig::load_layered(&cfg_path).unwrap();
+            let oop = config.oop_http.expect("oop_http present");
+            assert_eq!(
+                oop.labels.get("shard"),
+                Some(&"7".to_owned()),
+                "a bare-numeric env label value should be coerced to the string \"7\""
+            );
+        });
     }
 
     #[test]

--- a/libs/toolkit/src/bootstrap/oop.rs
+++ b/libs/toolkit/src/bootstrap/oop.rs
@@ -665,6 +665,22 @@ async fn build_oop_serve_options(
         .clone()
         .unwrap_or_else(|| default_advertise_uri(listen_addr));
 
+    // Fail fast on a malformed or unreachable advertise_uri rather than only
+    // when the directory rejects the registration — the same late-failure the
+    // label validation below avoids.
+    validate_advertise_uri(&advertise_uri, cfg.allow_loopback_advertise)?;
+
+    // Fail fast on a mis-configured label (bad charset, over-long, too many)
+    // at start-up, using the same shared rules the directory enforces. Without
+    // this the process would come up, attempt to register, and only then be
+    // permanently rejected by the directory — a confusing late failure for what
+    // is a static configuration error. Checked before authenticator init so a
+    // static config error is reported without any async backend setup.
+    cf_system_sdks::directory::validate_labels(&cfg.labels).with_context(|| {
+        "invalid oop_http.labels: label keys/values must be <=63 chars, <=64 entries, and use \
+         only ASCII alphanumerics plus '-', '_', '.' (starting and ending alphanumeric)"
+    })?;
+
     let internal_authenticator = build_internal_authenticator(cfg.internal_auth.as_ref()).await?;
 
     Ok(OopServeOptions {
@@ -680,6 +696,7 @@ async fn build_oop_serve_options(
         directory,
         bearer_authenticator: None,
         internal_authenticator,
+        labels: cfg.labels.clone(),
     })
 }
 
@@ -740,6 +757,46 @@ fn default_advertise_uri(listen_addr: std::net::SocketAddr) -> String {
         std::net::SocketAddr::V6(addr) => format!("[{}]", addr.ip()),
     };
     format!("http://{host}:{}", listen_addr.port())
+}
+
+/// Reject a malformed or unreachable `advertise_uri` at start-up (fail fast).
+///
+/// Checks shape (parseable `http`/`https` URL, non-empty host, no userinfo) and,
+/// unless `allow_loopback`, rejects a loopback / unspecified host - a
+/// registered-but-unreachable instance in multi-host Profile 2 / Profile 3
+/// (`cpt-cf-adr-instance-addressable-discovery` section 5). The default derives
+/// loopback from an unspecified bind, so this also covers an *unset* value. The
+/// directory enforces its full endpoint ruleset server-side.
+fn validate_advertise_uri(uri: &str, allow_loopback: bool) -> Result<()> {
+    let parsed = url::Url::parse(uri)
+        .with_context(|| format!("invalid oop_http.advertise_uri: not a valid URL: {uri}"))?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        anyhow::bail!(
+            "invalid oop_http.advertise_uri: scheme must be http or https (got '{}')",
+            parsed.scheme()
+        );
+    }
+    if parsed.host_str().is_none_or(str::is_empty) {
+        anyhow::bail!("invalid oop_http.advertise_uri: missing host: {uri}");
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        anyhow::bail!("invalid oop_http.advertise_uri: must not contain userinfo: {uri}");
+    }
+    let is_loopback = match parsed.host() {
+        Some(url::Host::Ipv4(ip)) => ip.is_loopback() || ip.is_unspecified(),
+        Some(url::Host::Ipv6(ip)) => ip.is_loopback() || ip.is_unspecified(),
+        Some(url::Host::Domain(d)) => d.trim_end_matches('.').eq_ignore_ascii_case("localhost"),
+        None => false,
+    };
+    if !allow_loopback && is_loopback {
+        anyhow::bail!(
+            "invalid oop_http.advertise_uri: '{uri}' is a loopback/unspecified address, which is \
+             unreachable by other gears in multi-host Profile 2 / Profile 3 (a registered-but-\
+             unreachable instance). Set oop_http.advertise_uri to a routable host, or set \
+             oop_http.allow_loopback_advertise = true for single-host / local-dev."
+        );
+    }
+    Ok(())
 }
 
 #[allow(unknown_lints, de1301_no_print_macros)] // direct stdout config print before exit

--- a/libs/toolkit/src/bootstrap/oop_tests.rs
+++ b/libs/toolkit/src/bootstrap/oop_tests.rs
@@ -806,3 +806,76 @@ mod full_oop_config {
         assert_eq!(gear_config["config"]["master_setting"], "value");
     }
 }
+
+// =============================================================================
+// advertise_uri startup validation
+// =============================================================================
+
+mod advertise_uri {
+    use super::*;
+
+    #[test]
+    fn accepts_well_formed_routable_hosts() {
+        validate_advertise_uri("http://billing.default.svc.cluster.local:8080", false).unwrap();
+        validate_advertise_uri("https://billing:8080", false).unwrap();
+        // A routable IP passes without the loopback opt-out.
+        validate_advertise_uri("http://10.0.0.5:8080", false).unwrap();
+    }
+
+    #[test]
+    fn rejects_malformed() {
+        // Missing scheme (parses without a host).
+        assert!(validate_advertise_uri("billing:8080", false).is_err());
+        // Unsupported scheme.
+        assert!(validate_advertise_uri("ftp://billing:8080", false).is_err());
+        // Not a URL at all.
+        assert!(validate_advertise_uri("not a uri", false).is_err());
+        // Embedded userinfo (credential smuggling).
+        assert!(validate_advertise_uri("http://billing@evil.com:8080", false).is_err());
+        assert!(validate_advertise_uri("http://user:pass@billing:8080", false).is_err());
+        // Missing-host authority.
+        assert!(validate_advertise_uri("http://", false).is_err());
+    }
+
+    #[test]
+    fn rejects_loopback_and_unspecified_by_default() {
+        // ADR-0009 section 5: a loopback / unspecified advertise_uri is a
+        // registered-but-unreachable instance in multi-host Profile 2 / 3.
+        for uri in [
+            "http://127.0.0.1:8080",
+            "http://localhost:8080",
+            // Fully-qualified `localhost.` (trailing dot) is DNS-equivalent to
+            // `localhost`, so it must still be treated as loopback.
+            "http://localhost.:8080",
+            "http://0.0.0.0:8080",
+            "http://[::1]:8080",
+            "http://[::]:8080",
+        ] {
+            assert!(
+                validate_advertise_uri(uri, false).is_err(),
+                "{uri} must be rejected without the loopback opt-out"
+            );
+        }
+        // The generated default (unspecified bind -> loopback) is exactly the
+        // unset-advertise_uri trap and must be rejected too.
+        let default = default_advertise_uri("0.0.0.0:8080".parse().unwrap());
+        assert!(validate_advertise_uri(&default, false).is_err());
+    }
+
+    #[test]
+    fn allows_loopback_when_opted_in() {
+        // Single-host / local-dev opt-out (oop_http.allow_loopback_advertise).
+        for uri in [
+            "http://127.0.0.1:8080",
+            "http://localhost:8080",
+            "http://localhost.:8080",
+            "http://0.0.0.0:8080",
+            "http://[::1]:8080",
+        ] {
+            validate_advertise_uri(uri, true).unwrap();
+        }
+        // The default still passes its own validation with the opt-out.
+        let default = default_advertise_uri("0.0.0.0:8080".parse().unwrap());
+        validate_advertise_uri(&default, true).unwrap();
+    }
+}

--- a/libs/toolkit/src/directory.rs
+++ b/libs/toolkit/src/directory.rs
@@ -32,9 +32,60 @@ fn openapi_spec_hash(spec: &str) -> String {
 
 // Re-export all types from contracts - this is the single source of truth
 pub use cf_system_sdks::directory::{
-    DirectoryClient, DirectoryInvalidArgument, DirectoryNotFound, GrpcServiceInfo,
-    RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo,
+    DirectoryClient, DirectoryInvalidArgument, DirectoryNotFound, GrpcServiceInfo, InstanceState,
+    LabelSelector, RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo,
 };
+
+/// Project the live runtime [`crate::runtime::InstanceState`] onto the domain
+/// [`InstanceState`] carried on `ServiceInstanceInfo`, so `resolve_by_labels`
+/// callers can apply their own health policy from a single resolve.
+fn runtime_state_to_domain(state: crate::runtime::InstanceState) -> InstanceState {
+    use crate::runtime::InstanceState as Rt;
+    match state {
+        Rt::Registered => InstanceState::Registered,
+        Rt::Ready => InstanceState::Ready,
+        Rt::Healthy => InstanceState::Healthy,
+        Rt::Quarantined => InstanceState::Quarantined,
+        Rt::Draining => InstanceState::Draining,
+    }
+}
+
+/// Project a live [`GearInstance`] into a [`ServiceInstanceInfo`].
+///
+/// `endpoint` prefers gRPC and falls back to REST; an instance advertising
+/// neither yields `endpoint: None` (never an empty-URI sentinel), which the
+/// label paths surface as *no-endpoint, not an error*. Always **spec-free**:
+/// only the `OpenAPI` spec *hash* rides along, never the document (fetched via
+/// `get_openapi_spec`).
+fn project_instance(gear: &str, inst: &GearInstance) -> ServiceInstanceInfo {
+    let endpoint = inst
+        .grpc_services
+        .values()
+        .next()
+        .or(inst.rest_endpoint.as_ref())
+        .map(|ep| ServiceEndpoint::new(ep.uri.clone()));
+
+    ServiceInstanceInfo::new(gear, inst.instance_id.to_string())
+        .with_endpoint(endpoint)
+        .with_version(inst.version.clone())
+        .with_rest_endpoint(
+            inst.rest_endpoint
+                .as_ref()
+                .map(|ep| ServiceEndpoint::new(ep.uri.clone())),
+        )
+        .with_openapi_spec_hash(inst.openapi_spec.as_deref().map(openapi_spec_hash))
+        // Carry every published gRPC service back so the directory-register
+        // phase can augment (not clobber) this instance when it adds a REST
+        // endpoint.
+        .with_grpc_services(
+            inst.grpc_services
+                .iter()
+                .map(|(name, e)| (name.clone(), ServiceEndpoint::new(e.uri.clone())))
+                .collect(),
+        )
+        .with_labels(inst.labels.clone())
+        .with_state(runtime_state_to_domain(inst.state()))
+}
 
 /// Local implementation of `DirectoryClient` that delegates to `GearManager`
 ///
@@ -83,90 +134,76 @@ impl DirectoryClient for LocalDirectoryClient {
     }
 
     async fn list_instances(&self, gear: &str) -> Result<Vec<ServiceInstanceInfo>> {
-        let mut result = Vec::new();
+        // Base label-targeting enumeration: project every instance, including
+        // endpoint-less ones (no-endpoint contract; see `project_instance`).
+        Ok(self
+            .mgr
+            .instances_of(gear)
+            .iter()
+            .map(|inst| project_instance(gear, inst))
+            .collect())
+    }
 
-        for inst in self.mgr.instances_of(gear) {
-            if let Some((_, ep)) = inst.grpc_services.iter().next() {
-                result.push(ServiceInstanceInfo {
-                    gear: gear.to_owned(),
-                    instance_id: inst.instance_id.to_string(),
-                    endpoint: ServiceEndpoint::new(ep.uri.clone()),
-                    version: inst.version.clone(),
-                    rest_endpoint: inst
-                        .rest_endpoint
-                        .as_ref()
-                        .map(|ep| ServiceEndpoint::new(ep.uri.clone())),
-                    openapi_spec_hash: inst.openapi_spec.as_deref().map(openapi_spec_hash),
-                    openapi_spec: inst.openapi_spec.clone(),
-                    // Carry every published gRPC service back so the
-                    // directory-register phase can augment (not clobber) this
-                    // instance when it adds a REST endpoint.
-                    grpc_services: inst
-                        .grpc_services
-                        .iter()
-                        .map(|(name, e)| (name.clone(), ServiceEndpoint::new(e.uri.clone())))
-                        .collect(),
-                });
-            }
-        }
-
-        Ok(result)
+    async fn resolve_by_labels(
+        &self,
+        gear: &str,
+        selector: &LabelSelector,
+    ) -> Result<Vec<ServiceInstanceInfo>> {
+        // Filter by selector only: no health/endpoint filtering, so a matched
+        // endpoint-less instance is still returned for the caller to fall back on.
+        Ok(self
+            .mgr
+            .instances_of(gear)
+            .iter()
+            .map(|inst| project_instance(gear, inst))
+            .filter(|i| selector.matches(&i.labels))
+            .collect())
     }
 
     async fn list_all_instances(&self) -> Result<Vec<ServiceInstanceInfo>> {
-        let result = self
+        // Edge snapshot: drop labels (shared `without_labels`) and, unlike the
+        // label paths, skip endpoint-less instances — the edge needs a dialable
+        // URI — with a `debug!` so the omission is observable.
+        Ok(self
             .mgr
             .all_instances()
-            .into_iter()
-            .map(|inst| {
-                // Prefer a gRPC endpoint for the primary `endpoint`; fall back to
-                // the REST endpoint (OoP gears often register REST-only).
-                let endpoint = inst
-                    .grpc_services
-                    .values()
-                    .next()
-                    .or(inst.rest_endpoint.as_ref())
-                    .map_or_else(
-                        || ServiceEndpoint::new(String::new()),
-                        |ep| ServiceEndpoint::new(ep.uri.clone()),
+            .iter()
+            .filter_map(|inst| {
+                let info = project_instance(&inst.gear, inst);
+                if info.endpoint.is_none() {
+                    tracing::debug!(
+                        gear = %inst.gear,
+                        instance_id = %inst.instance_id,
+                        "skipping instance with no gRPC or REST endpoint from cross-gear snapshot"
                     );
-                ServiceInstanceInfo {
-                    gear: inst.gear.clone(),
-                    instance_id: inst.instance_id.to_string(),
-                    endpoint,
-                    version: inst.version.clone(),
-                    rest_endpoint: inst
-                        .rest_endpoint
-                        .as_ref()
-                        .map(|ep| ServiceEndpoint::new(ep.uri.clone())),
-                    // The document itself is deliberately omitted here: the
-                    // cross-gear discovery snapshot must stay small and bounded
-                    // (it is polled every sync interval). Consumers that need
-                    // the document fetch it per gear via `get_openapi_spec`.
-                    // The content hash *is* carried so the edge can detect spec
-                    // changes and skip the fetch + rebuild when unchanged.
-                    openapi_spec_hash: inst.openapi_spec.as_deref().map(openapi_spec_hash),
-                    openapi_spec: None,
-                    // Same rationale as `list_instances`: carry the published
-                    // gRPC services so a later register can augment rather than
-                    // clobber them. Available here because this reads the live
-                    // `GearInstance`.
-                    grpc_services: inst
-                        .grpc_services
-                        .iter()
-                        .map(|(name, e)| (name.clone(), ServiceEndpoint::new(e.uri.clone())))
-                        .collect(),
+                    return None;
                 }
+                Some(info.without_labels())
             })
-            .collect();
-
-        Ok(result)
+            .collect())
     }
 
     async fn register_instance(&self, info: RegisterInstanceInfo) -> Result<()> {
         // Parse instance_id from string to Uuid
-        let instance_id = Uuid::parse_str(&info.instance_id)
-            .map_err(|e| anyhow::anyhow!("Invalid instance_id '{}': {}", info.instance_id, e))?;
+        let instance_id = Uuid::parse_str(&info.instance_id).map_err(|e| {
+            // A malformed instance_id is a client error, not a server fault:
+            // return the typed `DirectoryInvalidArgument` so a gRPC front-end
+            // maps it to `InvalidArgument` (and the caller stops retrying)
+            // rather than a bare `anyhow!` reported as `Internal`.
+            anyhow::Error::from(DirectoryInvalidArgument::new(format!(
+                "invalid instance_id '{}': {e}",
+                info.instance_id
+            )))
+        })?;
+
+        // Validate labels at the store boundary, not just at the gRPC
+        // front-end: this is the single point every registration path (remote
+        // gRPC, in-process, or a future transport) funnels through, so
+        // enforcing the shared rules here means an invalid label can never be
+        // stored regardless of how it arrived. The typed error maps to
+        // `InvalidArgument` at the wire boundary.
+        cf_system_sdks::directory::validate_labels(&info.labels)
+            .map_err(|e| anyhow::Error::from(DirectoryInvalidArgument::new(e.to_string())))?;
 
         // Build a GearInstance from RegisterInstanceInfo
         let mut instance = GearInstance::new(info.gear.clone(), instance_id);
@@ -189,6 +226,11 @@ impl DirectoryClient for LocalDirectoryClient {
         // Apply OpenAPI spec if provided
         if let Some(spec) = info.openapi_spec {
             instance = instance.with_openapi_spec(spec);
+        }
+
+        // Apply stable addressing labels if provided
+        if !info.labels.is_empty() {
+            instance = instance.with_labels(info.labels);
         }
 
         // Register the instance with the manager
@@ -243,17 +285,12 @@ mod tests {
 
         let instance_id = Uuid::new_v4();
         // Register an instance through the API
-        let register_info = RegisterInstanceInfo {
-            gear: "test_gear".to_owned(),
-            instance_id: instance_id.to_string(),
-            grpc_services: vec![(
+        let register_info = RegisterInstanceInfo::new("test_gear", instance_id.to_string())
+            .with_grpc_services(vec![(
                 "test.Service".to_owned(),
                 ServiceEndpoint::http("127.0.0.1", 8001),
-            )],
-            version: Some("1.0.0".to_owned()),
-            rest_endpoint: None,
-            openapi_spec: None,
-        };
+            )])
+            .with_version("1.0.0");
 
         api.register_instance(register_info).await.unwrap();
 
@@ -266,19 +303,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn register_rejects_invalid_labels_at_store_boundary() {
+        // Validation is enforced at the store, not only at the gRPC front-end:
+        // an invalid label registered in-process must be rejected here (typed
+        // as DirectoryInvalidArgument) and never reach the manager.
+        let dir = Arc::new(GearManager::new());
+        let api = LocalDirectoryClient::new(Arc::clone(&dir));
+
+        let err = api
+            .register_instance(
+                RegisterInstanceInfo::new("worker", Uuid::new_v4().to_string())
+                    .with_rest_endpoint(ServiceEndpoint::new("http://worker:8080"))
+                    .with_labels(labels(&[("bad key", "7")])),
+            )
+            .await
+            .expect_err("an invalid label must be rejected at the store boundary");
+        assert!(
+            err.downcast_ref::<DirectoryInvalidArgument>().is_some(),
+            "store-boundary label rejection must be typed InvalidArgument, got: {err}"
+        );
+        assert!(
+            dir.instances_of("worker").is_empty(),
+            "a rejected registration must not be stored"
+        );
+    }
+
+    #[tokio::test]
     async fn test_register_and_resolve_rest_and_openapi() {
         let dir = Arc::new(GearManager::new());
         let api = LocalDirectoryClient::new(dir.clone());
 
         let instance_id = Uuid::new_v4();
-        let register_info = RegisterInstanceInfo {
-            gear: "billing".to_owned(),
-            instance_id: instance_id.to_string(),
-            grpc_services: vec![],
-            version: Some("1.0.0".to_owned()),
-            rest_endpoint: Some(ServiceEndpoint::http("billing", 8080)),
-            openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
-        };
+        let register_info = RegisterInstanceInfo::new("billing", instance_id.to_string())
+            .with_version("1.0.0")
+            .with_rest_endpoint(ServiceEndpoint::http("billing", 8080))
+            .with_openapi_spec("{\"openapi\":\"3.1.0\"}");
 
         api.register_instance(register_info).await.unwrap();
 
@@ -366,14 +425,12 @@ mod tests {
 
         // Two REST-only OoP gears (no gRPC services) + one gRPC-only gear.
         for (gear, port) in [("billing", 8080u16), ("catalog", 8081u16)] {
-            api.register_instance(RegisterInstanceInfo {
-                gear: gear.to_owned(),
-                instance_id: Uuid::new_v4().to_string(),
-                grpc_services: vec![],
-                version: Some("1.0.0".to_owned()),
-                rest_endpoint: Some(ServiceEndpoint::http(gear, port)),
-                openapi_spec: Some(format!("{{\"openapi\":\"3.1.0\",\"x\":\"{gear}\"}}")),
-            })
+            api.register_instance(
+                RegisterInstanceInfo::new(gear, Uuid::new_v4().to_string())
+                    .with_version("1.0.0")
+                    .with_rest_endpoint(ServiceEndpoint::http(gear, port))
+                    .with_openapi_spec(format!("{{\"openapi\":\"3.1.0\",\"x\":\"{gear}\"}}")),
+            )
             .await
             .unwrap();
         }
@@ -381,17 +438,14 @@ mod tests {
         // gRPC-only gear: gRPC service metadata and no REST endpoint / spec. This
         // exercises gRPC endpoint selection in `list_all_instances` (which prefers
         // a gRPC endpoint for the primary `endpoint`).
-        api.register_instance(RegisterInstanceInfo {
-            gear: "reporting".to_owned(),
-            instance_id: Uuid::new_v4().to_string(),
-            grpc_services: vec![(
-                "reporting.Service".to_owned(),
-                ServiceEndpoint::new("http://reporting:7000"),
-            )],
-            version: Some("1.0.0".to_owned()),
-            rest_endpoint: None,
-            openapi_spec: None,
-        })
+        api.register_instance(
+            RegisterInstanceInfo::new("reporting", Uuid::new_v4().to_string())
+                .with_grpc_services(vec![(
+                    "reporting.Service".to_owned(),
+                    ServiceEndpoint::new("http://reporting:7000"),
+                )])
+                .with_version("1.0.0"),
+        )
         .await
         .unwrap();
 
@@ -419,8 +473,255 @@ mod tests {
             .iter()
             .find(|i| i.gear == "reporting")
             .expect("reporting");
-        assert_eq!(reporting.endpoint.uri.as_str(), "http://reporting:7000");
+        assert_eq!(
+            reporting.endpoint.as_ref().map(|e| e.uri.as_str()),
+            Some("http://reporting:7000")
+        );
         assert!(reporting.rest_endpoint.is_none());
         assert!(reporting.openapi_spec.is_none());
+    }
+
+    fn labels(pairs: &[(&str, &str)]) -> std::collections::BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn register_carries_labels_into_list_instances() {
+        let dir = Arc::new(GearManager::new());
+        let api = LocalDirectoryClient::new(Arc::clone(&dir));
+
+        api.register_instance(
+            RegisterInstanceInfo::new("worker", Uuid::new_v4().to_string())
+                .with_grpc_services(vec![(
+                    "worker.Svc".to_owned(),
+                    ServiceEndpoint::new("http://worker:7000"),
+                )])
+                .with_labels(labels(&[("shard", "7")])),
+        )
+        .await
+        .unwrap();
+
+        let listed = api.list_instances("worker").await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].labels.get("shard"), Some(&"7".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn resolve_by_labels_selects_matching_instances() {
+        let dir = Arc::new(GearManager::new());
+        let api = LocalDirectoryClient::new(Arc::clone(&dir));
+
+        for (id, shard) in [("a", "7"), ("b", "8"), ("c", "7")] {
+            api.register_instance(
+                RegisterInstanceInfo::new("worker", Uuid::new_v4().to_string())
+                    .with_grpc_services(vec![(
+                        format!("worker.{id}"),
+                        ServiceEndpoint::new(format!("http://worker-{id}:7000")),
+                    )])
+                    .with_labels(labels(&[("shard", shard)])),
+            )
+            .await
+            .unwrap();
+        }
+
+        let matched = api
+            .resolve_by_labels("worker", &LabelSelector::new().with("shard", "7"))
+            .await
+            .unwrap();
+        assert_eq!(matched.len(), 2, "two instances carry shard=7");
+        assert!(
+            matched
+                .iter()
+                .all(|i| i.labels.get("shard") == Some(&"7".to_owned()))
+        );
+    }
+
+    #[tokio::test]
+    async fn labelless_reregister_preserves_labels_through_api() {
+        let dir = Arc::new(GearManager::new());
+        let api = LocalDirectoryClient::new(Arc::clone(&dir));
+
+        let instance_id = Uuid::new_v4().to_string();
+        api.register_instance(
+            RegisterInstanceInfo::new("worker", instance_id.clone())
+                .with_rest_endpoint(ServiceEndpoint::new("http://worker:8080"))
+                .with_labels(labels(&[("shard", "7")])),
+        )
+        .await
+        .unwrap();
+
+        // A label-less re-registration (e.g. self-heal) must not wipe the shard.
+        api.register_instance(
+            RegisterInstanceInfo::new("worker", instance_id)
+                .with_rest_endpoint(ServiceEndpoint::new("http://worker:8080"))
+                .with_version("2.0.0"),
+        )
+        .await
+        .unwrap();
+
+        let listed = api.list_instances("worker").await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(
+            listed[0].labels.get("shard"),
+            Some(&"7".to_owned()),
+            "label-less re-registration must not wipe stored labels"
+        );
+
+        // And it is still selectable by the shard label.
+        let matched = api
+            .resolve_by_labels("worker", &LabelSelector::new().with("shard", "7"))
+            .await
+            .unwrap();
+        assert_eq!(matched.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn resolve_by_labels_carries_live_serving_state() {
+        let dir = Arc::new(GearManager::new());
+        let api = LocalDirectoryClient::new(Arc::clone(&dir));
+
+        let instance_id = Uuid::new_v4();
+        api.register_instance(
+            RegisterInstanceInfo::new("worker", instance_id.to_string())
+                .with_grpc_services(vec![(
+                    "worker.Svc".to_owned(),
+                    ServiceEndpoint::new("http://worker:7000"),
+                )])
+                .with_labels(labels(&[("shard", "7")])),
+        )
+        .await
+        .unwrap();
+
+        // A freshly-registered instance is not yet serving.
+        let matched = api
+            .resolve_by_labels("worker", &LabelSelector::new().with("shard", "7"))
+            .await
+            .unwrap();
+        assert_eq!(matched.len(), 1);
+        assert_eq!(matched[0].state, InstanceState::Registered);
+        assert!(!matched[0].state.is_serving());
+
+        // A heartbeat transitions it to Healthy; the state must be projected
+        // onto the resolve result so a caller can filter on it.
+        dir.update_heartbeat("worker", instance_id, std::time::Instant::now());
+        let matched = api
+            .resolve_by_labels("worker", &LabelSelector::new().with("shard", "7"))
+            .await
+            .unwrap();
+        assert_eq!(matched[0].state, InstanceState::Healthy);
+        assert!(matched[0].state.is_serving());
+    }
+
+    #[tokio::test]
+    async fn resolve_by_labels_omits_openapi_spec() {
+        let dir = Arc::new(GearManager::new());
+        let api = LocalDirectoryClient::new(Arc::clone(&dir));
+
+        api.register_instance(
+            RegisterInstanceInfo::new("worker", Uuid::new_v4().to_string())
+                .with_rest_endpoint(ServiceEndpoint::new("http://worker:8080"))
+                .with_openapi_spec("{\"openapi\":\"3.1.0\"}")
+                .with_labels(labels(&[("shard", "7")])),
+        )
+        .await
+        .unwrap();
+
+        // The in-process label path is spec-free, matching the gRPC client.
+        let matched = api
+            .resolve_by_labels("worker", &LabelSelector::new().with("shard", "7"))
+            .await
+            .unwrap();
+        assert_eq!(matched.len(), 1);
+        assert!(
+            matched[0].openapi_spec.is_none(),
+            "in-process resolve_by_labels must not attach the OpenAPI document"
+        );
+
+        // The plain enumeration path is spec-free too: only the hash rides
+        // along, the document is fetched via `get_openapi_spec`.
+        let listed = api.list_instances("worker").await.unwrap();
+        assert!(
+            listed[0].openapi_spec.is_none(),
+            "list_instances must not attach the OpenAPI document"
+        );
+        assert!(
+            listed[0].openapi_spec_hash.is_some(),
+            "list_instances must still carry the spec hash"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_all_instances_skips_endpoint_less() {
+        let dir = Arc::new(GearManager::new());
+        let api = LocalDirectoryClient::new(Arc::clone(&dir));
+
+        // One instance advertises a REST endpoint; the other advertises neither
+        // gRPC nor REST and must be skipped (no empty-URI sentinel).
+        api.register_instance(
+            RegisterInstanceInfo::new("worker", Uuid::new_v4().to_string())
+                .with_rest_endpoint(ServiceEndpoint::new("http://worker:8080")),
+        )
+        .await
+        .unwrap();
+        api.register_instance(RegisterInstanceInfo::new(
+            "placeholder",
+            Uuid::new_v4().to_string(),
+        ))
+        .await
+        .unwrap();
+
+        let all = api.list_all_instances().await.unwrap();
+        assert_eq!(all.len(), 1, "the endpoint-less instance is skipped");
+        assert_eq!(all[0].gear, "worker");
+        assert!(
+            all.iter()
+                .all(|i| i.endpoint.as_ref().is_some_and(|e| !e.uri.is_empty())),
+            "no instance may carry an absent or empty-URI endpoint"
+        );
+    }
+
+    #[tokio::test]
+    async fn label_path_returns_endpoint_less_match() {
+        let dir = Arc::new(GearManager::new());
+        let api = LocalDirectoryClient::new(Arc::clone(&dir));
+
+        // A matched instance that has not advertised any endpoint yet: treated
+        // as no-endpoint (not an error), so the label-targeting paths must still
+        // return the match (endpoint absent) rather than dropping it — the
+        // caller owns the fall-back decision.
+        api.register_instance(
+            RegisterInstanceInfo::new("worker", Uuid::new_v4().to_string())
+                .with_labels(labels(&[("shard", "7")])),
+        )
+        .await
+        .unwrap();
+
+        let matched = api
+            .resolve_by_labels("worker", &LabelSelector::new().with("shard", "7"))
+            .await
+            .unwrap();
+        assert_eq!(
+            matched.len(),
+            1,
+            "resolve_by_labels must return a matched instance even with no endpoint"
+        );
+        assert!(
+            matched[0].endpoint.is_none(),
+            "a no-endpoint match carries endpoint = None, not an empty-URI sentinel"
+        );
+        assert!(matched[0].rest_endpoint.is_none());
+        assert_eq!(matched[0].labels.get("shard"), Some(&"7".to_owned()));
+
+        // The base per-gear enumeration upholds the same contract.
+        let listed = api.list_instances("worker").await.unwrap();
+        assert_eq!(
+            listed.len(),
+            1,
+            "list_instances must not drop endpoint-less instances"
+        );
+        assert!(listed[0].endpoint.is_none());
     }
 }

--- a/libs/toolkit/src/runtime/gear_manager.rs
+++ b/libs/toolkit/src/runtime/gear_manager.rs
@@ -1,7 +1,7 @@
 //! Gear Manager - tracks and manages all live gear instances in the runtime
 
 use dashmap::DashMap;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
@@ -95,6 +95,9 @@ pub struct GearInstance {
     pub version: Option<String>,
     pub rest_endpoint: Option<Endpoint>,
     pub openapi_spec: Option<String>,
+    /// Stable addressing labels (k8s `matchLabels` style) advertised by this
+    /// instance, used for label-based instance selection.
+    pub labels: BTreeMap<String, String>,
     inner: Arc<parking_lot::RwLock<InstanceRuntimeState>>,
 }
 
@@ -108,6 +111,7 @@ impl Clone for GearInstance {
             version: self.version.clone(),
             rest_endpoint: self.rest_endpoint.clone(),
             openapi_spec: self.openapi_spec.clone(),
+            labels: self.labels.clone(),
             inner: Arc::clone(&self.inner),
         }
     }
@@ -127,6 +131,14 @@ impl GearInstance {
             version: other.version.clone(),
             rest_endpoint: other.rest_endpoint.clone(),
             openapi_spec: other.openapi_spec.clone(),
+            // Empty incoming labels mean "keep the stored set", not "clear"; a
+            // non-empty set replaces it. See `RegisterInstanceInfo::with_labels`
+            // for why (self-heal / REST-augmentation re-registers omit labels).
+            labels: if other.labels.is_empty() {
+                self.labels.clone()
+            } else {
+                other.labels.clone()
+            },
             inner: Arc::clone(&self.inner),
         }
     }
@@ -142,6 +154,7 @@ impl GearInstance {
             version: None,
             rest_endpoint: None,
             openapi_spec: None,
+            labels: BTreeMap::new(),
             inner: Arc::new(parking_lot::RwLock::new(InstanceRuntimeState {
                 last_heartbeat: Instant::now(),
                 state: InstanceState::Registered,
@@ -171,6 +184,11 @@ impl GearInstance {
 
     pub fn with_openapi_spec(mut self, spec: impl Into<String>) -> Self {
         self.openapi_spec = Some(spec.into());
+        self
+    }
+
+    pub fn with_labels(mut self, labels: BTreeMap<String, String>) -> Self {
+        self.labels = labels;
         self
     }
 
@@ -366,6 +384,28 @@ impl GearManager {
         }
     }
 
+    /// From a candidate set, return the serving subset (`Healthy`/`Ready`); if
+    /// none are serving, return the whole set so resolution falls back to the
+    /// not-ready instances (`Registered`/`Quarantined`/`Draining`) rather than
+    /// failing closed. `context` names the pool for the cold-path `debug!`.
+    fn prefer_serving(candidates: Vec<Arc<GearInstance>>, context: &str) -> Vec<Arc<GearInstance>> {
+        let serving: Vec<Arc<GearInstance>> = candidates
+            .iter()
+            .filter(|inst| matches!(inst.state(), InstanceState::Healthy | InstanceState::Ready))
+            .cloned()
+            .collect();
+        if serving.is_empty() {
+            tracing::debug!(
+                context,
+                "no serving (Ready/Healthy) instance available; round-robining over the \
+                 not-ready set instead of returning None"
+            );
+            candidates
+        } else {
+            serving
+        }
+    }
+
     /// Pick an instance using round-robin selection, preferring healthy instances
     #[must_use]
     pub fn pick_instance_round_robin(&self, gear: &str) -> Option<Arc<GearInstance>> {
@@ -376,22 +416,8 @@ impl GearManager {
             return None;
         }
 
-        // Prefer healthy or ready instances
-        let healthy: Vec<_> = instances
-            .iter()
-            .filter(|inst| matches!(inst.state(), InstanceState::Healthy | InstanceState::Ready))
-            .cloned()
-            .collect();
-
-        let candidates: Vec<_> = if healthy.is_empty() {
-            instances.clone()
-        } else {
-            healthy
-        };
-
-        if candidates.is_empty() {
-            return None;
-        }
+        // Non-empty in => non-empty out, so `candidates` is guaranteed non-empty.
+        let candidates = Self::prefer_serving(instances.clone(), gear);
 
         let len = candidates.len();
         let mut counter = self.rr_counters.entry(gear.to_owned()).or_insert(0);
@@ -408,23 +434,25 @@ impl GearManager {
         &self,
         service_name: &str,
     ) -> Option<(String, Arc<GearInstance>, Endpoint)> {
-        // Collect all instances that provide this service
-        let mut candidates = Vec::new();
+        // Collect the `Arc` of every instance that provides this service, then
+        // apply the shared serving-preference fallback so gRPC resolution
+        // survives an all-not-ready gear instead of failing closed. Cloning an
+        // `Arc` is a refcount bump; the gear name and endpoint are cloned once,
+        // for the winner, after the index is chosen.
+        let mut providing: Vec<Arc<GearInstance>> = Vec::new();
         for entry in &self.inner {
-            let gear = entry.key().clone();
             for inst in entry.value() {
-                if let Some(ep) = inst.grpc_services.get(service_name) {
-                    let state = inst.state();
-                    if matches!(state, InstanceState::Healthy | InstanceState::Ready) {
-                        candidates.push((gear.clone(), inst.clone(), ep.clone()));
-                    }
+                if inst.grpc_services.contains_key(service_name) {
+                    providing.push(inst.clone());
                 }
             }
         }
 
-        if candidates.is_empty() {
+        if providing.is_empty() {
             return None;
         }
+
+        let mut candidates = Self::prefer_serving(providing, service_name);
 
         // Use a counter keyed by service name for round-robin
         let len = candidates.len();
@@ -433,7 +461,10 @@ impl GearManager {
         let idx = *counter % len;
         *counter = (*counter + 1) % len;
 
-        candidates.get(idx).cloned()
+        let inst = candidates.swap_remove(idx);
+        let endpoint = inst.grpc_services.get(service_name)?.clone();
+        let gear = inst.gear.clone();
+        Some((gear, inst, endpoint))
     }
 
     /// Resolve a REST endpoint for a gear using round-robin over instances that
@@ -454,18 +485,7 @@ impl GearManager {
             return None;
         }
 
-        // Prefer healthy/ready instances, otherwise fall back to any with REST.
-        let healthy: Vec<_> = with_rest
-            .iter()
-            .filter(|inst| matches!(inst.state(), InstanceState::Healthy | InstanceState::Ready))
-            .cloned()
-            .collect();
-
-        let candidates = if healthy.is_empty() {
-            with_rest
-        } else {
-            healthy
-        };
+        let candidates = Self::prefer_serving(with_rest, gear);
 
         let len = candidates.len();
         let rr_key = format!("rest:{gear}");
@@ -520,6 +540,57 @@ mod tests {
         assert_eq!(instances[0].instance_id, instance_id);
         assert_eq!(instances[0].gear, "test_gear");
         assert_eq!(instances[0].version, Some("1.0.0".to_owned()));
+    }
+
+    fn labels(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn reregister_without_labels_preserves_stored_labels() {
+        let dir = GearManager::new();
+        let instance_id = Uuid::new_v4();
+
+        // Initial registration carries a shard label.
+        dir.register_instance(Arc::new(
+            GearInstance::new("shard-gear", instance_id).with_labels(labels(&[("shard", "7")])),
+        ));
+
+        // A label-less re-registration (e.g. periodic self-heal / REST
+        // augmentation) must NOT wipe the stored labels.
+        dir.register_instance(Arc::new(
+            GearInstance::new("shard-gear", instance_id).with_version("2.0.0"),
+        ));
+
+        let registered = dir.instances_of("shard-gear");
+        assert_eq!(registered.len(), 1);
+        assert_eq!(
+            registered[0].labels.get("shard"),
+            Some(&"7".to_owned()),
+            "label-less re-registration must preserve stored labels"
+        );
+        assert_eq!(registered[0].version, Some("2.0.0".to_owned()));
+    }
+
+    #[test]
+    fn reregister_with_labels_replaces_stored_labels() {
+        let dir = GearManager::new();
+        let instance_id = Uuid::new_v4();
+
+        dir.register_instance(Arc::new(
+            GearInstance::new("shard-gear", instance_id).with_labels(labels(&[("shard", "7")])),
+        ));
+        // An explicit non-empty set replaces the stored one wholesale.
+        dir.register_instance(Arc::new(
+            GearInstance::new("shard-gear", instance_id).with_labels(labels(&[("shard", "8")])),
+        ));
+
+        let registered = dir.instances_of("shard-gear");
+        assert_eq!(registered.len(), 1);
+        assert_eq!(registered[0].labels.get("shard"), Some(&"8".to_owned()));
     }
 
     #[test]
@@ -968,6 +1039,33 @@ mod tests {
         assert_ne!(inst1.instance_id, inst2.instance_id);
         // Endpoints should differ
         assert_ne!(ep1, ep2);
+    }
+
+    #[test]
+    fn pick_service_falls_back_to_not_ready() {
+        // A gear whose only service-providing instance is not yet serving
+        // (Registered, no heartbeat) must still resolve, mirroring the REST and
+        // instance pickers' not-ready fallback rather than failing closed.
+        let dir = GearManager::new();
+        let id = Uuid::new_v4();
+        dir.register_instance(Arc::new(
+            GearInstance::new("worker", id)
+                .with_grpc_service("worker.Svc", Endpoint::http("127.0.0.1", 9000)),
+        ));
+        // No heartbeat: the instance stays Registered (not serving).
+        assert!(matches!(
+            dir.instances_of("worker")[0].state(),
+            InstanceState::Registered
+        ));
+
+        let picked = dir.pick_service_round_robin("worker.Svc");
+        assert!(
+            picked.is_some(),
+            "gRPC service resolution must fall back to the not-ready instance"
+        );
+        let (gear, _, ep) = picked.unwrap();
+        assert_eq!(gear, "worker");
+        assert_eq!(ep, Endpoint::http("127.0.0.1", 9000));
     }
 
     #[test]

--- a/libs/toolkit/src/runtime/host_runtime.rs
+++ b/libs/toolkit/src/runtime/host_runtime.rs
@@ -1143,26 +1143,44 @@ impl HostRuntime {
             // The directory keys instances by (gear, instance_id) and replaces
             // wholesale. grpc-hub may have already registered this same
             // (gear, instance_id) with gRPC services during the start phase, so
-            // carry those forward instead of clobbering them to empty — adding
-            // the REST endpoint must augment, not replace, the entry.
+            // carry the grpc services and version forward instead of clobbering
+            // them to empty — adding the REST endpoint must augment, not
+            // replace, the entry.
+            //
+            // Labels are deliberately NOT read-and-rewritten here. Carrying them
+            // through would make this a cross-process read-modify-write with no
+            // compare-and-set: any label change committed between the read and
+            // the write would be silently reverted. Instead we register with an
+            // empty label set, which `GearInstance::with_metadata_of` treats as
+            // "preserve the stored labels" — an atomic no-op on labels.
             let (grpc_services, version) = match dir.list_instances(gear).await {
                 Ok(insts) => insts
                     .into_iter()
                     .find(|i| i.instance_id == instance_id)
                     .map(|i| (i.grpc_services, i.version))
                     .unwrap_or_default(),
-                Err(_) => (Vec::new(), None),
+                Err(e) => {
+                    // A failed directory read must not silently drop the
+                    // carried-forward metadata: log it, then fall back to an
+                    // empty augmentation so REST registration still proceeds.
+                    tracing::warn!(
+                        gear,
+                        error = %e,
+                        "directory-register: failed to read existing registration; \
+                         re-registering with empty grpc_services/version"
+                    );
+                    (Vec::new(), None)
+                }
             };
-            let info = crate::RegisterInstanceInfo {
-                gear: gear.to_owned(),
-                instance_id: instance_id.clone(),
-                grpc_services,
-                version,
-                rest_endpoint: Some(crate::ServiceEndpoint::new(endpoint.clone())),
-                // OpenAPI spec is published separately (grpc-hub start phase);
-                // the REST-augmentation registration does not carry it.
-                openapi_spec: None,
-            };
+            // OpenAPI spec is published separately (grpc-hub start phase); the
+            // REST-augmentation registration does not carry it. Labels are
+            // omitted so the store preserves the stored set (see above).
+            let mut info = crate::RegisterInstanceInfo::new(gear.to_owned(), instance_id.clone())
+                .with_grpc_services(grpc_services)
+                .with_rest_endpoint(crate::ServiceEndpoint::new(endpoint.clone()));
+            if let Some(version) = version {
+                info = info.with_version(version);
+            }
             match dir.register_instance(info).await {
                 Ok(()) => {
                     tracing::info!(gear, endpoint = %endpoint, "registered REST provider in directory");

--- a/libs/toolkit/src/runtime/host_runtime_oop_tests.rs
+++ b/libs/toolkit/src/runtime/host_runtime_oop_tests.rs
@@ -196,6 +196,7 @@ async fn e2e_oop_gear_boots_serves_registers_and_shuts_down() {
         directory: Arc::clone(&directory) as Arc<dyn DirectoryClient>,
         bearer_authenticator: None,
         internal_authenticator: None,
+        labels: std::collections::BTreeMap::new(),
     };
 
     // 2. Drive the full OoP serving lifecycle on a background task.

--- a/libs/toolkit/src/runtime/oop_registration.rs
+++ b/libs/toolkit/src/runtime/oop_registration.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 
 use tokio_util::sync::CancellationToken;
 
-use cf_system_sdks::directory::{DirectoryClient, RegisterInstanceInfo};
+use cf_system_sdks::directory::{DirectoryClient, DirectoryInvalidArgument, RegisterInstanceInfo};
 
 /// Initial retry backoff for registration and dependency polling.
 const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
@@ -46,8 +46,17 @@ async fn sleep_or_cancel(dur: Duration, cancel: &CancellationToken) -> bool {
     }
 }
 
-/// Register `info` with the directory, retrying with exponential backoff until
-/// success or cancellation. Returns `true` on success, `false` if cancelled.
+/// Register `info` with the directory, retrying with exponential backoff.
+///
+/// Returns `true` if the presence loop should keep running (the directory
+/// accepted the registration, or permanently rejected it), and `false` only if
+/// the task was cancelled.
+///
+/// A [`DirectoryInvalidArgument`] rejection (e.g. a mis-configured label or
+/// endpoint URI) is permanent: retrying it can never succeed, so the backoff
+/// retry stops with a loud `error!` rather than spinning forever at `warn!`.
+/// It still returns `true`, so the caller keeps the presence loop alive; see
+/// [`presence_loop`]. All other errors are treated as transient and retried.
 async fn register_once_with_backoff(
     directory: &Arc<dyn DirectoryClient>,
     info: &RegisterInstanceInfo,
@@ -64,6 +73,17 @@ async fn register_once_with_backoff(
                 return true;
             }
             Err(e) => {
+                if let Some(invalid) = e.downcast_ref::<DirectoryInvalidArgument>() {
+                    tracing::error!(
+                        gear = %info.gear,
+                        instance = %info.instance_id,
+                        error = %invalid,
+                        "registration permanently rejected by the directory (invalid \
+                         argument); this instance may not be discoverable. Check its \
+                         configured labels and endpoint URIs"
+                    );
+                    return true;
+                }
                 tracing::warn!(
                     gear = %info.gear,
                     error = %e,
@@ -96,6 +116,13 @@ async fn register_once_with_backoff(
 ///
 /// Registering *before* the first heartbeat is deliberate: a heartbeat for an
 /// unregistered instance is a no-op on the directory.
+///
+/// A permanent invalid-argument rejection never tears the presence loop down:
+/// the rejection is logged loudly at every attempt, but the loop keeps sending
+/// heartbeats (so an already-registered instance is not evicted by a transient
+/// directory-side validation change) and keeps retrying the idempotent
+/// re-registration (so it self-heals if the directory later accepts it). Only
+/// cancellation stops the loop.
 pub(super) async fn presence_loop(
     directory: Arc<dyn DirectoryClient>,
     info: RegisterInstanceInfo,

--- a/libs/toolkit/src/runtime/oop_registration_tests.rs
+++ b/libs/toolkit/src/runtime/oop_registration_tests.rs
@@ -4,15 +4,18 @@ use super::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
-use cf_system_sdks::directory::{ServiceEndpoint, ServiceInstanceInfo};
+use cf_system_sdks::directory::{DirectoryInvalidArgument, ServiceEndpoint, ServiceInstanceInfo};
 
 /// Stub directory: fails `register`/`resolve` a configurable number of times,
-/// then succeeds; records register calls and heartbeats.
+/// then succeeds; records register calls and heartbeats. When
+/// `reject_register` is set, `register` always returns a permanent
+/// [`DirectoryInvalidArgument`] rejection.
 struct StubDirectory {
     fail_register: AtomicUsize,
     register_calls: AtomicUsize,
     heartbeats: AtomicUsize,
     fail_resolve: AtomicUsize,
+    reject_register: bool,
 }
 
 impl StubDirectory {
@@ -22,6 +25,16 @@ impl StubDirectory {
             register_calls: AtomicUsize::new(0),
             heartbeats: AtomicUsize::new(0),
             fail_resolve: AtomicUsize::new(fail_resolve),
+            reject_register: false,
+        }
+    }
+
+    /// A directory that permanently rejects every registration (as the gRPC
+    /// front-end does for a mis-configured label / endpoint URI).
+    fn rejecting() -> Self {
+        Self {
+            reject_register: true,
+            ..Self::new(0, 0)
         }
     }
 }
@@ -54,6 +67,9 @@ impl DirectoryClient for StubDirectory {
 
     async fn register_instance(&self, _info: RegisterInstanceInfo) -> anyhow::Result<()> {
         self.register_calls.fetch_add(1, Ordering::SeqCst);
+        if self.reject_register {
+            return Err(DirectoryInvalidArgument::new("bad label").into());
+        }
         if self.fail_register.load(Ordering::SeqCst) > 0 {
             self.fail_register.fetch_sub(1, Ordering::SeqCst);
             anyhow::bail!("directory unavailable");
@@ -72,14 +88,10 @@ impl DirectoryClient for StubDirectory {
 }
 
 fn info() -> RegisterInstanceInfo {
-    RegisterInstanceInfo {
-        gear: "billing".to_owned(),
-        instance_id: "i-1".to_owned(),
-        grpc_services: vec![],
-        version: Some("1.0.0".to_owned()),
-        rest_endpoint: Some(ServiceEndpoint::new("http://billing:8080")),
-        openapi_spec: Some("{}".to_owned()),
-    }
+    RegisterInstanceInfo::new("billing", "i-1")
+        .with_version("1.0.0")
+        .with_rest_endpoint(ServiceEndpoint::new("http://billing:8080"))
+        .with_openapi_spec("{}")
 }
 
 #[test]
@@ -102,6 +114,23 @@ async fn registration_retries_until_success() {
     let cancel = CancellationToken::new();
     let ok = register_once_with_backoff(&directory, &info(), &cancel).await;
     assert!(ok);
+}
+
+#[tokio::test]
+async fn registration_keeps_loop_alive_on_permanent_rejection() {
+    // A DirectoryInvalidArgument is permanent: the backoff retry must give up
+    // after a single attempt rather than retrying a request that can never
+    // succeed, yet still return `true` so the presence loop keeps running.
+    let stub = Arc::new(StubDirectory::rejecting());
+    let directory: Arc<dyn DirectoryClient> = stub.clone();
+    let cancel = CancellationToken::new();
+    let ok = register_once_with_backoff(&directory, &info(), &cancel).await;
+    assert!(ok, "a permanent rejection must not stop the presence loop");
+    assert_eq!(
+        stub.register_calls.load(Ordering::SeqCst),
+        1,
+        "a permanent rejection must not be retried"
+    );
 }
 
 #[tokio::test]
@@ -138,6 +167,37 @@ async fn presence_loop_registers_once_then_heartbeats_until_cancel() {
     assert!(
         stub.heartbeats.load(Ordering::SeqCst) >= 1,
         "the single presence task must send heartbeats"
+    );
+
+    cancel.cancel();
+    task.await.unwrap();
+}
+
+#[tokio::test]
+async fn presence_loop_survives_permanent_rejection() {
+    // A permanent DirectoryInvalidArgument must NOT tear the presence loop down:
+    // it keeps heartbeating and periodically retrying re-registration. Only
+    // cancellation stops it.
+    let stub = Arc::new(StubDirectory::rejecting());
+    let directory: Arc<dyn DirectoryClient> = stub.clone();
+    let cancel = CancellationToken::new();
+
+    let task = tokio::spawn(presence_loop(
+        Arc::clone(&directory),
+        info(),
+        Duration::from_secs(1),
+        cancel.clone(),
+    ));
+
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    assert!(
+        !task.is_finished(),
+        "a permanent rejection must not stop the presence loop"
+    );
+    assert!(
+        stub.heartbeats.load(Ordering::SeqCst) >= 1,
+        "the loop must keep heartbeating despite a permanent rejection"
     );
 
     cancel.cancel();

--- a/libs/toolkit/src/runtime/oop_serve.rs
+++ b/libs/toolkit/src/runtime/oop_serve.rs
@@ -28,6 +28,7 @@
 //! gear routes. Self-registration and dependency resolution live in
 //! [`super::oop_registration`].
 
+use std::collections::BTreeMap;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -67,6 +68,13 @@ const STARTING_RETRY_AFTER_SECONDS: u64 = 1;
 
 /// Configuration and collaborators for the `OoP` HTTP runtime, assembled by the
 /// bootstrap layer and consumed by `HostRuntime`'s `OoP` serving path.
+///
+/// `#[non_exhaustive]` so new fields (like `labels`) stay additive: the type is
+/// built by the bootstrap layer, never struct-literal-constructed from another
+/// crate, so adding a field never breaks a downstream constructor. (A `Default`
+/// impl is intentionally not provided — the `directory` collaborator is a
+/// required dependency with no meaningful default.)
+#[non_exhaustive]
 pub struct OopServeOptions {
     /// Logical gear name (used for registration + `OpenAPI` title).
     pub gear_name: String,
@@ -102,6 +110,9 @@ pub struct OopServeOptions {
     /// Platform-plane authenticator; when `Some`, `internal_auth_middleware` is
     /// installed on gear routes (runs before the tenant plane).
     pub internal_authenticator: Option<DynInternalAuthenticator>,
+    /// Stable addressing labels (k8s `matchLabels` style) advertised with this
+    /// instance's directory registration for label-based selection.
+    pub labels: BTreeMap<String, String>,
 }
 
 impl std::fmt::Debug for OopServeOptions {
@@ -121,6 +132,7 @@ impl std::fmt::Debug for OopServeOptions {
                 "internal_authenticator",
                 &self.internal_authenticator.is_some(),
             )
+            .field("labels", &self.labels)
             .finish_non_exhaustive()
     }
 }
@@ -632,14 +644,16 @@ impl OopHttpServer {
         // Single directory-presence task: registration + heartbeat + self-heal.
         // Dependency resolution is handled by the proxy-wiring phase (typed
         // `#[toolkit::consumes]` clients), which runs before serving.
-        let registration_info = RegisterInstanceInfo {
-            gear: self.options.gear_name.clone(),
-            instance_id: self.options.instance_id.clone(),
-            grpc_services: vec![],
-            version: self.options.version.clone(),
-            rest_endpoint: Some(ServiceEndpoint::new(self.options.advertise_uri.clone())),
-            openapi_spec: Some(openapi_arc.to_string()),
-        };
+        let mut registration_info = RegisterInstanceInfo::new(
+            self.options.gear_name.clone(),
+            self.options.instance_id.clone(),
+        )
+        .with_rest_endpoint(ServiceEndpoint::new(self.options.advertise_uri.clone()))
+        .with_openapi_spec(openapi_arc.to_string())
+        .with_labels(self.options.labels.clone());
+        if let Some(version) = self.options.version.clone() {
+            registration_info = registration_info.with_version(version);
+        }
         self.registration_task = Some(tokio::spawn(super::oop_registration::presence_loop(
             Arc::clone(&self.options.directory),
             registration_info,

--- a/libs/toolkit/src/runtime/oop_serve_tests.rs
+++ b/libs/toolkit/src/runtime/oop_serve_tests.rs
@@ -269,9 +269,13 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 /// Stub directory that fails `resolve_rest_service` a fixed number of times
 /// before succeeding, so `/readyz` can be observed transitioning 503 → 200.
+/// Registrations are captured so a test can assert the serve path forwards the
+/// configured deployment labels.
+#[derive(Default)]
 struct E2eDirectory {
     fail_resolve: AtomicUsize,
     deregistered: AtomicUsize,
+    registrations: std::sync::Mutex<Vec<RegisterInstanceInfo>>,
 }
 
 #[async_trait]
@@ -295,7 +299,8 @@ impl DirectoryClient for E2eDirectory {
     async fn list_all_instances(&self) -> anyhow::Result<Vec<ServiceInstanceInfo>> {
         Ok(vec![])
     }
-    async fn register_instance(&self, _i: RegisterInstanceInfo) -> anyhow::Result<()> {
+    async fn register_instance(&self, i: RegisterInstanceInfo) -> anyhow::Result<()> {
+        self.registrations.lock().unwrap().push(i);
         Ok(())
     }
     async fn deregister_instance(&self, _g: &str, _i: &str) -> anyhow::Result<()> {
@@ -348,7 +353,7 @@ async fn e2e_startup_readiness_transition_and_graceful_shutdown() {
     let addr = free_addr();
     let directory: Arc<dyn DirectoryClient> = Arc::new(E2eDirectory {
         fail_resolve: AtomicUsize::new(3),
-        deregistered: AtomicUsize::new(0),
+        ..Default::default()
     });
 
     let readiness = readiness(["dep"]);
@@ -369,6 +374,7 @@ async fn e2e_startup_readiness_transition_and_graceful_shutdown() {
         directory: Arc::clone(&directory),
         bearer_authenticator: None,
         internal_authenticator: None,
+        labels: std::collections::BTreeMap::new(),
     };
 
     let mut server = super::OopHttpServer::start(Arc::clone(&readiness), options, cancel.clone())
@@ -428,6 +434,65 @@ async fn e2e_startup_readiness_transition_and_graceful_shutdown() {
 }
 
 #[tokio::test]
+async fn attach_forwards_configured_labels_to_directory_registration() {
+    let addr = free_addr();
+    let directory = Arc::new(E2eDirectory::default());
+    let readiness = readiness(Vec::<String>::new());
+    let cancel = CancellationToken::new();
+
+    let labels: std::collections::BTreeMap<String, String> =
+        [("shard".to_owned(), "7".to_owned())].into_iter().collect();
+
+    let options = OopServeOptions {
+        gear_name: "shard-gear".to_owned(),
+        instance_id: "i-1".to_owned(),
+        version: None,
+        advertise_uri: format!("http://{addr}"),
+        listen_addr: addr,
+        probe_bind_addr: None,
+        drain_timeout: Duration::from_secs(5),
+        heartbeat_interval: Duration::from_secs(30),
+        healthcheck_timeout: Duration::from_millis(500),
+        directory: Arc::clone(&directory) as Arc<dyn DirectoryClient>,
+        bearer_authenticator: None,
+        internal_authenticator: None,
+        labels: labels.clone(),
+    };
+
+    let mut server = super::OopHttpServer::start(readiness, options, cancel.clone())
+        .await
+        .expect("server should bind");
+
+    // `attach` spawns the presence loop, which registers immediately.
+    server.attach(
+        Router::new().route("/ping", get(|| async { "pong" })),
+        "{}".to_owned(),
+    );
+
+    // Poll until the registration is captured (registration is async).
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    let captured = loop {
+        if let Some(info) = directory.registrations.lock().unwrap().first().cloned() {
+            break Some(info);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            break None;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+
+    cancel.cancel();
+    let shutdown = tokio::time::timeout(Duration::from_secs(5), server.join()).await;
+    assert!(shutdown.is_ok(), "server should shut down promptly");
+
+    let captured = captured.expect("presence loop should register the instance");
+    assert_eq!(
+        captured.labels, labels,
+        "configured deployment labels must reach the directory registration"
+    );
+}
+
+#[tokio::test]
 async fn ephemeral_listen_port_updates_advertise_uri() {
     let readiness = readiness(Vec::<String>::new());
     let cancel = CancellationToken::new();
@@ -442,12 +507,10 @@ async fn ephemeral_listen_port_updates_advertise_uri() {
         drain_timeout: Duration::from_secs(5),
         heartbeat_interval: Duration::from_secs(30),
         healthcheck_timeout: Duration::from_millis(500),
-        directory: Arc::new(E2eDirectory {
-            fail_resolve: AtomicUsize::new(0),
-            deregistered: AtomicUsize::new(0),
-        }),
+        directory: Arc::new(E2eDirectory::default()),
         bearer_authenticator: None,
         internal_authenticator: None,
+        labels: std::collections::BTreeMap::new(),
     };
 
     let server = super::OopHttpServer::start(readiness, options, cancel.clone())
@@ -488,12 +551,10 @@ async fn user_advertise_uri_is_not_overwritten_by_ephemeral_bind_port() {
         drain_timeout: Duration::from_secs(5),
         heartbeat_interval: Duration::from_secs(30),
         healthcheck_timeout: Duration::from_millis(500),
-        directory: Arc::new(E2eDirectory {
-            fail_resolve: AtomicUsize::new(0),
-            deregistered: AtomicUsize::new(0),
-        }),
+        directory: Arc::new(E2eDirectory::default()),
         bearer_authenticator: None,
         internal_authenticator: None,
+        labels: std::collections::BTreeMap::new(),
     };
 
     let server = super::OopHttpServer::start(readiness, options, cancel.clone())
@@ -535,12 +596,10 @@ async fn gear_handler_receives_connect_info_through_fallback() {
         drain_timeout: Duration::from_secs(5),
         heartbeat_interval: Duration::from_secs(30),
         healthcheck_timeout: Duration::from_millis(500),
-        directory: Arc::new(E2eDirectory {
-            fail_resolve: AtomicUsize::new(0),
-            deregistered: AtomicUsize::new(0),
-        }),
+        directory: Arc::new(E2eDirectory::default()),
         bearer_authenticator: None,
         internal_authenticator: None,
+        labels: std::collections::BTreeMap::new(),
     };
 
     let mut server = super::OopHttpServer::start(readiness, options, cancel.clone())


### PR DESCRIPTION
Scoped portion of #4522: 

Gears advertise stable `matchLabels`-style labels at registration, and consumers resolve a *specific* subset of a gear's instances (a shard/peer) via `resolve_by_labels` instead of collapsing to one round-robin endpoint. Each resolved instance carries its **live serving state**, so callers apply their own health policy from a single resolve. Registration inputs are validated at the trust boundary with a shared ruleset.
 
## Features
 
- **Label selection:** `LabelSelector` (equality-AND) + `DirectoryClient::resolve_by_labels`; `labels` on register/instance info and proto.
- **Serving state:** `InstanceState` projected onto `ServiceInstanceInfo.state`, with `is_serving()`.
- **Shared validation** `directory::labels`: one ruleset (≤64 labels, ≤63-char k8s-style segments) enforced at the gRPC front-end, the store, and gear start-up.
- **Gear config:** `oop_http.labels` (config or `APP__OOP_HTTP__LABELS__<KEY>`, numeric/bool coerced to string) and `oop_http.allow_loopback_advertise`; start-up fails fast on bad labels or an unreachable `advertise_uri`.
- **Registration hardening:** `RegisterInstance` and the lookup RPCs validate labels, identity, endpoint URIs, and spec size as `InvalidArgument`, never reflecting caller bytes.
 
## Breaking changes
 
> Not on the REST surface, so the REST-only `oasdiff` gate won't flag these. All current gears pass - no live break.
 
1. `ServiceInstanceInfo.endpoint`: `ServiceEndpoint` -> `Option<ServiceEndpoint>` (drops the empty-URI sentinel).
2. `ServiceInstanceInfo` / `RegisterInstanceInfo` are now `#[non_exhaustive]` builders - use `::new(...).with_*(...)`.
3. `RegisterInstance` rejects previously-accepted malformed input with `InvalidArgument`.
4. register/deregister/heartbeat and lookup RPCs return `InvalidArgument` for malformed input instead of `Internal`/silent not-found.
 
## Example Usage
 
```yaml
oop_http:
  listen_addr: "0.0.0.0:8080"
  advertise_uri: "http://event-broker-ingest-0.event-broker:8080"
  labels: { shard: "7" }
```
 
```rust
use cf_system_sdks::directory::{DirectoryClient, LabelSelector};
 
// Resolve only shard 7 of event-broker, pick a serving instance.
let selector = LabelSelector::new().with("shard", "7");
let endpoint = directory
    .resolve_by_labels("event-broker", &selector)
    .await?
    .into_iter()
    .find(|i| i.state.is_serving())   // not health-filtered: caller decides
    .and_then(|i| i.endpoint)
    .ok_or_else(|| anyhow::anyhow!("no serving instance for shard 7"))?;
 
// Send the request to that specific instance).
let resp = reqwest::Client::new()
    .post(format!("{}/ingest/v1/events", endpoint.uri))
    .json(&event)
    .send()
    .await?;
```
 
## Follow-ups
 
- #4557 - Replaces polling with change-notification.
- #4555-  Serving-state-aware, cached instances-by-label view over resolve/watch.
- #4558 - Typed, sanctioned label-targeted client layer.
- #4556 - Label selectors beyond conjunctive equality (set-based / OR).
- #4554 -  Authorize instance registration against authenticated peer identity.
- #4575 - Reject `unix://` (UDS) endpoints; gRPC-over-UDS unsupported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added configurable, stable labels for service instances.
* Added label-based discovery and filtering with matching-label selectors.
* Instance listings now include labels and serving states, including unknown and not-ready states.
* Endpoint-less instances can be discovered and resolved when targeted.
* Service selection prefers serving instances and falls back to not-ready instances when needed.
* Added validation for labels, endpoints, and advertised URLs.
* Registration now stops retrying permanent validation failures.
* Improved metadata preservation during service re-registration.

## Documentation

* Updated architecture guidance for directory-based topology and service discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->