### PR TITLE
test: cover the OData value mappers and SecureInsertMany added by the SeaORM 2.0 port

### DIFF
--- a/gears/bss/ledger/ledger/src/infra/storage/odata_mapping_tests.rs
+++ b/gears/bss/ledger/ledger/src/infra/storage/odata_mapping_tests.rs
@@ -13,15 +13,27 @@
     clippy::inconsistent_struct_constructor
 )]
 
+use chrono::{DateTime, NaiveDate};
 use sea_orm::IdenStatic;
+use serde_json::Value as JsonValue;
 use uuid::Uuid;
 
-use crate::infra::storage::entity::{account_balance, journal_line, tenant_account};
-use crate::odata::{AccountInfoFilterField, BalanceFilterField, JournalLineFilterField};
+use crate::infra::storage::entity::{
+    account_balance, credit_note, debit_note, dispute, exception_queue, journal_entry,
+    journal_line, recognition_run, refund, tenant_account,
+};
+use crate::odata::{
+    AccountInfoFilterField, BalanceFilterField, CreditNoteFilterField, DebitNoteFilterField,
+    DisputeFilterField, ExceptionFilterField, JournalEntryFilterField, JournalLineFilterField,
+    RecognitionRunFilterField, RefundFilterField,
+};
 
 use super::{
-    AccountInfoODataMapper, BalanceColumn, BalanceODataMapper, JournalLineColumn,
-    JournalLineODataMapper, TenantAccountColumn,
+    AccountInfoODataMapper, BalanceColumn, BalanceODataMapper, CreditNoteColumn,
+    CreditNoteODataMapper, DebitNoteColumn, DebitNoteODataMapper, DisputeColumn,
+    DisputeODataMapper, ExceptionColumn, ExceptionODataMapper, JournalEntryColumn,
+    JournalEntryODataMapper, JournalLineColumn, JournalLineODataMapper, RecognitionRunColumn,
+    RecognitionRunODataMapper, RefundColumn, RefundODataMapper, TenantAccountColumn,
 };
 use toolkit_db::odata::sea_orm_filter::{FieldToColumn, ODataFieldMapping};
 
