### PR TITLE
cleanup(mini-chat): remove Retry-After workaround

### DIFF
--- a/gears/mini-chat/mini-chat/src/api/rest/handlers/attachments.rs
+++ b/gears/mini-chat/mini-chat/src/api/rest/handlers/attachments.rs
@@ -253,11 +253,7 @@ pub(crate) async fn upload_attachment(
         let err = CanonicalError::service_unavailable()
             .with_retry_after_seconds(UPLOAD_RETRY_AFTER_SECS)
             .create();
-        let mut resp = Problem::from(err).into_response();
-        resp.headers_mut().insert(
-            http::header::RETRY_AFTER,
-            http::HeaderValue::from_static("5"),
-        );
+        let resp = Problem::from(err).into_response();
         return Ok(resp);
     };
 


### PR DESCRIPTION
## Summary

- Remove the manual Retry-After header insertion from the attachment upload response.
- Use the canonical Problem response projection from #4544.
- Preserve the response flow, retry value, metrics, and logging.

## Tests

- `cargo test -p cf-gears-mini-chat`
- `cargo test -p cf-gears-toolkit-canonical-errors --features axum --test axum_integration`
- `cargo fmt --all -- --check`

Follow-up to #4544.