### PR TITLE
ci: skip fuzzing and code-ranker for docs-only changes

### DIFF
--- a/.github/workflows/clusterfuzzlite.yml
+++ b/.github/workflows/clusterfuzzlite.yml
@@ -3,9 +3,19 @@ name: ClusterFuzzLite PR Fuzzing
 on:
   pull_request:
     branches: [ main, develop ]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.cargo/**'
+      - '.clusterfuzzlite/**'
+      - 'tools/fuzz/**'
+      - '!**/tests/**'
+      - '!testing/**'
+      - '!**/*.md'
+      - '!docs/**'
+      - '!guidelines/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/code-ranker.yml
+++ b/.github/workflows/code-ranker.yml
@@ -1,7 +1,29 @@
 name: code-ranker
 on:
   pull_request:
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.cargo/**'
+      - '!**/tests/**'
+      - '!testing/**'
+      - '!**/*.md'
+      - '!docs/**'
+      - '!guidelines/**'
   push:
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.cargo/**'
+      - '!**/tests/**'
+      - '!testing/**'
+      - '!**/*.md'
+      - '!docs/**'
+      - '!guidelines/**'
 jobs:
   code-ranker:
     uses: code-ranker-com/actions/.github/workflows/report.yml@v1

--- a/.github/workflows/code-ranker.yml
+++ b/.github/workflows/code-ranker.yml
@@ -3,21 +3,11 @@ on:
   pull_request:
     paths:
       - '**/*.rs'
-      - '**/Cargo.toml'
-      - 'Cargo.lock'
-      - 'rust-toolchain.toml'
-      - '.cargo/**'
-      - '!**/tests/**'
-      - '!testing/**'
+      - '**/*.md'
   push:
     paths:
       - '**/*.rs'
-      - '**/Cargo.toml'
-      - 'Cargo.lock'
-      - 'rust-toolchain.toml'
-      - '.cargo/**'
-      - '!**/tests/**'
-      - '!testing/**'
+      - '**/*.md'
 jobs:
   code-ranker:
     uses: code-ranker-com/actions/.github/workflows/report.yml@v1

--- a/.github/workflows/code-ranker.yml
+++ b/.github/workflows/code-ranker.yml
@@ -9,9 +9,6 @@ on:
       - '.cargo/**'
       - '!**/tests/**'
       - '!testing/**'
-      - '!**/*.md'
-      - '!docs/**'
-      - '!guidelines/**'
   push:
     paths:
       - '**/*.rs'
@@ -21,9 +18,6 @@ on:
       - '.cargo/**'
       - '!**/tests/**'
       - '!testing/**'
-      - '!**/*.md'
-      - '!docs/**'
-      - '!guidelines/**'
 jobs:
   code-ranker:
     uses: code-ranker-com/actions/.github/workflows/report.yml@v1


### PR DESCRIPTION
Restrict ClusterFuzzLite and code-ranker workflows to Rust source, Cargo metadata, toolchain, and CI/fuzzing infrastructure changes.

This avoids running code-focused CI for Markdown, docs, guidelines, and tests-only changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow triggers to run only when relevant Rust, Cargo, toolchain, fuzzing, or configuration files change.
  * Excluded documentation, Markdown, guidelines, and test-only changes from selected workflow runs.
  * Applied consistent path filtering to pull request and push events.
  * Reduced unnecessary automated checks for unrelated changes, improving development workflow efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->