### PR TITLE
docs(credstore): add crate and module Rustdoc

### DIFF
--- a/gears/credstore/credstore-sdk/README.md
+++ b/gears/credstore/credstore-sdk/README.md
@@ -1,10 +1,10 @@
-# CredStore SDK
+# `CredStore` SDK
 
-SDK crate for the CredStore gear, providing public API contracts for credential storage in Gears.
+SDK crate for the `CredStore` gear, providing public API contracts for credential storage in Gears.
 
 ## Overview
 
-This crate defines the transport-agnostic interface for the CredStore gear:
+This crate defines the transport-agnostic interface for the `CredStore` gear:
 
 - **`CredStoreClientV1`** — consumer-facing trait (`get`/`put`/`create`/`delete`);
   `get` returns the value plus metadata (`owner_tenant_id`, `sharing`,
@@ -18,23 +18,26 @@ This crate defines the transport-agnostic interface for the CredStore gear:
 
 ## Usage
 
-### Getting the client
+A `ToolKit` consumer normally obtains `CredStoreClientV1` from `ClientHub`. The SDK
+itself is transport-independent, so the example accepts the resolved client directly:
 
-```rust
-use credstore_sdk::CredStoreClientV1;
+```no_run
+use credstore_sdk::{CredStoreClientV1, CredStoreError, SecretRef};
+use toolkit_security::SecurityContext;
 
-let credstore = hub.get::<dyn CredStoreClientV1>()?;
-```
+async fn secret_length(
+    credstore: &dyn CredStoreClientV1,
+    security: &SecurityContext,
+) -> Result<Option<usize>, CredStoreError> {
+    let key = SecretRef::new("my-api-key")?;
+    let response = credstore.get(security, &key).await?;
 
-### Retrieving a secret
-
-```rust
-if let Some(resp) = credstore.get(&ctx, &SecretRef::new("my-api-key")?).await? {
-    let bytes = resp.value.as_bytes();
+    Ok(response.map(|secret| secret.value.as_bytes().len()))
 }
 ```
 
-Access denial is expressed as `Ok(None)`, not as an error — this prevents secret enumeration.
+A missing or out-of-scope secret is expressed as `Ok(None)`, preventing existence
+leaks. An explicit denial of the read action is returned as `CredStoreError::AccessDenied`.
 
 ## License
 

--- a/gears/credstore/credstore-sdk/src/api.rs
+++ b/gears/credstore/credstore-sdk/src/api.rs
@@ -1,3 +1,8 @@
+//! Consumer contract for tenant-scoped credential operations.
+//!
+//! Defines anti-enumerating reads and explicit optimistic-concurrency semantics
+//! for create, update, and delete operations.
+
 use async_trait::async_trait;
 use toolkit_security::SecurityContext;
 

--- a/gears/credstore/credstore-sdk/src/error.rs
+++ b/gears/credstore/credstore-sdk/src/error.rs
@@ -1,3 +1,5 @@
+//! Stable SDK error taxonomy shared by consumers and storage plugins.
+
 use std::time::Duration;
 
 use thiserror::Error;

--- a/gears/credstore/credstore-sdk/src/lib.rs
+++ b/gears/credstore/credstore-sdk/src/lib.rs
@@ -1,4 +1,4 @@
-//! credstore SDK — public API traits, models, errors, GTS schema, secret types.
+#![doc = include_str!("../README.md")]
 pub mod api;
 pub mod error;
 pub mod gts;

--- a/gears/credstore/credstore-sdk/src/models.rs
+++ b/gears/credstore/credstore-sdk/src/models.rs
@@ -1,5 +1,9 @@
 // Updated: 2026-04-07 by Constructor Tech
 // Updated: 2026-03-18 by Constructor Tech
+//! Public credential references, values, metadata, sharing, expiry, and write
+//! preconditions.
+//!
+//! Secret values redact formatting output and zeroize their bytes on drop.
 use std::fmt;
 
 use serde::de::Deserializer;

--- a/gears/credstore/credstore-sdk/src/plugin_api.rs
+++ b/gears/credstore/credstore-sdk/src/plugin_api.rs
@@ -1,3 +1,8 @@
+//! Backend storage-plugin contract.
+//!
+//! Plugins store opaque values by tenant, reference, and optional owner; the
+//! host gear retains hierarchy, sharing, metadata, and authorization policy.
+
 use async_trait::async_trait;
 use toolkit_security::SecurityContext;
 

--- a/gears/credstore/credstore/README.md
+++ b/gears/credstore/credstore/README.md
@@ -1,12 +1,12 @@
-# CredStore
+# `CredStore`
 
 Stateful credential-storage gear module. Owns per-secret metadata in its own
 database, enforces authorization in SQL, resolves secrets hierarchically across
 the tenant tree, and stores the secret **value** in a backend plugin discovered
 via the types registry.
 
-> Design: [`docs/DESIGN.md`](../docs/DESIGN.md) is the baseline; the shipped
-> implementation is described in [`docs/DESIGN-ADDENDUM.md`](../docs/DESIGN-ADDENDUM.md)
+> Design: the [technical design](https://github.com/constructorfabric/gears-rust/blob/main/gears/credstore/docs/DESIGN.md) is the baseline; the shipped
+> implementation is described in the [design addendum](https://github.com/constructorfabric/gears-rust/blob/main/gears/credstore/docs/DESIGN-ADDENDUM.md)
 > (stateful gear, `credstore_secrets` table, PDP-scope authz, versioning/ETag,
 > write saga).
 
@@ -14,10 +14,10 @@ via the types registry.
 
 The `cf-gears-credstore` module provides:
 
-- **Local metadata** — a gear-owned `credstore_secrets` table (SecureORM /
+- **Local metadata** — a gear-owned `credstore_secrets` table (`SecureORM` /
   sea-orm, migration `m0001`) holding sharing, owner, status, `version`, and
   the value-fingerprint fence
-- **PDP authorization** — `AccessScope` enforced in SQL via SecureORM clamps;
+- **PDP authorization** — `AccessScope` enforced in SQL via `SecureORM` clamps;
   out-of-scope access is fail-closed (canonical 404, anti-enumeration)
 - **Hierarchical resolution** — a single indexed query over the ancestor chain
   (TTL+LRU cached, barriers ignored — `shared` inherits through them); the backend is read once for the winner's value
@@ -30,7 +30,7 @@ The `cf-gears-credstore` module provides:
   last-writer-wins; no ABA across recreation)
 - **Crash-safe writes** — provisioning→backend→active saga with rollback and a reaper
 - **Backend plugin** — value-only store discovered via the types registry (vendor)
-- **ClientHub + REST** — registers `CredStoreClientV1`; exposes `/credstore/v1/secrets`
+- **`ClientHub` + REST** — registers `CredStoreClientV1`; exposes `/credstore/v1/secrets`
 
 This module depends on `types-registry`, `tenant-resolver`, and `authz-resolver`,
 and **requires a database**. The secret value is stored in a plugin (e.g.
@@ -38,15 +38,25 @@ and **requires a database**. The secret value is stored in a plugin (e.g.
 
 ## Usage
 
-Consumers obtain the client from `ClientHub`:
+After the gear initializes, consumers obtain its client from `ClientHub`. This
+example retrieves a secret without formatting or logging its value:
 
-```rust
-use credstore_sdk::CredStoreClientV1;
+```no_run
+use std::error::Error;
 
-let credstore = ctx.client_hub().get::<dyn CredStoreClientV1>()?;
+use credstore_sdk::{CredStoreClientV1, SecretRef};
+use toolkit::ClientHub;
+use toolkit_security::SecurityContext;
 
-if let Some(resp) = credstore.get(&ctx, &SecretRef::new("my-api-key")?).await? {
-    // resp.value, resp.sharing, resp.is_inherited
+async fn secret_length(
+    hub: &ClientHub,
+    security: &SecurityContext,
+) -> Result<Option<usize>, Box<dyn Error>> {
+    let credstore = hub.get::<dyn CredStoreClientV1>()?;
+    let key = SecretRef::new("my-api-key")?;
+    let response = credstore.get(security, &key).await?;
+
+    Ok(response.map(|secret| secret.value.as_bytes().len()))
 }
 ```
 
@@ -60,7 +70,7 @@ credstore:
     server: "sqlite_users"   # a database server template; module gets its own file
     file: "credstore.db"
   config:
-    vendor: "virtuozzo"      # GTS vendor used to discover the value-store plugin
+    vendor: "constructorfabric" # GTS vendor used to discover the value-store plugin
     hierarchy:
       ancestor_cache_ttl_secs: 300
     reaper:

--- a/gears/credstore/credstore/README.md
+++ b/gears/credstore/credstore/README.md
@@ -5,8 +5,8 @@ database, enforces authorization in SQL, resolves secrets hierarchically across
 the tenant tree, and stores the secret **value** in a backend plugin discovered
 via the types registry.
 
-> Design: the [technical design](https://github.com/constructorfabric/gears-rust/blob/main/gears/credstore/docs/DESIGN.md) is the baseline; the shipped
-> implementation is described in the [design addendum](https://github.com/constructorfabric/gears-rust/blob/main/gears/credstore/docs/DESIGN-ADDENDUM.md)
+> Design: [`docs/DESIGN.md`](../docs/DESIGN.md) is the baseline; the shipped
+> implementation is described in [`docs/DESIGN-ADDENDUM.md`](../docs/DESIGN-ADDENDUM.md)
 > (stateful gear, `credstore_secrets` table, PDP-scope authz, versioning/ETag,
 > write saga).
 

--- a/gears/credstore/credstore/README.md
+++ b/gears/credstore/credstore/README.md
@@ -5,8 +5,8 @@ database, enforces authorization in SQL, resolves secrets hierarchically across
 the tenant tree, and stores the secret **value** in a backend plugin discovered
 via the types registry.
 
-> Design: [`docs/DESIGN.md`](../docs/DESIGN.md) is the baseline; the shipped
-> implementation is described in [`docs/DESIGN-ADDENDUM.md`](../docs/DESIGN-ADDENDUM.md)
+> Design: the [technical design](https://github.com/constructorfabric/gears-rust/blob/main/gears/credstore/docs/DESIGN.md) is the baseline; the shipped
+> implementation is described in the [design addendum](https://github.com/constructorfabric/gears-rust/blob/main/gears/credstore/docs/DESIGN-ADDENDUM.md)
 > (stateful gear, `credstore_secrets` table, PDP-scope authz, versioning/ETag,
 > write saga).
 

--- a/gears/credstore/credstore/src/client.rs
+++ b/gears/credstore/credstore/src/client.rs
@@ -1,3 +1,9 @@
+//! In-process SDK adapter for the credential store.
+//!
+//! [`CredStoreLocalClient`] maps the public SDK contract onto the domain
+//! [`Service`] and translates domain
+//! failures into stable SDK errors.
+
 use std::sync::Arc;
 
 use async_trait::async_trait;

--- a/gears/credstore/credstore/src/config.rs
+++ b/gears/credstore/credstore/src/config.rs
@@ -1,3 +1,8 @@
+//! Validated credential-store configuration.
+//!
+//! Controls backend plugin selection, hierarchy-cache lifetime, and recovery
+//! cadences for provisioning and deprovisioning sagas.
+
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]

--- a/gears/credstore/credstore/src/domain.rs
+++ b/gears/credstore/credstore/src/domain.rs
@@ -1,3 +1,8 @@
+//! Credential-store domain model and service boundaries.
+//!
+//! Contains authorization policy, errors, ports, hierarchical resolution, and
+//! the secret lifecycle service independently of HTTP and database adapters.
+
 pub mod authz;
 pub mod error;
 pub mod ports;

--- a/gears/credstore/credstore/src/domain/authz.rs
+++ b/gears/credstore/credstore/src/domain/authz.rs
@@ -1,3 +1,9 @@
+//! Authorization policy-enforcement helpers for typed secrets.
+//!
+//! Builds the concrete GTS resource type for each secret and converts PDP
+//! decisions into tenant-scoped [`AccessScope`]
+//! values or fail-closed domain errors.
+
 use authz_resolver_sdk::pep::{AccessRequest, EnforcerError, PolicyEnforcer, ResourceType};
 use toolkit_security::{AccessScope, SecurityContext, pep_properties};
 

--- a/gears/credstore/credstore/src/domain/error.rs
+++ b/gears/credstore/credstore/src/domain/error.rs
@@ -1,3 +1,8 @@
+//! Internal credential-store error taxonomy.
+//!
+//! Domain failures retain operational causes while boundary adapters project
+//! only curated SDK and canonical HTTP errors.
+
 use std::time::Duration;
 
 use thiserror::Error;

--- a/gears/credstore/credstore/src/domain/ports.rs
+++ b/gears/credstore/credstore/src/domain/ports.rs
@@ -1,2 +1,7 @@
+//! Outbound ports used by the credential-store domain.
+//!
+//! Infrastructure adapters implement backend plugin selection and metrics
+//! recording without coupling domain services to concrete providers.
+
 pub mod metrics;
 pub mod plugin;

--- a/gears/credstore/credstore/src/domain/ports/metrics.rs
+++ b/gears/credstore/credstore/src/domain/ports/metrics.rs
@@ -1,3 +1,8 @@
+//! Metrics vocabulary and recording port for credential-store operations.
+//!
+//! Defines bounded labels for outcomes, dependencies, lifecycle counts, and
+//! value-fingerprint verification.
+
 use toolkit_macros::domain_model;
 
 #[domain_model]

--- a/gears/credstore/credstore/src/domain/ports/plugin.rs
+++ b/gears/credstore/credstore/src/domain/ports/plugin.rs
@@ -1,3 +1,8 @@
+//! Storage-plugin selection boundary.
+//!
+//! The domain resolves a value-store implementation lazily without depending
+//! on types-registry or `ClientHub` details.
+
 use std::sync::Arc;
 
 use async_trait::async_trait;

--- a/gears/credstore/credstore/src/domain/resolver.rs
+++ b/gears/credstore/credstore/src/domain/resolver.rs
@@ -1,3 +1,5 @@
+//! Tenant hierarchy resolution boundary used by inherited-secret lookup.
+
 use async_trait::async_trait;
 use credstore_sdk::TenantId;
 use toolkit_security::SecurityContext;

--- a/gears/credstore/credstore/src/domain/secret.rs
+++ b/gears/credstore/credstore/src/domain/secret.rs
@@ -1,3 +1,8 @@
+//! Secret lifecycle domain.
+//!
+//! Defines metadata models, persistence and type-resolution ports, hierarchical
+//! lookup, crash-safe writes, expiry, and the value-fingerprint fence.
+
 pub mod fence;
 pub mod model;
 pub mod repo;

--- a/gears/credstore/credstore/src/domain/secret/model.rs
+++ b/gears/credstore/credstore/src/domain/secret/model.rs
@@ -1,3 +1,8 @@
+//! Domain models for secret metadata and write concurrency.
+//!
+//! Models lifecycle status, sharing, expiry, optimistic preconditions, and the
+//! metadata persisted separately from secret values.
+
 use credstore_sdk::{OwnerId, SecretRef, SharingMode, TenantId, WriteOptions};
 use time::OffsetDateTime;
 use toolkit_macros::domain_model;

--- a/gears/credstore/credstore/src/domain/secret/repo.rs
+++ b/gears/credstore/credstore/src/domain/secret/repo.rs
@@ -1,3 +1,8 @@
+//! Persistence port for secret metadata and lifecycle transitions.
+//!
+//! Repository operations accept explicit authorization scopes and preserve the
+//! provisioning, activation, optimistic update, and deprovisioning invariants.
+
 use async_trait::async_trait;
 use credstore_sdk::{OwnerId, SecretRef, SharingMode, TenantId};
 use time::OffsetDateTime;
@@ -90,7 +95,7 @@ pub trait SecretRepo: Send + Sync {
 
     /// Find the row a write of `sharing` would target, by sharing-class identity
     /// (mirrors the partial unique indexes): `Private` → `(tenant, ref, owner)`,
-    /// `Tenant`/`Shared` → `(tenant, ref)` among non-private. Unlike [`find_own`]
+    /// `Tenant`/`Shared` → `(tenant, ref)` among non-private. Unlike [`Self::find_own`]
     /// this never crosses the private boundary, so a private write does not see a
     /// coexisting tenant/shared secret (and vice-versa) — they coexist per design.
     async fn find_for_write(

--- a/gears/credstore/credstore/src/domain/secret/service.rs
+++ b/gears/credstore/credstore/src/domain/secret/service.rs
@@ -1,3 +1,9 @@
+//! Credential-store domain service.
+//!
+//! Orchestrates authorization, typed-secret validation, hierarchy resolution,
+//! value-store calls, fingerprint verification, crash-safe write sagas, and
+//! recovery sweeps.
+
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 

--- a/gears/credstore/credstore/src/gear.rs
+++ b/gears/credstore/credstore/src/gear.rs
@@ -1,3 +1,8 @@
+//! `ToolKit` gear declaration, dependency wiring, and managed lifecycle.
+//!
+//! Initialization builds the domain service, registers its SDK client and REST
+//! routes, and the stateful lifecycle runs recovery and fence-backfill sweeps.
+
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 

--- a/gears/credstore/credstore/src/infra/plugin_select.rs
+++ b/gears/credstore/credstore/src/infra/plugin_select.rs
@@ -1,3 +1,9 @@
+//! Types-registry-backed selection of the active value-store plugin.
+//!
+//! Resolves the configured vendor lazily and retrieves its scoped
+//! [`CredStorePluginClientV1`] from
+//! `ClientHub`.
+
 use std::sync::Arc;
 
 use async_trait::async_trait;

--- a/gears/credstore/credstore/src/lib.rs
+++ b/gears/credstore/credstore/src/lib.rs
@@ -1,4 +1,4 @@
-//! credstore — `CredStore` module: tenant-scoped secrets over pluggable backends.
+#![doc = include_str!("../README.md")]
 pub mod api;
 pub mod client;
 pub mod config;

--- a/gears/credstore/plugins/static-credstore-plugin/README.md
+++ b/gears/credstore/plugins/static-credstore-plugin/README.md
@@ -1,6 +1,6 @@
-# Static CredStore Plugin
+# Static `CredStore` Plugin
 
-CredStore **value-store** backend for development and testing: an in-memory
+`CredStore` **value-store** backend for development and testing: an in-memory
 per-tenant secret store, optionally seeded from YAML configuration. Implements
 the `CredStorePluginClientV1` contract (`get`/`put`/`delete`) so the stateful
 `credstore` gear can use it as a backend without a full secrets vault.
@@ -11,7 +11,7 @@ The `cf-gears-static-credstore-plugin` module provides:
 
 - **Per-tenant value store** — `get`/`put`/`delete` keyed by `tenant_id` + `key`
   + optional `owner_id` (`Some` = private key class, `None` = tenant key class).
-  No sharing/hierarchy/policy here — that lives in the gear.
+    No sharing/hierarchy/policy here — that lives in the gear.
 - **Writable at runtime** — the gear's write saga (`put`/`delete`) mutates the
   in-memory store, so it works as a development backend, not just a read fixture.
 - **Config seeding** — secrets defined in YAML are loaded and validated at init.
@@ -28,9 +28,20 @@ The `cf-gears-static-credstore-plugin` module provides:
 
 The plugin registers itself via the types registry as a `CredStorePluginClientV1` implementation and is discovered by the `credstore` gear module.
 
+## Rust usage
+
+`ToolKit` normally discovers and instantiates the plugin through inventory. Direct
+construction is useful for host wiring tests:
+
+```rust
+use static_credstore_plugin::StaticCredStorePlugin;
+
+let plugin = StaticCredStorePlugin::default();
+```
+
 ## Configuration
 
-Add the plugin section under your module configuration:
+Add the plugin section under your gear configuration:
 
 ```yaml
 static-credstore-plugin:
@@ -112,12 +123,12 @@ resolving; they are never written by `put`. The plugin returns the raw
 ## Architecture
 
 ```text
-module.rs          ModKit module — init, config loading, GTS registration
-config.rs          YAML config model + resolve_sharing() + validation docs
+gear.rs            ToolKit gear — initialization and GTS/ClientHub registration
+config.rs          YAML config model, sharing inference, and validation
 domain/
-  service.rs       Service — from_config() seeder + get_value/put_value/delete_value (RwLock store)
-  client.rs        CredStorePluginClientV1 impl (get/put/delete -> SecretValue)
-  mod.rs           Re-exports
+  service.rs       In-memory key classes and runtime get/put/delete operations
+  client.rs        CredStorePluginClientV1 adapter
+  mod.rs           Domain exports
 ```
 
 ### Init sequence

--- a/gears/credstore/plugins/static-credstore-plugin/src/config.rs
+++ b/gears/credstore/plugins/static-credstore-plugin/src/config.rs
@@ -1,4 +1,8 @@
 // Updated: 2026-04-07 by Constructor Tech
+//! Configuration and validation inputs for the static credential backend.
+//!
+//! Secrets may be seeded as private, tenant, shared, or global values; secret
+//! contents remain redacted from debug output.
 use serde::Deserialize;
 use uuid::Uuid;
 

--- a/gears/credstore/plugins/static-credstore-plugin/src/domain/client.rs
+++ b/gears/credstore/plugins/static-credstore-plugin/src/domain/client.rs
@@ -1,4 +1,8 @@
 // Updated: 2026-06-06 — implements the per-tenant value-store `CredStorePluginClientV1`.
+//! SDK adapter for the static value store.
+//!
+//! Requests are already authorized and resolved by the host gear, so this
+//! adapter keys values only by tenant, reference, and optional owner.
 use async_trait::async_trait;
 use credstore_sdk::{
     CredStoreError, CredStorePluginClientV1, OwnerId, SecretRef, SecretValue, TenantId,

--- a/gears/credstore/plugins/static-credstore-plugin/src/domain/mod.rs
+++ b/gears/credstore/plugins/static-credstore-plugin/src/domain/mod.rs
@@ -1,3 +1,5 @@
+//! In-memory value-store implementation and SDK adapter.
+
 mod client;
 pub mod service;
 

--- a/gears/credstore/plugins/static-credstore-plugin/src/domain/service.rs
+++ b/gears/credstore/plugins/static-credstore-plugin/src/domain/service.rs
@@ -1,4 +1,8 @@
 // Updated: 2026-06-06 — adapted to the per-tenant value-store `CredStorePluginClientV1`.
+//! Thread-safe in-memory secret-value store.
+//!
+//! Configuration seeds private, tenant, shared, and global key classes; runtime
+//! writes mutate only private and tenant classes.
 use std::collections::HashMap;
 use std::sync::RwLock;
 

--- a/gears/credstore/plugins/static-credstore-plugin/src/gear.rs
+++ b/gears/credstore/plugins/static-credstore-plugin/src/gear.rs
@@ -1,3 +1,8 @@
+//! `ToolKit` gear registration for the static credential backend.
+//!
+//! Loads and validates configuration, registers its GTS plugin instance, and
+//! publishes a scoped `CredStorePluginClientV1` through `ClientHub`.
+
 use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;

--- a/gears/credstore/plugins/static-credstore-plugin/src/lib.rs
+++ b/gears/credstore/plugins/static-credstore-plugin/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 pub mod config;


### PR DESCRIPTION
## Description

Adds a useful Rustdoc surface for the Credstore gear, SDK, and static backend plugin. Each crate now uses its README as the crate landing page, includes a compilable usage example, and documents its module boundaries, configuration, security behavior, lifecycle, and plugin responsibilities.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] `cargo doc --no-deps --all-features -p cf-gears-credstore -p cf-gears-credstore-sdk -p cf-gears-static-credstore-plugin`
- [x] `cargo test --doc --all-features -p cf-gears-credstore -p cf-gears-credstore-sdk -p cf-gears-static-credstore-plugin` — 3 passed
- [x] `cargo clippy --all-targets --all-features -p cf-gears-credstore -p cf-gears-credstore-sdk -p cf-gears-static-credstore-plugin -- -D warnings -D clippy::perf`
- [x] `rustfmt --edition 2024 --check` on changed Rust sources
- [x] `git diff --check`
- [ ] Unit tests pass — no runtime behavior changed
- [ ] Integration tests pass — no runtime behavior changed

`cargo doc` completes successfully without warnings for all three crates.

## Documentation

- [x] Added README-backed crate landing pages for the gear, SDK, and static plugin
- [x] Added compilable Rustdoc examples for `ClientHub`, the SDK contract, and plugin construction
- [x] Documented the configuration, client, domain, authorization, ports, secret lifecycle, infrastructure, gear lifecycle, and plugin module boundaries
- [x] Corrected stale configuration, repository links, and static-plugin architecture text
- [x] Kept public modules visible in generated Rustdoc

## Checklist

- [x] Self-review completed
- [x] Rebased onto current `upstream/main`
- [x] No runtime behavior or dependency changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reworked credential-store documentation with clearer SDK usage examples and guidance for retrieving secrets safely.
  * Clarified behavior for missing, out-of-scope, and explicitly denied secret reads.
  * Documented credential lifecycle, authorization, hierarchy resolution, concurrency, recovery, metrics, and plugin responsibilities.
  * Updated backend configuration, architecture, branding, and integration guidance.
  * Improved crate and module documentation consistency across the credential-store components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->