### PR TITLE
fix(chat-engine): map authz READ action to "get"

### DIFF
--- a/gears/chat-engine/chat-engine/src/domain/authz/mod.rs
+++ b/gears/chat-engine/chat-engine/src/domain/authz/mod.rs
@@ -15,7 +15,10 @@ pub mod resource_types;
 pub mod actions {
     pub const LIST: &str = "list";
     pub const CREATE: &str = "create";
-    pub const READ: &str = "read";
+    // Aligned with the authorization-engine action vocabulary
+    // ([list, get, create, update, delete]); the gear previously emitted
+    // "read", which is outside that enum and cannot back a read/get ACE.
+    pub const READ: &str = "get";
     pub const UPDATE: &str = "update";
     pub const DELETE: &str = "delete";
 }


### PR DESCRIPTION
The PEP action vocabulary is [list, get, create, update, delete]; the gear emitted "read" for the READ constant, which is outside that enum and cannot back a read/get ACE. Point READ at "get" so read/get authorization decisions resolve against a real action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the authorization action used for read operations from “read” to “get” for improved compatibility with supported authorization terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->