@@ -341,4 +353,677 @@ fn balance_cursor_currency_is_string() {
     let model = sample_account_balance();
     let val = BalanceODataMapper::extract_cursor_value(&model, BalanceFilterField::Currency);
     assert_eq!(val, sea_orm::Value::String(Some("GBP".to_owned())),);
+}
+
+// ===========================================================================
+// Fixtures for the mappers below.
+//
+// Each `sample_*` builds a full `Model` literal so a test can read one field
+// without a DB — `map_field` and `extract_cursor_value` are both pure.
+// Nullable columns are populated here and cleared in the dedicated NULL-arm
+// tests, mirroring the `tenant_account` / `journal_line` pattern above.
+// ===========================================================================
+
+fn sample_journal_entry() -> journal_entry::Model {
+    journal_entry::Model {
+        entry_id: Uuid::from_u128(0x0C),
+        tenant_id: Uuid::from_u128(0x1C),
+        legal_entity_id: Uuid::from_u128(0x2C),
+        period_id: "2025-03".to_owned(),
+        entry_currency: "EUR".to_owned(),
+        source_doc_type: "INVOICE_POST".to_owned(),
+        source_business_id: "INV-2025-0007".to_owned(),
+        reverses_entry_id: None,
+        reverses_period_id: None,
+        posted_at_utc: DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+        effective_at: NaiveDate::from_ymd_opt(2025, 3, 31).unwrap(),
+        origin: "posting".to_owned(),
+        posted_by_actor_id: Uuid::from_u128(0x3C),
+        correlation_id: Uuid::from_u128(0x4C),
+        rounding_evidence: JsonValue::Null,
+        created_seq: 42,
+        row_hash: None,
+        prev_hash: None,
+        prev_entry_id: None,
+        prev_period_id: None,
+    }
+}
+
+fn sample_refund() -> refund::Model {
+    refund::Model {
+        tenant_id: Uuid::from_u128(0x1D),
+        refund_id: "RFND-001".to_owned(),
+        psp_refund_id: "PSP-RFND-001".to_owned(),
+        phase: "settled".to_owned(),
+        pattern: "B".to_owned(),
+        payment_id: "PAY-001".to_owned(),
+        invoice_id: Some("INV-001".to_owned()),
+        currency: "USD".to_owned(),
+        amount_minor: 2_500,
+        clearing_state: "cleared".to_owned(),
+        relates_to_refund_id: None,
+        reverses_entry_id: None,
+        created_at_utc: DateTime::from_timestamp(1_700_000_001, 0).unwrap(),
+        version: 1,
+    }
+}
+
+fn sample_credit_note() -> credit_note::Model {
+    credit_note::Model {
+        tenant_id: Uuid::from_u128(0x1E),
+        credit_note_id: "CN-001".to_owned(),
+        origin_invoice_id: "INV-002".to_owned(),
+        origin_invoice_item_ref: None,
+        revenue_stream: "SAAS".to_owned(),
+        currency: "USD".to_owned(),
+        amount_minor: 1_000,
+        recognized_part_minor: 600,
+        deferred_part_minor: 400,
+        split_basis_ref: None,
+        reason_code: "SERVICE_CREDIT".to_owned(),
+        created_at_utc: DateTime::from_timestamp(1_700_000_002, 0).unwrap(),
+    }
+}
+
+fn sample_debit_note() -> debit_note::Model {
+    debit_note::Model {
+        tenant_id: Uuid::from_u128(0x1F),
+        debit_note_id: "DN-001".to_owned(),
+        origin_invoice_id: "INV-003".to_owned(),
+        currency: "USD".to_owned(),
+        amount_minor: 750,
+        recognized_part_minor: 750,
+        deferred_part_minor: 0,
+        created_at_utc: DateTime::from_timestamp(1_700_000_003, 0).unwrap(),
+    }
+}
+
+fn sample_dispute() -> dispute::Model {
+    dispute::Model {
+        tenant_id: Uuid::from_u128(0x2D),
+        dispute_id: "DSP-001".to_owned(),
+        payment_id: "PAY-002".to_owned(),
+        currency: "USD".to_owned(),
+        variant: "chargeback".to_owned(),
+        last_phase: "representment".to_owned(),
+        cycle: 2,
+        disputed_amount_minor: 5_000,
+        cash_hold_minor: 5_000,
+        version: 3,
+    }
+}
+
+fn sample_recognition_run() -> recognition_run::Model {
+    recognition_run::Model {
+        tenant_id: Uuid::from_u128(0x2E),
+        period_id: "2025-04".to_owned(),
+        run_id: Uuid::from_u128(0x0E),
+        started_at_utc: DateTime::from_timestamp(1_700_000_004, 0).unwrap(),
+        status: "completed".to_owned(),
+    }
+}
+
+fn sample_exception() -> exception_queue::Model {
+    exception_queue::Model {
+        tenant_id: Uuid::from_u128(0x2F),
+        exception_id: Uuid::from_u128(0x0F),
+        exception_type: "UNAPPLIED_CASH".to_owned(),
+        business_ref: "PAY-003".to_owned(),
+        status: "open".to_owned(),
+        period_id: Some("2025-05".to_owned()),
+        detail: None,
+        opened_at: DateTime::from_timestamp(1_700_000_005, 0).unwrap(),
+        resolved_at: None,
+        resolved_by: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JournalEntryODataMapper — map_field (column name lock)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn journal_entry_map_entry_id() {
+    assert_eq!(
+        JournalEntryODataMapper::map_field(JournalEntryFilterField::EntryId).as_str(),
+        JournalEntryColumn::EntryId.as_str()
+    );
+}
+
+#[test]
+fn journal_entry_map_source_doc_type() {
+    assert_eq!(
+        JournalEntryODataMapper::map_field(JournalEntryFilterField::SourceDocType).as_str(),
+        JournalEntryColumn::SourceDocType.as_str()
+    );
+}
+
+#[test]
+fn journal_entry_map_source_business_id() {
+    assert_eq!(
+        JournalEntryODataMapper::map_field(JournalEntryFilterField::SourceBusinessId).as_str(),
+        JournalEntryColumn::SourceBusinessId.as_str()
+    );
+}
+
+#[test]
+fn journal_entry_map_period_id() {
+    assert_eq!(
+        JournalEntryODataMapper::map_field(JournalEntryFilterField::PeriodId).as_str(),
+        JournalEntryColumn::PeriodId.as_str()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// JournalEntryODataMapper — extract_cursor_value
+// ---------------------------------------------------------------------------
+
+#[test]
+fn journal_entry_cursor_entry_id_is_uuid() {
+    let model = sample_journal_entry();
+    let val =
+        JournalEntryODataMapper::extract_cursor_value(&model, JournalEntryFilterField::EntryId);
+    assert_eq!(val, sea_orm::Value::Uuid(Some(Uuid::from_u128(0x0C))));
+}
+
+#[test]
+fn journal_entry_cursor_source_doc_type_is_string() {
+    let model = sample_journal_entry();
+    let val = JournalEntryODataMapper::extract_cursor_value(
+        &model,
+        JournalEntryFilterField::SourceDocType,
+    );
+    assert_eq!(val, sea_orm::Value::String(Some("INVOICE_POST".to_owned())));
+}
+
+#[test]
+fn journal_entry_cursor_source_business_id_is_string() {
+    let model = sample_journal_entry();
+    let val = JournalEntryODataMapper::extract_cursor_value(
+        &model,
+        JournalEntryFilterField::SourceBusinessId,
+    );
+    assert_eq!(
+        val,
+        sea_orm::Value::String(Some("INV-2025-0007".to_owned()))
+    );
+}
+
+#[test]
+fn journal_entry_cursor_period_id_is_string() {
+    let model = sample_journal_entry();
+    let val =
+        JournalEntryODataMapper::extract_cursor_value(&model, JournalEntryFilterField::PeriodId);
+    assert_eq!(val, sea_orm::Value::String(Some("2025-03".to_owned())));
+}
+
+// ---------------------------------------------------------------------------
+// RefundODataMapper — map_field (column name lock)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn refund_map_refund_id() {
+    assert_eq!(
+        RefundODataMapper::map_field(RefundFilterField::RefundId).as_str(),
+        RefundColumn::RefundId.as_str()
+    );
+}
+
+#[test]
+fn refund_map_payment_id() {
+    assert_eq!(
+        RefundODataMapper::map_field(RefundFilterField::PaymentId).as_str(),
+        RefundColumn::PaymentId.as_str()
+    );
+}
+
+#[test]
+fn refund_map_psp_refund_id() {
+    assert_eq!(
+        RefundODataMapper::map_field(RefundFilterField::PspRefundId).as_str(),
+        RefundColumn::PspRefundId.as_str()
+    );
+}
+
+#[test]
+fn refund_map_phase() {
+    assert_eq!(
+        RefundODataMapper::map_field(RefundFilterField::Phase).as_str(),
+        RefundColumn::Phase.as_str()
+    );
+}
+
+#[test]
+fn refund_map_pattern() {
+    assert_eq!(
+        RefundODataMapper::map_field(RefundFilterField::Pattern).as_str(),
+        RefundColumn::Pattern.as_str()
+    );
+}
+
+#[test]
+fn refund_map_clearing_state() {
+    assert_eq!(
+        RefundODataMapper::map_field(RefundFilterField::ClearingState).as_str(),
+        RefundColumn::ClearingState.as_str()
+    );
+}
+
+#[test]
+fn refund_map_invoice_id() {
+    assert_eq!(
+        RefundODataMapper::map_field(RefundFilterField::InvoiceId).as_str(),
+        RefundColumn::InvoiceId.as_str()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// RefundODataMapper — extract_cursor_value
+// ---------------------------------------------------------------------------
+
+#[test]
+fn refund_cursor_refund_id_is_string() {
+    let model = sample_refund();
+    let val = RefundODataMapper::extract_cursor_value(&model, RefundFilterField::RefundId);
+    assert_eq!(val, sea_orm::Value::String(Some("RFND-001".to_owned())));
+}
+
+#[test]
+fn refund_cursor_payment_id_is_string() {
+    let model = sample_refund();
+    let val = RefundODataMapper::extract_cursor_value(&model, RefundFilterField::PaymentId);
+    assert_eq!(val, sea_orm::Value::String(Some("PAY-001".to_owned())));
+}
+
+#[test]
+fn refund_cursor_psp_refund_id_is_string() {
+    let model = sample_refund();
+    let val = RefundODataMapper::extract_cursor_value(&model, RefundFilterField::PspRefundId);
+    assert_eq!(val, sea_orm::Value::String(Some("PSP-RFND-001".to_owned())));
+}
+
+#[test]
+fn refund_cursor_phase_is_string() {
+    let model = sample_refund();
+    let val = RefundODataMapper::extract_cursor_value(&model, RefundFilterField::Phase);
+    assert_eq!(val, sea_orm::Value::String(Some("settled".to_owned())));
+}
+
+#[test]
+fn refund_cursor_pattern_is_string() {
+    let model = sample_refund();
+    let val = RefundODataMapper::extract_cursor_value(&model, RefundFilterField::Pattern);
+    assert_eq!(val, sea_orm::Value::String(Some("B".to_owned())));
+}
+
+#[test]
+fn refund_cursor_clearing_state_is_string() {
+    let model = sample_refund();
+    let val = RefundODataMapper::extract_cursor_value(&model, RefundFilterField::ClearingState);
+    assert_eq!(val, sea_orm::Value::String(Some("cleared".to_owned())));
+}
+
+#[test]
+fn refund_cursor_invoice_id_some() {
+    let model = sample_refund();
+    let val = RefundODataMapper::extract_cursor_value(&model, RefundFilterField::InvoiceId);
+    assert_eq!(val, sea_orm::Value::String(Some("INV-001".to_owned())));
+}
+
+/// The nullable-column arm: a `None` must become a *typed* NULL, not be skipped
+/// or panic — the keyset predicate relies on the `Value` variant to stay
+/// `String` so the comparison keeps its type.
+#[test]
+fn refund_cursor_invoice_id_none_is_null_string() {
+    let mut model = sample_refund();
+    model.invoice_id = None;
+    let val = RefundODataMapper::extract_cursor_value(&model, RefundFilterField::InvoiceId);
+    assert_eq!(val, sea_orm::Value::String(None));
+}
+
+// ---------------------------------------------------------------------------
+// CreditNoteODataMapper — map_field (column name lock)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn credit_note_map_credit_note_id() {
+    assert_eq!(
+        CreditNoteODataMapper::map_field(CreditNoteFilterField::CreditNoteId).as_str(),
+        CreditNoteColumn::CreditNoteId.as_str()
+    );
+}
+
+#[test]
+fn credit_note_map_origin_invoice_id() {
+    assert_eq!(
+        CreditNoteODataMapper::map_field(CreditNoteFilterField::OriginInvoiceId).as_str(),
+        CreditNoteColumn::OriginInvoiceId.as_str()
+    );
+}
+
+#[test]
+fn credit_note_map_revenue_stream() {
+    assert_eq!(
+        CreditNoteODataMapper::map_field(CreditNoteFilterField::RevenueStream).as_str(),
+        CreditNoteColumn::RevenueStream.as_str()
+    );
+}
+
+#[test]
+fn credit_note_map_reason_code() {
+    assert_eq!(
+        CreditNoteODataMapper::map_field(CreditNoteFilterField::ReasonCode).as_str(),
+        CreditNoteColumn::ReasonCode.as_str()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CreditNoteODataMapper — extract_cursor_value
+// ---------------------------------------------------------------------------
+
+#[test]
+fn credit_note_cursor_credit_note_id_is_string() {
+    let model = sample_credit_note();
+    let val =
+        CreditNoteODataMapper::extract_cursor_value(&model, CreditNoteFilterField::CreditNoteId);
+    assert_eq!(val, sea_orm::Value::String(Some("CN-001".to_owned())));
+}
+
+#[test]
+fn credit_note_cursor_origin_invoice_id_is_string() {
+    let model = sample_credit_note();
+    let val =
+        CreditNoteODataMapper::extract_cursor_value(&model, CreditNoteFilterField::OriginInvoiceId);
+    assert_eq!(val, sea_orm::Value::String(Some("INV-002".to_owned())));
+}
+
+/// `credit_note.revenue_stream` is NOT nullable, unlike `tenant_account`'s — so
+/// this arm must emit `Some`, never the typed NULL.
+#[test]
+fn credit_note_cursor_revenue_stream_is_non_null_string() {
+    let model = sample_credit_note();
+    let val =
+        CreditNoteODataMapper::extract_cursor_value(&model, CreditNoteFilterField::RevenueStream);
+    assert_eq!(val, sea_orm::Value::String(Some("SAAS".to_owned())));
+}
+
+#[test]
+fn credit_note_cursor_reason_code_is_string() {
+    let model = sample_credit_note();
+    let val =
+        CreditNoteODataMapper::extract_cursor_value(&model, CreditNoteFilterField::ReasonCode);
+    assert_eq!(
+        val,
+        sea_orm::Value::String(Some("SERVICE_CREDIT".to_owned()))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// DebitNoteODataMapper — map_field (column name lock)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn debit_note_map_debit_note_id() {
+    assert_eq!(
+        DebitNoteODataMapper::map_field(DebitNoteFilterField::DebitNoteId).as_str(),
+        DebitNoteColumn::DebitNoteId.as_str()
+    );
+}
+
+#[test]
+fn debit_note_map_origin_invoice_id() {
+    assert_eq!(
+        DebitNoteODataMapper::map_field(DebitNoteFilterField::OriginInvoiceId).as_str(),
+        DebitNoteColumn::OriginInvoiceId.as_str()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// DebitNoteODataMapper — extract_cursor_value
+// ---------------------------------------------------------------------------
+
+#[test]
+fn debit_note_cursor_debit_note_id_is_string() {
+    let model = sample_debit_note();
+    let val = DebitNoteODataMapper::extract_cursor_value(&model, DebitNoteFilterField::DebitNoteId);
+    assert_eq!(val, sea_orm::Value::String(Some("DN-001".to_owned())));
+}
+
+#[test]
+fn debit_note_cursor_origin_invoice_id_is_string() {
+    let model = sample_debit_note();
+    let val =
+        DebitNoteODataMapper::extract_cursor_value(&model, DebitNoteFilterField::OriginInvoiceId);
+    assert_eq!(val, sea_orm::Value::String(Some("INV-003".to_owned())));
+}
+
+// ---------------------------------------------------------------------------
+// DisputeODataMapper — map_field (column name lock)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dispute_map_dispute_id() {
+    assert_eq!(
+        DisputeODataMapper::map_field(DisputeFilterField::DisputeId).as_str(),
+        DisputeColumn::DisputeId.as_str()
+    );
+}
+
+#[test]
+fn dispute_map_payment_id() {
+    assert_eq!(
+        DisputeODataMapper::map_field(DisputeFilterField::PaymentId).as_str(),
+        DisputeColumn::PaymentId.as_str()
+    );
+}
+
+#[test]
+fn dispute_map_last_phase() {
+    assert_eq!(
+        DisputeODataMapper::map_field(DisputeFilterField::LastPhase).as_str(),
+        DisputeColumn::LastPhase.as_str()
+    );
+}
+
+#[test]
+fn dispute_map_variant() {
+    assert_eq!(
+        DisputeODataMapper::map_field(DisputeFilterField::Variant).as_str(),
+        DisputeColumn::Variant.as_str()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// DisputeODataMapper — extract_cursor_value
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dispute_cursor_dispute_id_is_string() {
+    let model = sample_dispute();
+    let val = DisputeODataMapper::extract_cursor_value(&model, DisputeFilterField::DisputeId);
+    assert_eq!(val, sea_orm::Value::String(Some("DSP-001".to_owned())));
+}
+
+#[test]
+fn dispute_cursor_payment_id_is_string() {
+    let model = sample_dispute();
+    let val = DisputeODataMapper::extract_cursor_value(&model, DisputeFilterField::PaymentId);
+    assert_eq!(val, sea_orm::Value::String(Some("PAY-002".to_owned())));
+}
+
+#[test]
+fn dispute_cursor_last_phase_is_string() {
+    let model = sample_dispute();
+    let val = DisputeODataMapper::extract_cursor_value(&model, DisputeFilterField::LastPhase);
+    assert_eq!(
+        val,
+        sea_orm::Value::String(Some("representment".to_owned()))
+    );
+}
+
+/// `variant` must map to the `variant` column, not `last_phase` — the two are
+/// adjacent `String` fields, so a copy-paste slip here would silently order the
+/// keyset by the wrong column.
+#[test]
+fn dispute_cursor_variant_is_string() {
+    let model = sample_dispute();
+    let val = DisputeODataMapper::extract_cursor_value(&model, DisputeFilterField::Variant);
+    assert_eq!(val, sea_orm::Value::String(Some("chargeback".to_owned())));
+}
+
+// ---------------------------------------------------------------------------
+// RecognitionRunODataMapper — map_field (column name lock)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn recognition_run_map_run_id() {
+    assert_eq!(
+        RecognitionRunODataMapper::map_field(RecognitionRunFilterField::RunId).as_str(),
+        RecognitionRunColumn::RunId.as_str()
+    );
+}
+
+#[test]
+fn recognition_run_map_period_id() {
+    assert_eq!(
+        RecognitionRunODataMapper::map_field(RecognitionRunFilterField::PeriodId).as_str(),
+        RecognitionRunColumn::PeriodId.as_str()
+    );
+}
+
+#[test]
+fn recognition_run_map_status() {
+    assert_eq!(
+        RecognitionRunODataMapper::map_field(RecognitionRunFilterField::Status).as_str(),
+        RecognitionRunColumn::Status.as_str()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// RecognitionRunODataMapper — extract_cursor_value
+// ---------------------------------------------------------------------------
+
+#[test]
+fn recognition_run_cursor_run_id_is_uuid() {
+    let model = sample_recognition_run();
+    let val =
+        RecognitionRunODataMapper::extract_cursor_value(&model, RecognitionRunFilterField::RunId);
+    assert_eq!(val, sea_orm::Value::Uuid(Some(Uuid::from_u128(0x0E))));
+}
+
+#[test]
+fn recognition_run_cursor_period_id_is_string() {
+    let model = sample_recognition_run();
+    let val = RecognitionRunODataMapper::extract_cursor_value(
+        &model,
+        RecognitionRunFilterField::PeriodId,
+    );
+    assert_eq!(val, sea_orm::Value::String(Some("2025-04".to_owned())));
+}
+
+#[test]
+fn recognition_run_cursor_status_is_string() {
+    let model = sample_recognition_run();
+    let val =
+        RecognitionRunODataMapper::extract_cursor_value(&model, RecognitionRunFilterField::Status);
+    assert_eq!(val, sea_orm::Value::String(Some("completed".to_owned())));
+}
+
+// ---------------------------------------------------------------------------
+// ExceptionODataMapper — map_field (column name lock)
+// ---------------------------------------------------------------------------
+
+/// `exception_type` is the Rust field name; the SQL column is `type` (a
+/// reserved word), so this lock is load-bearing.
+#[test]
+fn exception_map_exception_type() {
+    assert_eq!(
+        ExceptionODataMapper::map_field(ExceptionFilterField::ExceptionType).as_str(),
+        ExceptionColumn::ExceptionType.as_str()
+    );
+}
+
+#[test]
+fn exception_map_exception_id() {
+    assert_eq!(
+        ExceptionODataMapper::map_field(ExceptionFilterField::ExceptionId).as_str(),
+        ExceptionColumn::ExceptionId.as_str()
+    );
+}
+
+#[test]
+fn exception_map_status() {
+    assert_eq!(
+        ExceptionODataMapper::map_field(ExceptionFilterField::Status).as_str(),
+        ExceptionColumn::Status.as_str()
+    );
+}
+
+#[test]
+fn exception_map_business_ref() {
+    assert_eq!(
+        ExceptionODataMapper::map_field(ExceptionFilterField::BusinessRef).as_str(),
+        ExceptionColumn::BusinessRef.as_str()
+    );
+}
+
+#[test]
+fn exception_map_period_id() {
+    assert_eq!(
+        ExceptionODataMapper::map_field(ExceptionFilterField::PeriodId).as_str(),
+        ExceptionColumn::PeriodId.as_str()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ExceptionODataMapper — extract_cursor_value
+// ---------------------------------------------------------------------------
+
+#[test]
+fn exception_cursor_exception_id_is_uuid() {
+    let model = sample_exception();
+    let val = ExceptionODataMapper::extract_cursor_value(&model, ExceptionFilterField::ExceptionId);
+    assert_eq!(val, sea_orm::Value::Uuid(Some(Uuid::from_u128(0x0F))));
+}
+
+#[test]
+fn exception_cursor_exception_type_is_string() {
+    let model = sample_exception();
+    let val =
+        ExceptionODataMapper::extract_cursor_value(&model, ExceptionFilterField::ExceptionType);
+    assert_eq!(
+        val,
+        sea_orm::Value::String(Some("UNAPPLIED_CASH".to_owned()))
+    );
+}
+
+#[test]
+fn exception_cursor_status_is_string() {
+    let model = sample_exception();
+    let val = ExceptionODataMapper::extract_cursor_value(&model, ExceptionFilterField::Status);
+    assert_eq!(val, sea_orm::Value::String(Some("open".to_owned())));
+}
+
+#[test]
+fn exception_cursor_business_ref_is_string() {
+    let model = sample_exception();
+    let val = ExceptionODataMapper::extract_cursor_value(&model, ExceptionFilterField::BusinessRef);
+    assert_eq!(val, sea_orm::Value::String(Some("PAY-003".to_owned())));
+}
+
+#[test]
+fn exception_cursor_period_id_some() {
+    let model = sample_exception();
+    let val = ExceptionODataMapper::extract_cursor_value(&model, ExceptionFilterField::PeriodId);
+    assert_eq!(val, sea_orm::Value::String(Some("2025-05".to_owned())));
+}
+
+/// The second nullable-column arm: a non-period exception has no `period_id`,
+/// which must still produce a typed NULL rather than being dropped.
+#[test]
+fn exception_cursor_period_id_none_is_null_string() {
+    let mut model = sample_exception();
+    model.period_id = None;
+    let val = ExceptionODataMapper::extract_cursor_value(&model, ExceptionFilterField::PeriodId);
+    assert_eq!(val, sea_orm::Value::String(None));
 }

--- a/libs/toolkit-db/src/migration_runner.rs
+++ b/libs/toolkit-db/src/migration_runner.rs
@@ -74,6 +74,22 @@ pub enum MigrationError {
     },
 }
 
+/// Build the [`MigrationError::UnsupportedBackend`] returned by every
+/// backend-dispatching helper below.
+///
+/// `coverage(off)`: `DatabaseBackend` has exactly three constructible variants
+/// (`MySql`/`Postgres`/`Sqlite`) — `#[non_exhaustive]` restricts matching, it
+/// does not add values — so no test can reach the arms that call this without
+/// transmuting an invalid discriminant. Excluding it keeps unreachable lines out
+/// of the coverage denominator instead of inviting a fake test.
+#[cfg_attr(coverage_nightly, coverage(off))]
+fn unsupported_backend(gear_name: &str, backend: DatabaseBackend) -> MigrationError {
+    MigrationError::UnsupportedBackend {
+        gear: gear_name.to_owned(),
+        backend,
+    }
+}
+
 /// Result of a migration run.
 #[derive(Debug, Clone)]
 pub struct MigrationResult {
@@ -171,12 +187,7 @@ async fn ensure_migration_table(
             )
             "#
         ),
-        _ => {
-            return Err(MigrationError::UnsupportedBackend {
-                gear: gear_name.to_owned(),
-                backend,
-            });
-        }
+        _ => return Err(unsupported_backend(gear_name, backend)),
     };
 
     conn.execute_raw(Statement::from_string(backend, sql))
@@ -202,12 +213,7 @@ async fn get_applied_migrations(
             format!(r#"SELECT version FROM "{table_name}""#)
         }
         DatabaseBackend::MySql => format!(r"SELECT version FROM `{table_name}`"),
-        _ => {
-            return Err(MigrationError::UnsupportedBackend {
-                gear: gear_name.to_owned(),
-                backend,
-            });
-        }
+        _ => return Err(unsupported_backend(gear_name, backend)),
     };
 
     let records: Vec<MigrationRecord> =
@@ -236,12 +242,7 @@ async fn record_migration(
             format!(r#"INSERT INTO "{table_name}" (version) VALUES ($1)"#)
         }
         DatabaseBackend::MySql => format!(r"INSERT INTO `{table_name}` (version) VALUES (?)"),
-        _ => {
-            return Err(MigrationError::UnsupportedBackend {
-                gear: gear_name.to_owned(),
-                backend,
-            });
-        }
+        _ => return Err(unsupported_backend(gear_name, backend)),
     };
 
     conn.execute_raw(Statement::from_sql_and_values(
@@ -565,12 +566,7 @@ async fn get_pending_migrations_internal(
             row.and_then(|r| r.try_get_by_index::<i32>(0).ok())
                 .is_some_and(|c| c > 0)
         }
-        _ => {
-            return Err(MigrationError::UnsupportedBackend {
-                gear: gear_name.to_owned(),
-                backend,
-            });
-        }
+        _ => return Err(unsupported_backend(gear_name, backend)),
     };
 
     if !table_exists {

--- a/libs/toolkit-db/src/odata/core.rs
+++ b/libs/toolkit-db/src/odata/core.rs
@@ -956,3 +956,343 @@ fn build_cursor<E: EntityTrait>(
         })
         .transpose()
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    // `super` aliases `toolkit_odata::ast` as `core`, which shadows the `core`
+    // crate inside this module; spell the path out to disambiguate.
+    use self::core::Value as V;
+
+    // -----------------------------------------------------------------------
+    // coerce — one arm per FieldKind, asserting which `sea_orm::Value` variant
+    // the OData literal lands in. The variant matters beyond equality: the
+    // keyset comparison and the bound parameter's SQL type both follow from it.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn coerce_string_produces_string_value() {
+        let got = coerce(FieldKind::String, &V::String("abc".to_owned())).unwrap();
+        assert_eq!(got, sea_orm::Value::String(Some("abc".to_owned())));
+    }
+
+    #[test]
+    fn coerce_integral_number_produces_big_int() {
+        let got = coerce(FieldKind::I64, &V::Number(BigDecimal::from(42))).unwrap();
+        assert_eq!(got, sea_orm::Value::BigInt(Some(42)));
+    }
+
+    #[test]
+    fn coerce_number_for_f64_produces_double() {
+        let bd: BigDecimal = "1.5".parse().unwrap();
+        let got = coerce(FieldKind::F64, &V::Number(bd)).unwrap();
+        assert_eq!(got, sea_orm::Value::Double(Some(1.5)));
+    }
+
+    /// Decimal must go through the string round-trip, not `to_f64`, or the
+    /// fractional digits a money column depends on are silently lost.
+    #[test]
+    fn coerce_number_for_decimal_preserves_scale() {
+        let bd: BigDecimal = "10.05".parse().unwrap();
+        let got = coerce(FieldKind::Decimal, &V::Number(bd)).unwrap();
+        assert_eq!(
+            got,
+            sea_orm::Value::Decimal(Some("10.05".parse::<Decimal>().unwrap()))
+        );
+    }
+
+    #[test]
+    fn coerce_bool_produces_bool_value() {
+        let got = coerce(FieldKind::Bool, &V::Bool(true)).unwrap();
+        assert_eq!(got, sea_orm::Value::Bool(Some(true)));
+    }
+
+    #[test]
+    fn coerce_uuid_produces_uuid_value() {
+        let u = uuid::Uuid::from_u128(0x51);
+        let got = coerce(FieldKind::Uuid, &V::Uuid(u)).unwrap();
+        assert_eq!(got, sea_orm::Value::Uuid(Some(u)));
+    }
+
+    #[test]
+    fn coerce_datetime_produces_chrono_datetime_utc() {
+        let dt = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        let got = coerce(FieldKind::DateTimeUtc, &V::DateTime(dt)).unwrap();
+        assert_eq!(got, sea_orm::Value::ChronoDateTimeUtc(Some(dt)));
+    }
+
+    #[test]
+    fn coerce_date_produces_chrono_date() {
+        let d = NaiveDate::from_ymd_opt(2025, 6, 15).unwrap();
+        let got = coerce(FieldKind::Date, &V::Date(d)).unwrap();
+        assert_eq!(got, sea_orm::Value::ChronoDate(Some(d)));
+    }
+
+    #[test]
+    fn coerce_time_produces_chrono_time() {
+        let t = NaiveTime::from_hms_opt(13, 45, 30).unwrap();
+        let got = coerce(FieldKind::Time, &V::Time(t)).unwrap();
+        assert_eq!(got, sea_orm::Value::ChronoTime(Some(t)));
+    }
+
+    // -----------------------------------------------------------------------
+    // coerce — error paths. A filter that names a field of one type but passes
+    // a literal of another must be rejected, not coerced: silently accepting it
+    // would compare a column against the wrong SQL type.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn coerce_reports_the_offending_literal_type_on_mismatch() {
+        let err = coerce(FieldKind::I64, &V::String("nope".to_owned())).unwrap_err();
+        match err {
+            ODataBuildError::TypeMismatch { expected, got } => {
+                assert_eq!(expected, FieldKind::I64);
+                assert_eq!(got, "string");
+            }
+            other => panic!("expected TypeMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn coerce_rejects_null_literal_with_its_own_tag() {
+        let err = coerce(FieldKind::String, &V::Null).unwrap_err();
+        match err {
+            ODataBuildError::TypeMismatch { expected, got } => {
+                assert_eq!(expected, FieldKind::String);
+                assert_eq!(got, "null");
+            }
+            other => panic!("expected TypeMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn coerce_rejects_uuid_literal_against_string_field() {
+        let err = coerce(FieldKind::String, &V::Uuid(uuid::Uuid::nil())).unwrap_err();
+        assert!(matches!(
+            err,
+            ODataBuildError::TypeMismatch { got: "uuid", .. }
+        ));
+    }
+
+    #[test]
+    fn coerce_rejects_bool_literal_against_date_field() {
+        let err = coerce(FieldKind::Date, &V::Bool(false)).unwrap_err();
+        assert!(matches!(
+            err,
+            ODataBuildError::TypeMismatch { got: "bool", .. }
+        ));
+    }
+
+    /// A number too large for `i64` must fail rather than wrap or saturate.
+    #[test]
+    fn coerce_rejects_number_out_of_i64_range() {
+        let huge: BigDecimal = "99999999999999999999999999".parse().unwrap();
+        let err = coerce(FieldKind::I64, &V::Number(huge)).unwrap_err();
+        assert!(matches!(
+            err,
+            ODataBuildError::TypeMismatch {
+                expected: FieldKind::I64,
+                got: "number"
+            }
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // coerce_many
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn coerce_many_maps_every_literal_in_order() {
+        let items = vec![
+            core::Expr::Value(V::Number(BigDecimal::from(1))),
+            core::Expr::Value(V::Number(BigDecimal::from(2))),
+        ];
+        let got = coerce_many(FieldKind::I64, &items).unwrap();
+        assert_eq!(
+            got,
+            vec![
+                sea_orm::Value::BigInt(Some(1)),
+                sea_orm::Value::BigInt(Some(2))
+            ]
+        );
+    }
+
+    /// `x in (y)` where `y` is a column reference rather than a literal must be
+    /// rejected — otherwise the identifier would be bound as a string parameter.
+    #[test]
+    fn coerce_many_rejects_non_literal_items() {
+        let items = vec![core::Expr::Identifier("some_column".to_owned())];
+        let err = coerce_many(FieldKind::I64, &items).unwrap_err();
+        assert!(matches!(err, ODataBuildError::NonLiteralInList));
+    }
+
+    // -----------------------------------------------------------------------
+    // parse_cursor_value — the decode half of the keyset cursor. A cursor is
+    // attacker-supplied (it arrives as an opaque query parameter), so every
+    // malformed input must produce an error, never a panic or a wrong type.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_cursor_string_is_infallible() {
+        let got = parse_cursor_value(FieldKind::String, "anything").unwrap();
+        assert_eq!(got, sea_orm::Value::String(Some("anything".to_owned())));
+    }
+
+    #[test]
+    fn parse_cursor_i64_round_trips() {
+        let got = parse_cursor_value(FieldKind::I64, "-7").unwrap();
+        assert_eq!(got, sea_orm::Value::BigInt(Some(-7)));
+    }
+
+    #[test]
+    fn parse_cursor_f64_round_trips() {
+        let got = parse_cursor_value(FieldKind::F64, "2.25").unwrap();
+        assert_eq!(got, sea_orm::Value::Double(Some(2.25)));
+    }
+
+    #[test]
+    fn parse_cursor_bool_round_trips() {
+        let got = parse_cursor_value(FieldKind::Bool, "true").unwrap();
+        assert_eq!(got, sea_orm::Value::Bool(Some(true)));
+    }
+
+    #[test]
+    fn parse_cursor_uuid_round_trips() {
+        let u = uuid::Uuid::from_u128(0x52);
+        let got = parse_cursor_value(FieldKind::Uuid, &u.to_string()).unwrap();
+        assert_eq!(got, sea_orm::Value::Uuid(Some(u)));
+    }
+
+    #[test]
+    fn parse_cursor_datetime_normalizes_offset_to_utc() {
+        // Same instant, expressed in +02:00 — must come back as the UTC value so
+        // the keyset comparison is against a comparable timestamp.
+        let got = parse_cursor_value(FieldKind::DateTimeUtc, "2025-06-15T14:00:00+02:00").unwrap();
+        let expected = chrono::DateTime::parse_from_rfc3339("2025-06-15T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(got, sea_orm::Value::ChronoDateTimeUtc(Some(expected)));
+    }
+
+    #[test]
+    fn parse_cursor_date_round_trips() {
+        let got = parse_cursor_value(FieldKind::Date, "2025-06-15").unwrap();
+        assert_eq!(
+            got,
+            sea_orm::Value::ChronoDate(Some(NaiveDate::from_ymd_opt(2025, 6, 15).unwrap()))
+        );
+    }
+
+    #[test]
+    fn parse_cursor_time_round_trips() {
+        let got = parse_cursor_value(FieldKind::Time, "13:45:30").unwrap();
+        assert_eq!(
+            got,
+            sea_orm::Value::ChronoTime(Some(NaiveTime::from_hms_opt(13, 45, 30).unwrap()))
+        );
+    }
+
+    #[test]
+    fn parse_cursor_decimal_round_trips() {
+        let got = parse_cursor_value(FieldKind::Decimal, "10.05").unwrap();
+        assert_eq!(
+            got,
+            sea_orm::Value::Decimal(Some("10.05".parse::<Decimal>().unwrap()))
+        );
+    }
+
+    /// Every kind must reject garbage with its own message, so a malformed
+    /// cursor surfaces as a 400 rather than a panic or a silent default.
+    #[test]
+    fn parse_cursor_rejects_garbage_for_every_typed_kind() {
+        let cases = [
+            (FieldKind::I64, "invalid i64 in cursor"),
+            (FieldKind::F64, "invalid f64 in cursor"),
+            (FieldKind::Bool, "invalid bool in cursor"),
+            (FieldKind::Uuid, "invalid uuid in cursor"),
+            (FieldKind::DateTimeUtc, "invalid datetime in cursor"),
+            (FieldKind::Date, "invalid date in cursor"),
+            (FieldKind::Time, "invalid time in cursor"),
+            (FieldKind::Decimal, "invalid decimal in cursor"),
+        ];
+        for (kind, expected_msg) in cases {
+            let err = parse_cursor_value(kind, "!!not-a-value!!").unwrap_err();
+            match err {
+                ODataBuildError::Other(msg) => {
+                    assert_eq!(msg, expected_msg, "wrong message for {kind:?}: got {msg:?}");
+                }
+                other => panic!("expected Other for {kind:?}, got {other:?}"),
+            }
+        }
+    }
+
+    /// An empty cursor segment is the realistic malformed case (a truncated
+    /// token), and it must be rejected for typed kinds while staying valid for
+    /// `String` — where the empty string is a legitimate key.
+    #[test]
+    fn parse_cursor_empty_segment_is_rejected_for_typed_kinds_but_ok_for_string() {
+        assert_eq!(
+            parse_cursor_value(FieldKind::String, "").unwrap(),
+            sea_orm::Value::String(Some(String::new()))
+        );
+        assert!(parse_cursor_value(FieldKind::I64, "").is_err());
+        assert!(parse_cursor_value(FieldKind::Uuid, "").is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // LIKE escaping — `contains`/`startswith`/`endswith` interpolate user text
+    // into a LIKE pattern, so the wildcards must be neutralised or a filter of
+    // "%" would match every row.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn like_escape_neutralises_wildcards_and_the_escape_char() {
+        assert_eq!(like_escape("100%"), r"100\%");
+        assert_eq!(like_escape("a_b"), r"a\_b");
+        assert_eq!(like_escape(r"back\slash"), r"back\\slash");
+    }
+
+    #[test]
+    fn like_escape_leaves_ordinary_text_untouched() {
+        assert_eq!(like_escape("plain text 42"), "plain text 42");
+    }
+
+    #[test]
+    fn like_helpers_anchor_the_pattern_on_the_expected_side() {
+        assert_eq!(like_contains("ab"), "%ab%");
+        assert_eq!(like_starts("ab"), "ab%");
+        assert_eq!(like_ends("ab"), "%ab");
+    }
+
+    /// The wildcard in the *user's* text stays escaped while the anchors the
+    /// helper adds stay live — that distinction is the whole point.
+    #[test]
+    fn like_helpers_escape_user_wildcards_but_keep_their_own_anchors() {
+        assert_eq!(like_contains("50%"), r"%50\%%");
+        assert_eq!(like_starts("_x"), r"\_x%");
+    }
+
+    // -----------------------------------------------------------------------
+    // bigdecimal_to_decimal
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bigdecimal_to_decimal_preserves_fractional_digits() {
+        let bd: BigDecimal = "123.4500".parse().unwrap();
+        assert_eq!(
+            bigdecimal_to_decimal(&bd).unwrap(),
+            "123.45".parse::<Decimal>().unwrap()
+        );
+    }
+
+    /// `rust_decimal` is a 96-bit fixed-point type, so a `BigDecimal` beyond its
+    /// range must error rather than truncate a monetary amount.
+    #[test]
+    fn bigdecimal_to_decimal_rejects_out_of_range_values() {
+        let bd: BigDecimal = "1e40".parse().unwrap();
+        let err = bigdecimal_to_decimal(&bd).unwrap_err();
+        assert!(matches!(err, ODataBuildError::Other("invalid decimal")));
+    }
+}

--- a/libs/toolkit-db/src/outbox/dialect.rs
+++ b/libs/toolkit-db/src/outbox/dialect.rs
@@ -38,12 +38,23 @@ impl From<DbBackend> for Dialect {
             DbBackend::Postgres => Self::Postgres,
             DbBackend::Sqlite => Self::Sqlite,
             DbBackend::MySql => Self::MySql,
-            other => panic!(
-                "toolkit-db outbox supports Postgres, SQLite and MySQL only; \
-                 got unsupported database backend {other:?}"
-            ),
+            other => unsupported_backend(other),
         }
     }
+}
+
+/// Diverging helper for the unreachable arm of [`Dialect::from`].
+///
+/// `coverage(off)` sits here rather than on `from` itself so the three real arms
+/// stay in the coverage numerator (they are exercised by `dialect_from_dbbackend`)
+/// while the unreachable panic body leaves the denominator. `DbBackend` has
+/// exactly three constructible variants, so no test can reach this.
+#[cfg_attr(coverage_nightly, coverage(off))]
+fn unsupported_backend(backend: DbBackend) -> ! {
+    panic!(
+        "toolkit-db outbox supports Postgres, SQLite and MySQL only; \
+         got unsupported database backend {backend:?}"
+    )
 }
 
 /// SQL for the vacuum's bounded-chunk cleanup operation.

--- a/libs/toolkit-db/src/outbox/migrations.rs
+++ b/libs/toolkit-db/src/outbox/migrations.rs
@@ -93,6 +93,11 @@ impl MigrationTrait for CreateOutboxSchema {
 /// helper below needs a fallback arm. Returning an error (rather than picking a
 /// dialect) keeps us from creating outbox tables with SQL meant for a different
 /// engine.
+///
+/// `coverage(off)`: the enum has exactly three constructible variants, so the
+/// nine arms that call this are unreachable without transmuting an invalid
+/// discriminant. Excluded from the denominator rather than faked with a test.
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn unsupported_backend(backend: DatabaseBackend) -> DbErr {
     DbErr::Custom(format!(
         "outbox migrations support Postgres, SQLite and MySQL only; \

--- a/libs/toolkit-db/src/secure/db_ops.rs
+++ b/libs/toolkit-db/src/secure/db_ops.rs
@@ -1571,4 +1571,306 @@ mod tests {
             "Unknown property must cause constraint to fail (fail-closed)"
         );
     }
+
+    /// Test entity whose scope-resolvable column is a type
+    /// `sea_value_to_scope_value` does not support, used to prove the
+    /// unsupported-type path fails closed rather than allowing the insert.
+    mod unsupported_value_entity {
+        use super::*;
+        use toolkit_security::pep_properties;
+
+        #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+        #[sea_orm(table_name = "unsupported_value_table")]
+        pub struct Model {
+            #[sea_orm(primary_key)]
+            pub id: Uuid,
+            pub tenant_id: Uuid,
+            /// `f64` becomes `Value::Double`, which the scope-value converter
+            /// has no `ScopeValue` mapping for.
+            pub score: f64,
+        }
+
+        #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+        pub enum Relation {}
+
+        impl ActiveModelBehavior for ActiveModel {}
+
+        impl ScopableEntity for Entity {
+            fn tenant_col() -> Option<Column> {
+                Some(Column::TenantId)
+            }
+            fn resource_col() -> Option<Column> {
+                Some(Column::Id)
+            }
+            fn owner_col() -> Option<Column> {
+                None
+            }
+            fn type_col() -> Option<Column> {
+                None
+            }
+            fn resolve_property(property: &str) -> Option<Column> {
+                match property {
+                    pep_properties::OWNER_TENANT_ID => Self::tenant_col(),
+                    "score" => Some(Column::Score),
+                    _ => None,
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // sea_value_to_scope_value
+    //
+    // This is the bridge between a column's stored `sea_orm::Value` and the
+    // `ScopeValue` an access-scope filter compares against. A variant it fails
+    // to recognise makes `validate_insert_scope` fail closed, so the arm list
+    // is security-relevant, not cosmetic.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn sea_value_to_scope_value_maps_uuid() {
+        let id = Uuid::from_u128(0x91);
+        assert_eq!(
+            sea_value_to_scope_value(&sea_orm::Value::Uuid(Some(id))),
+            Some(toolkit_security::ScopeValue::Uuid(id))
+        );
+    }
+
+    /// A UUID stored in a text column must still compare as a `Uuid`, so a
+    /// scope filter written with UUIDs matches a `VARCHAR` tenant column too.
+    #[test]
+    fn sea_value_to_scope_value_parses_uuid_shaped_strings_as_uuid() {
+        let id = Uuid::from_u128(0x92);
+        assert_eq!(
+            sea_value_to_scope_value(&sea_orm::Value::String(Some(id.to_string()))),
+            Some(toolkit_security::ScopeValue::Uuid(id))
+        );
+    }
+
+    #[test]
+    fn sea_value_to_scope_value_keeps_non_uuid_strings_as_strings() {
+        assert_eq!(
+            sea_value_to_scope_value(&sea_orm::Value::String(Some("draft".to_owned()))),
+            Some(toolkit_security::ScopeValue::String("draft".to_owned()))
+        );
+    }
+
+    /// Every integer width widens to `ScopeValue::Int(i64)`, so a scope filter
+    /// need not know the column's storage width.
+    #[test]
+    fn sea_value_to_scope_value_widens_every_integer_width_to_i64() {
+        let cases = [
+            sea_orm::Value::BigInt(Some(7i64)),
+            sea_orm::Value::Int(Some(7i32)),
+            sea_orm::Value::SmallInt(Some(7i16)),
+            sea_orm::Value::TinyInt(Some(7i8)),
+        ];
+        for v in cases {
+            assert_eq!(
+                sea_value_to_scope_value(&v),
+                Some(toolkit_security::ScopeValue::Int(7)),
+                "unexpected mapping for {v:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn sea_value_to_scope_value_maps_bool() {
+        assert_eq!(
+            sea_value_to_scope_value(&sea_orm::Value::Bool(Some(true))),
+            Some(toolkit_security::ScopeValue::Bool(true))
+        );
+    }
+
+    /// Unsupported variants and SQL NULLs must return `None` so the caller fails
+    /// closed instead of treating an unknown value as a match.
+    #[test]
+    fn sea_value_to_scope_value_returns_none_for_unsupported_and_null_values() {
+        let unsupported = [
+            sea_orm::Value::Double(Some(1.5)),
+            sea_orm::Value::Float(Some(1.5)),
+            sea_orm::Value::Uuid(None),
+            sea_orm::Value::String(None),
+            sea_orm::Value::BigInt(None),
+            sea_orm::Value::Bool(None),
+        ];
+        for v in unsupported {
+            assert_eq!(
+                sea_value_to_scope_value(&v),
+                None,
+                "{v:?} must not map to a ScopeValue"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // validate_insert_scope — the two branches the existing suite misses
+    // -----------------------------------------------------------------------
+
+    /// A filter on a column the insert does not set (auto-generated, defaulted)
+    /// must be *skipped*, not treated as a mismatch — otherwise every insert
+    /// that omits an optional scoped column would be denied.
+    #[test]
+    fn validate_insert_scope_skips_filters_on_not_set_columns() {
+        use owner_entity::ActiveModel;
+        use sea_orm::{NotSet, Set};
+        use toolkit_security::access_scope::{ScopeConstraint, ScopeFilter};
+        use toolkit_security::pep_properties;
+
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+
+        let scope = AccessScope::from_constraints(vec![ScopeConstraint::new(vec![
+            ScopeFilter::in_uuids(pep_properties::OWNER_TENANT_ID, vec![tenant_id]),
+            ScopeFilter::eq(pep_properties::OWNER_ID, user_id),
+            // Resolvable, but the ActiveModel leaves it NotSet below.
+            ScopeFilter::eq("city_id", Uuid::new_v4()),
+        ])]);
+
+        let am = ActiveModel {
+            id: Set(Uuid::new_v4()),
+            tenant_id: Set(tenant_id),
+            user_id: Set(user_id),
+            city_id: NotSet,
+        };
+
+        assert!(
+            validate_insert_scope(&am, &scope).is_ok(),
+            "a filter on a NotSet column must be skipped, not denied"
+        );
+    }
+
+    /// If a resolvable column's value has a type the scope-value converter does
+    /// not understand, the constraint must fail closed — comparing an unknown
+    /// value optimistically would let an out-of-scope row through.
+    #[test]
+    fn validate_insert_scope_denies_when_column_type_is_unsupported() {
+        use sea_orm::Set;
+        use toolkit_security::access_scope::{ScopeConstraint, ScopeFilter};
+        use toolkit_security::pep_properties;
+        use unsupported_value_entity::ActiveModel;
+
+        let tenant_id = Uuid::new_v4();
+
+        let scope = AccessScope::from_constraints(vec![ScopeConstraint::new(vec![
+            ScopeFilter::in_uuids(pep_properties::OWNER_TENANT_ID, vec![tenant_id]),
+            // `score` resolves to an f64 column -> Value::Double -> no ScopeValue.
+            ScopeFilter::eq("score", Uuid::new_v4()),
+        ])]);
+
+        let am = ActiveModel {
+            id: Set(Uuid::new_v4()),
+            tenant_id: Set(tenant_id),
+            score: Set(0.5),
+        };
+
+        assert!(
+            matches!(
+                validate_insert_scope(&am, &scope),
+                Err(ScopeError::Denied(_))
+            ),
+            "an unsupported column type must fail closed"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // SecureInsertMany — the multi-row wrapper added for SeaORM 2.0's split of
+    // insert_many out of Insert<A>. These exercise the builder/type-state half,
+    // which needs no database; the exec paths are covered by the sqlite suite.
+    // -----------------------------------------------------------------------
+
+    /// The type-state gate: a deny-all scope must be rejected at
+    /// `scope_unchecked`, before any statement can be executed.
+    #[test]
+    fn secure_insert_many_rejects_deny_all_scope() {
+        use sea_orm::Set;
+        use test_entity::{ActiveModel, Entity};
+
+        let am = ActiveModel {
+            id: Set(Uuid::new_v4()),
+            tenant_id: Set(Uuid::new_v4()),
+            name: Set("row".to_owned()),
+            value: Set(1),
+        };
+
+        let result = Entity::insert_many([am])
+            .secure()
+            .scope_unchecked(&AccessScope::default());
+
+        assert!(
+            matches!(result, Err(ScopeError::Denied(_))),
+            "a deny-all scope must not reach the Scoped state"
+        );
+    }
+
+    #[test]
+    fn secure_insert_many_accepts_a_scope_with_constraints() {
+        use sea_orm::Set;
+        use test_entity::{ActiveModel, Entity};
+
+        let tenant_id = Uuid::new_v4();
+        let am = ActiveModel {
+            id: Set(Uuid::new_v4()),
+            tenant_id: Set(tenant_id),
+            name: Set("row".to_owned()),
+            value: Set(1),
+        };
+
+        assert!(
+            Entity::insert_many([am])
+                .secure()
+                .scope_unchecked(&AccessScope::for_tenants(vec![tenant_id]))
+                .is_ok()
+        );
+    }
+
+    /// `into_inner` is the documented escape hatch; the built statement must
+    /// still carry the ON CONFLICT clause set through the secure wrapper,
+    /// otherwise an upsert would silently degrade to a plain insert.
+    #[test]
+    fn secure_insert_many_on_conflict_raw_survives_into_inner() {
+        use sea_orm::{QueryTrait, Set};
+        use test_entity::{ActiveModel, Column, Entity};
+
+        let tenant_id = Uuid::new_v4();
+        let am = ActiveModel {
+            id: Set(Uuid::new_v4()),
+            tenant_id: Set(tenant_id),
+            name: Set("row".to_owned()),
+            value: Set(1),
+        };
+
+        let mut on_conflict = OnConflict::column(Column::Id);
+        on_conflict.do_nothing();
+
+        let insert = Entity::insert_many([am])
+            .secure()
+            .scope_unchecked(&AccessScope::for_tenants(vec![tenant_id]))
+            .expect("scope with constraints is accepted")
+            .on_conflict_raw(on_conflict)
+            .into_inner();
+
+        let sql = insert.build(sea_orm::DatabaseBackend::Postgres).to_string();
+        assert!(
+            sql.contains("ON CONFLICT"),
+            "ON CONFLICT must survive the secure wrapper; got: {sql}"
+        );
+        assert!(
+            sql.contains("DO NOTHING"),
+            "the DO NOTHING action must be preserved; got: {sql}"
+        );
+    }
+
+    /// The secure `on_conflict` path still enforces tenant immutability, so a
+    /// caller cannot use an upsert to move a row between tenants.
+    #[test]
+    fn secure_insert_many_secure_on_conflict_rejects_tenant_column_update() {
+        let result = SecureOnConflict::<test_entity::Entity>::columns([test_entity::Column::Id])
+            .update_columns([test_entity::Column::TenantId]);
+
+        assert!(
+            matches!(result, Err(ScopeError::Denied(_))),
+            "tenant_id must stay immutable through an upsert"
+        );
+    }
 }


### PR DESCRIPTION
- gears/bss/ledger .../odata_mapping_tests.rs (+60 tests)
  7 of the 10 OData mappers had zero tests: JournalEntry, Refund, CreditNote,
  DebitNote, adn etc.
- libs/toolkit-db/src/odata/core.rs (+33 tests, first test module in the file)
- libs/toolkit-db/src/secure/db_ops.rs (+12 tests)
- Unreachable-by-construction arms are excluded from the denominator rather than faked with tests. Each is now a #[cfg_attr(coverage_nightly, coverage(off))] helper. In dialect.rs the attribute sits on an extracted diverging helper rather than on `from` itself, so the three real arms stay in the numerator.