### PR TITLE
fix(lints): make `make dylint` fully green (DE0904, DE0309, DE1201)

### DIFF
--- a/examples/toolkit/api-contracts/api-contracts-sdk/src/error.rs
+++ b/examples/toolkit/api-contracts/api-contracts-sdk/src/error.rs
@@ -7,7 +7,7 @@ use toolkit_contract::ContractError;
 /// Resource error constructors for payment operations.
 ///
 /// Generates typed constructors like `PaymentResourceError::not_found(detail)`.
-#[resource_error("gts.cf.demo.api_contracts.payment.v1~")]
+#[resource_error(gts_id!("cf.demo.api_contracts.payment.v1~"))]
 pub struct PaymentResourceError;
 
 /// Domain errors that flow across the `PaymentApi` wire boundary as

--- a/gears/bss/ledger/ledger-sdk/Cargo.toml
+++ b/gears/bss/ledger/ledger-sdk/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 description = "BSS Billing Ledger SDK: infrastructure-free contract for ClientHub consumers"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lints]
 workspace = true
 

--- a/gears/bss/rate-provider/plugins/ecb-plugin/Cargo.toml
+++ b/gears/bss/rate-provider/plugins/ecb-plugin/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 description = "BSS FX rate-provider ECB source plugin: fetches ECB daily reference rates and registers as a RateProviderV1 plugin instance"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lints]
 workspace = true
 

--- a/gears/bss/rate-provider/plugins/http-json-plugin/Cargo.toml
+++ b/gears/bss/rate-provider/plugins/http-json-plugin/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 description = "BSS FX rate-provider generic http-json source plugin: config-mapped GET-JSON feed registered as a RateProviderV1 plugin instance"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lints]
 workspace = true
 

--- a/gears/bss/rate-provider/rate-provider-sdk/Cargo.toml
+++ b/gears/bss/rate-provider/rate-provider-sdk/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 description = "BSS FX rate-provider SDK: the source-plugin GTS spec + shared source utilities (conversion, error mapping, fetch metrics)"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lints]
 workspace = true
 

--- a/gears/bss/rate-provider/rate-provider/Cargo.toml
+++ b/gears/bss/rate-provider/rate-provider/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 description = "BSS FX rate-provider core gear: discovers + composes source plugins and registers the composite as a RateProviderV1 plugin the ledger resolves"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lints]
 workspace = true
 

--- a/gears/file-parser/file-parser/src/domain/local_client.rs
+++ b/gears/file-parser/file-parser/src/domain/local_client.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use file_parser_sdk::{FileParserClientError, FileParserClientV1, ParseBytesRequest, ParsedText};
+use toolkit_macros::domain_model;
 use toolkit_security::SecurityContext;
 
 use crate::domain::error::DomainError;
