### PR TITLE
fix(toolkit-canonical-errors): emit Retry-After for service unavailable

### DIFF
--- a/libs/toolkit-canonical-errors/src/problem.rs
+++ b/libs/toolkit-canonical-errors/src/problem.rs
@@ -613,18 +613,38 @@ impl TryFrom<Problem> for CanonicalError {
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "axum")]
+fn service_unavailable_retry_after_seconds(problem: &Problem) -> Option<u64> {
+    if category_from_problem_type(&problem.problem_type) != Some("service_unavailable") {
+        return None;
+    }
+
+    ServiceUnavailable::deserialize(&problem.context)
+        .ok()?
+        .retry_after_seconds
+}
+
+#[cfg(feature = "axum")]
 impl axum::response::IntoResponse for Problem {
     fn into_response(self) -> axum::response::Response {
         match serde_json::to_vec(&self) {
             Ok(body) => {
                 let status = http::StatusCode::from_u16(self.status)
                     .unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR);
-                (
+                let retry_after_seconds = service_unavailable_retry_after_seconds(&self);
+                let mut response = (
                     status,
                     [(http::header::CONTENT_TYPE, APPLICATION_PROBLEM_JSON)],
                     body,
                 )
-                    .into_response()
+                    .into_response();
+
+                if let Some(seconds) = retry_after_seconds {
+                    response
+                        .headers_mut()
+                        .insert(http::header::RETRY_AFTER, http::HeaderValue::from(seconds));
+                }
+
+                response
             }
             Err(e) => {
                 tracing::error!(

--- a/libs/toolkit-canonical-errors/tests/axum_integration.rs
+++ b/libs/toolkit-canonical-errors/tests/axum_integration.rs
@@ -3,7 +3,7 @@
 use axum::response::IntoResponse;
 use toolkit_canonical_errors::problem::APPLICATION_PROBLEM_JSON;
 use toolkit_canonical_errors::resource_error;
-use toolkit_canonical_errors::{CanonicalError, Problem};
+use toolkit_canonical_errors::{CanonicalError, Http, Problem};
 
 #[resource_error(gts_id!("cf.core.test.axum.v1~"))]
 struct AxumTestR;
@@ -22,6 +22,103 @@ fn problem_into_response_sets_status_and_content_type() {
             .get(http::header::CONTENT_TYPE)
             .and_then(|v| v.to_str().ok()),
         Some(APPLICATION_PROBLEM_JSON)
+    );
+}
+
+#[test]
+fn problem_into_response_sets_retry_after_header() {
+    let problem = Problem::from(
+        CanonicalError::service_unavailable()
+            .with_retry_after_seconds(30)
+            .create(),
+    );
+
+    let response = problem.into_response();
+
+    assert_eq!(response.status(), http::StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        response.headers().get(http::header::RETRY_AFTER),
+        Some(&http::HeaderValue::from_static("30"))
+    );
+}
+
+#[test]
+fn canonical_error_into_response_sets_retry_after_header() {
+    let err = CanonicalError::service_unavailable()
+        .with_retry_after_seconds(30)
+        .create();
+
+    let response = err.into_response();
+
+    assert_eq!(
+        response.headers().get(http::header::RETRY_AFTER),
+        Some(&http::HeaderValue::from_static("30"))
+    );
+}
+
+#[test]
+fn service_unavailable_without_retry_hint_omits_retry_after_header() {
+    let response = CanonicalError::service_unavailable()
+        .create()
+        .into_response();
+
+    assert!(response.headers().get(http::header::RETRY_AFTER).is_none());
+}
+
+#[test]
+fn service_unavailable_zero_retry_hint_emits_zero_header() {
+    let response = CanonicalError::service_unavailable()
+        .with_retry_after_seconds(0)
+        .create()
+        .into_response();
+
+    assert_eq!(
+        response.headers().get(http::header::RETRY_AFTER),
+        Some(&http::HeaderValue::from_static("0"))
+    );
+}
+
+#[test]
+fn another_category_with_retry_field_omits_retry_after_header() {
+    let mut problem = Problem::from(
+        AxumTestR::not_found("missing")
+            .with_resource("abc")
+            .create(),
+    );
+    problem.context["retry_after_seconds"] = serde_json::json!(30);
+
+    let response = problem.into_response();
+
+    assert!(response.headers().get(http::header::RETRY_AFTER).is_none());
+}
+
+#[test]
+fn malformed_service_unavailable_context_omits_retry_after_header() {
+    let mut problem = Problem::from(
+        CanonicalError::service_unavailable()
+            .with_retry_after_seconds(30)
+            .create(),
+    );
+    problem.context = serde_json::json!({ "retry_after_seconds": "soon" });
+
+    let response = problem.into_response();
+
+    assert_eq!(response.status(), http::StatusCode::SERVICE_UNAVAILABLE);
+    assert!(response.headers().get(http::header::RETRY_AFTER).is_none());
+}
+
+#[test]
+fn service_unavailable_status_override_keeps_retry_after_header() {
+    let response = CanonicalError::service_unavailable()
+        .with_retry_after_seconds(30)
+        .with_override(Http::status_code(502))
+        .create()
+        .into_response();
+
+    assert_eq!(response.status(), http::StatusCode::BAD_GATEWAY);
+    assert_eq!(
+        response.headers().get(http::header::RETRY_AFTER),
+        Some(&http::HeaderValue::from_static("30"))
     );
 }
 


### PR DESCRIPTION
## Summary

- Emit the Retry-After header from the canonical service unavailable retry hint.
- Apply the header to Problem and CanonicalError Axum responses.
- Use the canonical error category instead of the effective HTTP status when selecting the header.
- Ignore absent, malformed, and unrelated context values.

## Tests

- cargo test -p cf-gears-toolkit-canonical-errors --all-features

Closes #4541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service-unavailable error responses now include a `Retry-After` header when a valid retry delay is provided.
  * The header remains available when the response’s HTTP status is customized.

* **Bug Fixes**
  * Retry guidance is omitted when the delay is missing or invalid, or when the error is not service-unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->