### PR TITLE
fix(account-management): close unbalanced traceability marker in m0005

### DIFF
--- a/gears/system/account-management/account-management/src/infra/storage/migrations/m0005_tenant_metadata_indexes.rs
+++ b/gears/system/account-management/account-management/src/infra/storage/migrations/m0005_tenant_metadata_indexes.rs
@@ -64,7 +64,7 @@ impl MigrationTrait for Migration {
             ],
             _ => {
                 return Err(DbErr::Custom(MYSQL_NOT_SUPPORTED.to_owned()));
-            }
+            } // @cpt-end:cpt-cf-account-management-dbtable-tenant-metadata:p2:inst-dbtable-tenant-metadata-index-schema
         };
 
         for sql in statements {


### PR DESCRIPTION
## Summary

One-line, comment-only fix: adds the missing `@cpt-end` for `cpt-cf-account-management-dbtable-tenant-metadata` (inst `dbtable-tenant-metadata-index-schema`) in `m0005_tenant_metadata_indexes.rs`. The block was opened at line 61 and never closed — the closing marker appears to have been lost in the SeaORM 1.1 → 2.0 upgrade (5446288b).

## Why this matters beyond tidiness

Corrected root cause after archaeology (the earlier "new validator version" framing was wrong — verified by running cfs 1.5.9 against bare `main`, which reports the same single error):

- The `@cpt-end` was deleted by 5446288b (SeaORM 1.1 → 2.0): the explicit `DatabaseBackend::MySql =>` match arm was replaced with a wildcard `_ =>` arm, and the marker comment sitting directly above that arm went with the replaced lines. Comment-only, so nothing compiled differently.
- It reached `main` on Aug 16 00:44 +0800 with the merge of #4553. The first failing `Validate CFS Artifacts` runs in the workflow history appear ~1.5h later — the timeline matches the merge, not any tool update.
- Any validator version flags it; branches based on a pre-merge `main` validate clean locally, which is why the error only surfaces in CI against the merge state. Every PR whose paths trigger the workflow fails on it — we hit it on #4450, where the failing run's single error is this file:

```
✗ gears/system/account-management/account-management/src/infra/storage/migrations/m0005_tenant_metadata_indexes.rs:61 [marker-begin-no-end]
  @cpt-begin for `cpt-cf-account-management-dbtable-tenant-metadata` … was never closed with @cpt-end
```

## Verification

- `@cpt-begin`/`@cpt-end` balance restored (1/1); the end marker mirrors the begin's full `id:prio:inst` form, matching the convention used across account-management.
- Repo-wide `cfs validate` on this branch: 0 errors.
- Comment-only change — no code, no behavior, no migration semantics affected.

