### PR TITLE
refactor(users-info): show UsersInfoStream usage

### DIFF
--- a/examples/toolkit/users-info/users-info-sdk/src/lib.rs
+++ b/examples/toolkit/users-info/users-info-sdk/src/lib.rs
@@ -62,7 +62,8 @@ pub mod odata;
 // Re-export main types at crate root for convenience
 #[cfg(feature = "odata")]
 pub use client::{
-    AddressesStreamingClientV1, CitiesStreamingClientV1, UsersInfoClientV1, UsersStreamingClientV1,
+    AddressesStreamingClientV1, CitiesStreamingClientV1, UsersInfoClientV1, UsersInfoStream,
+    UsersStreamingClientV1,
 };
 pub use gts::{ADDRESS_RESOURCE_TYPE, CITY_RESOURCE_TYPE, USER_RESOURCE_TYPE};
 pub use models::{

--- a/examples/toolkit/users-info/users-info/src/api/rest/handlers/addresses.rs
+++ b/examples/toolkit/users-info/users-info/src/api/rest/handlers/addresses.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use axum::Extension;
 use axum::extract::Path;
 use axum::response::IntoResponse;
@@ -20,7 +22,7 @@ use crate::gear::ConcreteAppServices;
 )]
 pub async fn get_user_address(
     Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Extension(svc): Extension<Arc<ConcreteAppServices>>,
     Path(user_id): Path<Uuid>,
 ) -> ApiResult<JsonBody<AddressDto>> {
     info!(
@@ -48,7 +50,7 @@ pub async fn get_user_address(
 )]
 pub async fn put_user_address(
     Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Extension(svc): Extension<Arc<ConcreteAppServices>>,
     Path(user_id): Path<Uuid>,
     Json(req_body): Json<PutAddressReq>,
 ) -> ApiResult<impl IntoResponse> {
@@ -78,7 +80,7 @@ pub async fn put_user_address(
 )]
 pub async fn delete_user_address(
     Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Extension(svc): Extension<Arc<ConcreteAppServices>>,
     Path(user_id): Path<Uuid>,
 ) -> ApiResult<impl IntoResponse> {
     info!(

--- a/examples/toolkit/users-info/users-info/src/api/rest/handlers/cities.rs
+++ b/examples/toolkit/users-info/users-info/src/api/rest/handlers/cities.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use axum::Extension;
 use axum::extract::Path;
 use axum::http::Uri;
@@ -24,7 +26,7 @@ use crate::gear::ConcreteAppServices;
 )]
 pub async fn list_cities(
     Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Extension(svc): Extension<Arc<ConcreteAppServices>>,
     OData(query): OData,
 ) -> ApiResult<JsonPage<serde_json::Value>> {
     info!(
@@ -49,7 +51,7 @@ pub async fn list_cities(
 )]
 pub async fn get_city(
     Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Extension(svc): Extension<Arc<ConcreteAppServices>>,
     Path(id): Path<Uuid>,
     OData(query): OData,
 ) -> ApiResult<JsonBody<serde_json::Value>> {
@@ -81,7 +83,7 @@ pub async fn get_city(
 pub async fn create_city(
     uri: Uri,
     Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Extension(svc): Extension<Arc<ConcreteAppServices>>,
     Json(req_body): Json<CreateCityReq>,
 ) -> ApiResult<impl IntoResponse> {
     info!(
@@ -109,7 +111,7 @@ pub async fn create_city(
 )]
 pub async fn update_city(
     Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Extension(svc): Extension<Arc<ConcreteAppServices>>,
     Path(id): Path<Uuid>,
     Json(req_body): Json<UpdateCityReq>,
 ) -> ApiResult<JsonBody<CityDto>> {
@@ -135,7 +137,7 @@ pub async fn update_city(
 )]
 pub async fn delete_city(
     Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Extension(svc): Extension<Arc<ConcreteAppServices>>,
     Path(id): Path<Uuid>,
 ) -> ApiResult<impl IntoResponse> {
     info!(

--- a/examples/toolkit/users-info/users-info/src/api/rest/handlers/users.rs
+++ b/examples/toolkit/users-info/users-info/src/api/rest/handlers/users.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use axum::Extension;
 use axum::extract::Path;
 use axum::http::Uri;
@@ -25,7 +27,7 @@ use crate::gear::ConcreteAppServices;
 )]
 pub async fn list_users(
     Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Extension(svc): Extension<Arc<ConcreteAppServices>>,
     OData(query): OData,
 ) -> ApiResult<JsonPage<serde_json::Value>> {
     info!(
@@ -50,7 +52,7 @@ pub async fn list_users(
 )]
 pub async fn get_user(
     Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Extension(svc): Extension<Arc<ConcreteAppServices>>,
     Path(id): Path<Uuid>,
     OData(query): OData,
 ) -> ApiResult<JsonBody<serde_json::Value>> {
@@ -80,7 +82,7 @@ pub async fn get_user(
 pub async fn create_user(
     uri: Uri,
     Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Extension(svc): Extension<Arc<ConcreteAppServices>>,
     Json(req_body): Json<CreateUserReq>,
 ) -> ApiResult<impl IntoResponse> {
     info!(
@@ -91,19 +93,7 @@ pub async fn create_user(
         "Creating new user"
     );
 
-    let CreateUserReq {
-        id,
-        tenant_id,
-        email,
-        display_name,
-    } = req_body;
-
-    let new_user = users_info_sdk::NewUser {
-        id,
-        tenant_id,
-        email,
-        display_name,
-    };
+    let new_user = req_body.into();
 
     let user = svc.users.create_user(&ctx, new_user).await?;
     let id_str = user.id.to_string();
@@ -121,7 +111,7 @@ pub async fn create_user(
 )]
 pub async fn update_user(
     Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Extension(svc): Extension<Arc<ConcreteAppServices>>,
     Path(id): Path<Uuid>,
     Json(req_body): Json<UpdateUserReq>,
 ) -> ApiResult<JsonBody<UserDto>> {
@@ -147,7 +137,7 @@ pub async fn update_user(
 )]
 pub async fn delete_user(
     Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Extension(svc): Extension<Arc<ConcreteAppServices>>,
     Path(id): Path<Uuid>,
 ) -> ApiResult<impl IntoResponse> {
     info!(

--- a/examples/toolkit/users-info/users-info/src/domain/local_client/addresses.rs
+++ b/examples/toolkit/users-info/users-info/src/domain/local_client/addresses.rs
@@ -1,12 +1,11 @@
-use std::pin::Pin;
 use std::sync::Arc;
 
-use futures_util::{Stream, StreamExt};
+use futures_util::StreamExt;
 use toolkit_macros::domain_model;
-use toolkit_sdk::odata::{QueryBuilder, items_stream_boxed};
+use toolkit_sdk::odata::{QueryBuilder, items_stream};
 use toolkit_security::SecurityContext;
 use users_info_sdk::odata::AddressSchema;
-use users_info_sdk::{Address, AddressesStreamingClientV1, UsersInfoError};
+use users_info_sdk::{Address, AddressesStreamingClientV1, UsersInfoError, UsersInfoStream};
 
 use crate::gear::ConcreteAppServices;
 
@@ -27,26 +26,19 @@ impl AddressesStreamingClientV1 for LocalAddressesStreamingClient {
         &self,
         ctx: SecurityContext,
         query: QueryBuilder<AddressSchema>,
-    ) -> Pin<Box<dyn Stream<Item = Result<Address, UsersInfoError>> + Send + 'static>> {
+    ) -> UsersInfoStream<Address> {
         let services = Arc::clone(&self.services);
-        let stream = items_stream_boxed(
-            query,
-            Box::new(move |q| {
-                let services = Arc::clone(&services);
-                let ctx = ctx.clone();
-                Box::pin(async move {
-                    services
-                        .addresses
-                        .list_addresses_page(&ctx, &q)
-                        .await
-                        .map_err(UsersInfoError::from)
-                })
-            }),
-        );
-        Box::pin(stream.map(|res| {
-            res.map_err(|err| {
-                UsersInfoError::internal(format!("streaming failure: {err}")).create()
-            })
-        }))
+        let stream = items_stream(query, move |q| {
+            let services = Arc::clone(&services);
+            let ctx = ctx.clone();
+            async move {
+                services
+                    .addresses
+                    .list_addresses_page(&ctx, &q)
+                    .await
+                    .map_err(UsersInfoError::from)
+            }
+        });
+        Box::pin(stream.map(|res| res.map_err(super::pager_to_users_info)))
     }
 }

--- a/examples/toolkit/users-info/users-info/src/domain/local_client/cities.rs
+++ b/examples/toolkit/users-info/users-info/src/domain/local_client/cities.rs
@@ -1,12 +1,11 @@
-use std::pin::Pin;
 use std::sync::Arc;
 
-use futures_util::{Stream, StreamExt};
+use futures_util::StreamExt;
 use toolkit_macros::domain_model;
-use toolkit_sdk::odata::{QueryBuilder, items_stream_boxed};
+use toolkit_sdk::odata::{QueryBuilder, items_stream};
 use toolkit_security::SecurityContext;
 use users_info_sdk::odata::CitySchema;
-use users_info_sdk::{CitiesStreamingClientV1, City, UsersInfoError};
+use users_info_sdk::{CitiesStreamingClientV1, City, UsersInfoError, UsersInfoStream};
 
 use crate::gear::ConcreteAppServices;
 
@@ -27,26 +26,19 @@ impl CitiesStreamingClientV1 for LocalCitiesStreamingClient {
         &self,
         ctx: SecurityContext,
         query: QueryBuilder<CitySchema>,
-    ) -> Pin<Box<dyn Stream<Item = Result<City, UsersInfoError>> + Send + 'static>> {
+    ) -> UsersInfoStream<City> {
         let services = Arc::clone(&self.services);
-        let stream = items_stream_boxed(
-            query,
-            Box::new(move |q| {
-                let services = Arc::clone(&services);
-                let ctx = ctx.clone();
-                Box::pin(async move {
-                    services
-                        .cities
-                        .list_cities_page(&ctx, &q)
-                        .await
-                        .map_err(UsersInfoError::from)
-                })
-            }),
-        );
-        Box::pin(stream.map(|res| {
-            res.map_err(|err| {
-                UsersInfoError::internal(format!("streaming failure: {err}")).create()
-            })
-        }))
+        let stream = items_stream(query, move |q| {
+            let services = Arc::clone(&services);
+            let ctx = ctx.clone();
+            async move {
+                services
+                    .cities
+                    .list_cities_page(&ctx, &q)
+                    .await
+                    .map_err(UsersInfoError::from)
+            }
+        });
+        Box::pin(stream.map(|res| res.map_err(super::pager_to_users_info)))
     }
 }

--- a/examples/toolkit/users-info/users-info/src/domain/local_client/mod.rs
+++ b/examples/toolkit/users-info/users-info/src/domain/local_client/mod.rs
@@ -2,8 +2,26 @@
 //!
 //! This gear houses the object-safe streaming facades that wrap the
 //! domain service. Type erasure happens here, at the SDK boundary.
+//!
+//! Streaming pattern (copy per resource client):
+//! 1. `items_stream` turns a page fetch into an item stream (`PagerError`).
+//! 2. Map `PagerError` to `UsersInfoError` (`pager_to_users_info`).
+//! 3. `Box::pin` to `UsersInfoStream` for `ClientHub` / `dyn` traits.
 
 pub mod addresses;
 pub mod cities;
 pub mod client;
 pub mod users;
+
+use toolkit_sdk::PagerError;
+use users_info_sdk::UsersInfoError;
+
+/// `items_stream` yields `PagerError<E>`; the SDK stream is `Result<T, UsersInfoError>`.
+fn pager_to_users_info(err: PagerError<UsersInfoError>) -> UsersInfoError {
+    match err {
+        PagerError::Fetch(e) => e,
+        PagerError::InvalidCursor(c) => {
+            UsersInfoError::internal(format!("invalid cursor: {c}")).create()
+        }
+    }
+}

--- a/examples/toolkit/users-info/users-info/src/domain/local_client/users.rs
+++ b/examples/toolkit/users-info/users-info/src/domain/local_client/users.rs
@@ -1,12 +1,11 @@
-use std::pin::Pin;
 use std::sync::Arc;
 
-use futures_util::{Stream, StreamExt};
+use futures_util::StreamExt;
 use toolkit_macros::domain_model;
-use toolkit_sdk::odata::{QueryBuilder, items_stream_boxed};
+use toolkit_sdk::odata::{QueryBuilder, items_stream};
 use toolkit_security::SecurityContext;
 use users_info_sdk::odata::UserSchema;
-use users_info_sdk::{User, UsersInfoError, UsersStreamingClientV1};
+use users_info_sdk::{User, UsersInfoError, UsersInfoStream, UsersStreamingClientV1};
 
 use crate::gear::ConcreteAppServices;
 
@@ -27,26 +26,19 @@ impl UsersStreamingClientV1 for LocalUsersStreamingClient {
         &self,
         ctx: SecurityContext,
         query: QueryBuilder<UserSchema>,
-    ) -> Pin<Box<dyn Stream<Item = Result<User, UsersInfoError>> + Send + 'static>> {
+    ) -> UsersInfoStream<User> {
         let services = Arc::clone(&self.services);
-        let stream = items_stream_boxed(
-            query,
-            Box::new(move |q| {
-                let services = Arc::clone(&services);
-                let ctx = ctx.clone();
-                Box::pin(async move {
-                    services
-                        .users
-                        .list_users_page(&ctx, &q)
-                        .await
-                        .map_err(UsersInfoError::from)
-                })
-            }),
-        );
-        Box::pin(stream.map(|res| {
-            res.map_err(|err| {
-                UsersInfoError::internal(format!("streaming failure: {err}")).create()
-            })
-        }))
+        let stream = items_stream(query, move |q| {
+            let services = Arc::clone(&services);
+            let ctx = ctx.clone();
+            async move {
+                services
+                    .users
+                    .list_users_page(&ctx, &q)
+                    .await
+                    .map_err(UsersInfoError::from)
+            }
+        });
+        Box::pin(stream.map(|res| res.map_err(super::pager_to_users_info)))
     }
 }


### PR DESCRIPTION
## Description
Make the `users-info` local streaming clients a copy-paste example of the object-safe SDK boundary: return `UsersInfoStream<T>`, use `items_stream`, map `PagerError`, then `Box::pin` for `ClientHub`.

Also re-export `UsersInfoStream` from `users-info-sdk`, and small handler nits (`Arc` import, `create_user` via `Into`).

Behavior change: `PagerError::Fetch(e)` now keeps the original `UsersInfoError` instead of wrapping it as `internal("streaming failure: …")`. Invalid cursors still map to `internal`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactor (example gear; additive SDK re-export)

## Testing
- [x] Unit tests pass (`cargo test -p users-info --lib` — 41 passed, earlier run)
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] New tests added for new functionality

`cargo check -p users-info -p users-info-sdk` passed.

## Documentation
- [x] Code is documented with rustdoc comments
- [ ] README updated (if applicable)
- [ ] API documentation updated (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] No linting errors (`cargo clippy`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] Tests pass (`cargo test`)
- [x] Commits are DCO signed (`git commit -s`)

## Related Issues
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Made the user information streaming interface available directly through the SDK.
  - Standardized streaming access for users, cities, and addresses.

- **Bug Fixes**
  - Improved handling of streaming and pagination errors, including invalid cursors.
  - Preserved consistent error reporting across streaming operations.

- **Improvements**
  - Simplified user creation request processing without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->