@@ -39,6 +40,7 @@ impl From<DomainError> for FileParserClientError {
 
 /// In-process implementation of [`FileParserClientV1`], registered in
 /// `ClientHub` by `FileParserGear::init`.
+#[domain_model]
 pub struct FileParserLocalClient {
     svc: Arc<FileParserService>,
 }

--- a/gears/system/event-broker/event-broker/src/domain/cluster.rs
+++ b/gears/system/event-broker/event-broker/src/domain/cluster.rs
@@ -8,6 +8,7 @@
 
 use cluster_sdk::{ClusterCacheV1, ClusterError, DistributedLockV1, LeaderElectionV1};
 use toolkit::client_hub::ClientHub;
+use toolkit::domain_model;
 
 /// Every Event Broker cache key / lock name / election name is scoped under
 /// this prefix (`DESIGN.md:756-764`'s `evbk.*` cache-key table).
@@ -19,6 +20,7 @@ pub const CLUSTER_SCOPE_PREFIX: &str = "evbk";
 /// same module wiring") - standalone is simply backed by the
 /// zero-dependency `standalone` cluster-gear provider instead of a
 /// network-backed one.
+#[domain_model]
 pub struct EventBrokerCluster {
     pub cache: ClusterCacheV1,
     pub leader_election: LeaderElectionV1,

--- a/gears/system/event-broker/event-broker/src/domain/delivery.rs
+++ b/gears/system/event-broker/event-broker/src/domain/delivery.rs
@@ -3,6 +3,7 @@
 //! (REST API implementation) and #4347 (standalone runtime).
 
 use async_trait::async_trait;
+use toolkit::domain_model;
 use toolkit_security::SecurityContext;
 use uuid::Uuid;
 
@@ -12,6 +13,7 @@ use crate::domain::model::{Event, Subscription};
 /// JOIN request body (`DESIGN.md:692`: `consumer_group` + `interests[]`).
 /// Exact shape (typed filters per ADR-0005) is finalized alongside the REST
 /// DTOs in #4346.
+#[domain_model]
 #[derive(Debug, Clone)]
 pub struct JoinRequest {
     pub consumer_group: String,
@@ -20,6 +22,7 @@ pub struct JoinRequest {
 
 /// Long-poll response - events plus topology-version-aware metadata
 /// (`DESIGN.md:657`). Exact shape finalized in #4346.
+#[domain_model]
 #[derive(Debug, Clone, Default)]
 pub struct PollResponse {
     pub events: Vec<Event>,
@@ -30,6 +33,7 @@ pub struct PollResponse {
 /// assignments/cursors are identified by the full `(topic, partition)`
 /// pair (`DESIGN.md:658`) - keying by `partition` alone would collapse
 /// partition `0` of two different topics into one entry.
+#[domain_model]
 #[derive(Debug, Clone)]
 pub struct SeekPosition {
     pub topic: String,

--- a/gears/system/event-broker/event-broker/src/domain/error.rs
+++ b/gears/system/event-broker/event-broker/src/domain/error.rs
@@ -2,7 +2,9 @@
 //! REST-layer concern (`api/rest/error.rs`), not decided here (#4346).
 
 use thiserror::Error;
+use toolkit::domain_model;
 
+#[domain_model]
 #[derive(Debug, Error)]
 pub enum DomainError {
     /// Client-supplied input failed validation (e.g.

--- a/gears/system/event-broker/event-broker/src/domain/idempotency.rs
+++ b/gears/system/event-broker/event-broker/src/domain/idempotency.rs
@@ -3,12 +3,14 @@
 //! `ADR/0004-idempotent-producer-protocol.md`). Signatures only.
 
 use async_trait::async_trait;
+use toolkit::domain_model;
 use uuid::Uuid;
 
 use crate::domain::error::DomainError;
 
 /// Outcome of an idempotency check for one incoming event's producer
 /// chain (`meta.producer_id`, `meta.previous`, `meta.sequence`).
+#[domain_model]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IdempotencyOutcome {
     Accept,

--- a/gears/system/event-broker/event-broker/src/domain/ingest.rs
+++ b/gears/system/event-broker/event-broker/src/domain/ingest.rs
@@ -3,6 +3,7 @@
 //! and #4347 (standalone runtime).
 
 use async_trait::async_trait;
+use toolkit::domain_model;
 use toolkit_security::SecurityContext;
 use uuid::Uuid;
 
@@ -12,6 +13,7 @@ use crate::domain::model::Event;
 /// Result of a batch publish - which events were accepted (in submission
 /// order) and which were rejected with a reason. Exact shape is finalized
 /// alongside the REST DTOs in #4346.
+#[domain_model]
 #[derive(Debug, Clone, Default)]
 pub struct BatchResult {
     pub accepted: Vec<Uuid>,

--- a/gears/system/event-broker/event-broker/src/domain/model.rs
+++ b/gears/system/event-broker/event-broker/src/domain/model.rs
@@ -6,9 +6,11 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use serde_json::Value as JsonValue;
+use toolkit::domain_model;
 use uuid::Uuid;
 
 /// `gts.cf.core.events.topic.v1~` - a named, partitioned event log.
+#[domain_model]
 #[derive(Debug, Clone)]
 pub struct Topic {
     pub id: String,
@@ -21,6 +23,7 @@ pub struct Topic {
 
 /// `gts.cf.core.events.event_type.v1~` - schema and constraints for one
 /// category of events within a topic.
+#[domain_model]
 #[derive(Debug, Clone)]
 pub struct EventType {
     pub id: String,
@@ -33,6 +36,7 @@ pub struct EventType {
 
 /// `gts.cf.core.events.event.v1~` - an immutable record in a
 /// `(topic, partition)` log.
+#[domain_model]
 #[derive(Debug, Clone)]
 pub struct Event {
     pub id: Uuid,
@@ -56,6 +60,7 @@ pub struct Event {
 }
 
 /// Producer chain metadata. Publish-input only; stripped on read.
+#[domain_model]
 #[derive(Debug, Clone)]
 pub struct Meta {
     pub version: i32,
@@ -66,6 +71,7 @@ pub struct Meta {
 
 /// `gts.cf.core.events.subscription.v1~` - ephemeral, in-cache consumer
 /// instance.
+#[domain_model]
 #[derive(Debug, Clone)]
 pub struct Subscription {
     pub id: Uuid,
@@ -78,6 +84,7 @@ pub struct Subscription {
     pub expires_at: DateTime<Utc>,
 }
 
+#[domain_model]
 #[derive(Debug, Clone)]
 pub struct Assignment {
     pub topic: String,
@@ -87,6 +94,7 @@ pub struct Assignment {
 }
 
 /// Ephemeral, in-cache runtime state of a consumer group.
+#[domain_model]
 #[derive(Debug, Clone)]
 pub struct GroupState {
     pub consumer_group: String,
@@ -98,6 +106,7 @@ pub struct GroupState {
 }
 
 /// Ephemeral, in-cache group progress for one `(topic, partition)`.
+#[domain_model]
 #[derive(Debug, Clone)]
 pub struct Cursor {
     pub topic: String,

--- a/libs/toolkit-canonical-errors/src/problem.rs
+++ b/libs/toolkit-canonical-errors/src/problem.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 // (overridable via the `GTS_ID_PREFIX` env var at build
 // time). Used to assemble the canonical error type id prefix without
 // hard-coding the literal prefix.
-use toolkit_gts::{GTS_ID_PREFIX, GTS_ID_URI_PREFIX, gts_uri};
+use toolkit_gts::{GTS_ID_PREFIX, GTS_ID_URI_PREFIX, gts_id, gts_uri};
 
 use crate::context::{
     Aborted, AlreadyExists, Cancelled, DataLoss, DeadlineExceeded, FailedPrecondition, Internal,
@@ -58,28 +58,40 @@ impl ProblemCategory {
     #[must_use]
     pub fn gts_fragment(self) -> &'static str {
         match self {
-            Self::Cancelled => "gts.cf.core.errors.err.v1~cf.core.err.cancelled.v1~",
-            Self::Unknown => "gts.cf.core.errors.err.v1~cf.core.err.unknown.v1~",
-            Self::InvalidArgument => "gts.cf.core.errors.err.v1~cf.core.err.invalid_argument.v1~",
-            Self::DeadlineExceeded => "gts.cf.core.errors.err.v1~cf.core.err.deadline_exceeded.v1~",
-            Self::NotFound => "gts.cf.core.errors.err.v1~cf.core.err.not_found.v1~",
-            Self::AlreadyExists => "gts.cf.core.errors.err.v1~cf.core.err.already_exists.v1~",
-            Self::PermissionDenied => "gts.cf.core.errors.err.v1~cf.core.err.permission_denied.v1~",
+            Self::Cancelled => gts_id!("cf.core.errors.err.v1~cf.core.err.cancelled.v1~"),
+            Self::Unknown => gts_id!("cf.core.errors.err.v1~cf.core.err.unknown.v1~"),
+            Self::InvalidArgument => {
+                gts_id!("cf.core.errors.err.v1~cf.core.err.invalid_argument.v1~")
+            }
+            Self::DeadlineExceeded => {
+                gts_id!("cf.core.errors.err.v1~cf.core.err.deadline_exceeded.v1~")
+            }
+            Self::NotFound => gts_id!("cf.core.errors.err.v1~cf.core.err.not_found.v1~"),
+            Self::AlreadyExists => {
+                gts_id!("cf.core.errors.err.v1~cf.core.err.already_exists.v1~")
+            }
+            Self::PermissionDenied => {
+                gts_id!("cf.core.errors.err.v1~cf.core.err.permission_denied.v1~")
+            }
             Self::ResourceExhausted => {
-                "gts.cf.core.errors.err.v1~cf.core.err.resource_exhausted.v1~"
+                gts_id!("cf.core.errors.err.v1~cf.core.err.resource_exhausted.v1~")
             }
             Self::FailedPrecondition => {
-                "gts.cf.core.errors.err.v1~cf.core.err.failed_precondition.v1~"
+                gts_id!("cf.core.errors.err.v1~cf.core.err.failed_precondition.v1~")
             }
-            Self::Aborted => "gts.cf.core.errors.err.v1~cf.core.err.aborted.v1~",
-            Self::OutOfRange => "gts.cf.core.errors.err.v1~cf.core.err.out_of_range.v1~",
-            Self::Unimplemented => "gts.cf.core.errors.err.v1~cf.core.err.unimplemented.v1~",
-            Self::Internal => "gts.cf.core.errors.err.v1~cf.core.err.internal.v1~",
+            Self::Aborted => gts_id!("cf.core.errors.err.v1~cf.core.err.aborted.v1~"),
+            Self::OutOfRange => gts_id!("cf.core.errors.err.v1~cf.core.err.out_of_range.v1~"),
+            Self::Unimplemented => {
+                gts_id!("cf.core.errors.err.v1~cf.core.err.unimplemented.v1~")
+            }
+            Self::Internal => gts_id!("cf.core.errors.err.v1~cf.core.err.internal.v1~"),
             Self::ServiceUnavailable => {
-                "gts.cf.core.errors.err.v1~cf.core.err.service_unavailable.v1~"
+                gts_id!("cf.core.errors.err.v1~cf.core.err.service_unavailable.v1~")
             }
-            Self::DataLoss => "gts.cf.core.errors.err.v1~cf.core.err.data_loss.v1~",
-            Self::Unauthenticated => "gts.cf.core.errors.err.v1~cf.core.err.unauthenticated.v1~",
+            Self::DataLoss => gts_id!("cf.core.errors.err.v1~cf.core.err.data_loss.v1~"),
+            Self::Unauthenticated => {
+                gts_id!("cf.core.errors.err.v1~cf.core.err.unauthenticated.v1~")
+            }
         }
     }
 

--- a/libs/toolkit-contract-macros/Cargo.toml
+++ b/libs/toolkit-contract-macros/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 description = "Proc macros for ToolKit contracts"
 rust-version.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lib]
 proc-macro = true
 name = "toolkit_contract_macros"

--- a/libs/toolkit-contract-protogen/Cargo.toml
+++ b/libs/toolkit-contract-protogen/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 description = "Generate idiomatic .proto files from ToolKit ContractIr + JsonSchema"
 rust-version.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lib]
 name = "toolkit_contract_protogen"
 

--- a/libs/toolkit-contract/Cargo.toml
+++ b/libs/toolkit-contract/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 description = "ToolKit contract IR, binding metadata, validation, policy stack, and proc-macro re-exports"
 rust-version.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lib]
 name = "toolkit_contract"
 

--- a/libs/toolkit/src/lib.rs
+++ b/libs/toolkit/src/lib.rs
@@ -102,7 +102,7 @@ pub use toolkit_contract::{
     ContractError, GrpcRepr, GrpcReprScalar, ProtoBridge, QueryParams, consumes, contract,
     grpc_contract, provides, rest_contract,
 };
-pub use toolkit_macros::{ExpandVars, gear, lifecycle};
+pub use toolkit_macros::{ExpandVars, domain_model, gear, lifecycle};
 
 pub mod contract_support {
     // Re-export only the items referenced from generated macro code (see


### PR DESCRIPTION
## Summary

Makes `make dylint` fully green (exit 0, **zero errors and zero warnings**) by bringing the workspace into compliance with the stricter cargo-gears dylint rules.

## Changes by lint

### DE0904 — no hard-coded GTS ID prefix (`Deny`)
Build GTS IDs via `gts_id!("<suffix>")` so the build-time `GTS_ID_PREFIX` stays effective. The macro prepends the prefix, so the emitted `&'static str` values are unchanged.
- `toolkit-canonical-errors`: `ProblemCategory::gts_fragment()` (16 arms)
- `api-contracts` example SDK: `#[resource_error(...)]`

### DE0309 — domain types must carry `#[domain_model]` (`Deny`)
Annotate every `pub` domain struct/enum so DDD boundaries are enforced at compile time.
- `event-broker`: `Topic`, `EventType`, `Event`, `Meta`, `Subscription`, `Assignment`, `GroupState`, `Cursor`, `JoinRequest`, `PollResponse`, `SeekPosition`, `EventBrokerCluster`, `DomainError`, `IdempotencyOutcome`, `BatchResult`
- `file-parser`: `FileParserLocalClient`
- `toolkit`: re-export `domain_model` alongside `gear`/`lifecycle` so `toolkit`-only crates can write `use toolkit::domain_model;`

### DE1201 — publishable crates must set docs.rs all-features (`warn`)
Add `[package.metadata.docs.rs] all-features = true` to: `toolkit-contract`, `toolkit-contract-macros`, `toolkit-contract-protogen`, `bss-ledger-sdk`, `bss-rate-provider-sdk`, `bss-rate-provider`, and the ECB + http-json rate-provider plugins.

## Testing
`make dylint` exits 0 with no errors or warnings.

## Notes
No behavioral changes — GTS ID string values are byte-for-byte identical; the remaining edits are attributes and Cargo manifest metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved hosted API documentation builds by enabling all available features across multiple packages.
  - Expanded documentation support for event-broker and file-parser domain models.

- **Improvements**
  - Standardized validation of resource and problem identifiers.
  - Improved consistency and reliability of public domain model metadata.
  - Made the domain model tooling available through the primary toolkit interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->