### PR TITLE
feat(file-parser): Add magika support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
     outputs:
       rust:   ${{ steps.filter.outputs.rust }}
       fips:   ${{ steps.filter.outputs.fips }}
+      magika: ${{ steps.filter.outputs.magika }}
       dylint: ${{ steps.filter.outputs.dylint }}
       deps:   ${{ steps.filter.outputs.deps }}
       ci:     ${{ steps.filter.outputs.ci }}
@@ -83,6 +84,8 @@ jobs:
               - 'libs/toolkit/**'
               - 'libs/toolkit-http/**'
               - 'libs/rustls-*/**'
+            magika:
+              - 'gears/file-parser/**'
             dylint:
               - 'tools/dylint_lints/**'
             deps:
@@ -467,6 +470,95 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: cargo check --target x86_64-pc-windows-msvc -p cf-gears-toolkit-http --features fips
+
+  # Builds and tests file-parser's optional `magika` feature so it doesn't
+  # silently rot. `ort`'s own `download-binaries` feature is NOT used here —
+  # it always links statically, which conflicts with `load-dynamic` (baked
+  # into the workspace `ort` dependency for production) and reliably
+  # deadlocks `ort` 2.0.0-rc.12 (confirmed via stack sampling: its
+  # error-reporting path for a failed/incompatible runtime recursively
+  # re-enters the same `OnceLock` it's initializing, blocking the thread
+  # forever instead of returning an error). Instead, this job downloads a
+  # real ONNX Runtime shared library and points `ORT_DYLIB_PATH` at it —
+  # exactly the mechanism production uses. `timeout-minutes` on the test step
+  # is a backstop in case a future regression reintroduces that hang.
+  test-magika:
+    name: Magika feature verification
+    needs: changes
+    if: >-
+      !cancelled()
+      && (needs.changes.result != 'success'
+      || needs.changes.outputs.magika == 'true'
+      || needs.changes.outputs.deps == 'true'
+      || needs.changes.outputs.ci == 'true'
+      || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    env:
+      # api-24 (see workspace Cargo.toml `ort` entry) requires an ONNX
+      # Runtime with minor version >= 24; older builds fail `ort`'s version
+      # check on load. Bump alongside `ort`'s pinned version.
+      ONNXRUNTIME_VERSION: "1.29.0"
+      # sha256 of onnxruntime-linux-x64-1.29.0.tgz. Recompute and bump
+      # alongside ONNXRUNTIME_VERSION.
+      ONNXRUNTIME_SHA256: "c3fddc4f139a045b0c4902c57410f0694f1c2fdf9b6939fbe38b1aeae7cd14ba"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
+
+      - name: Cache Cargo/target
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          cache-bin: false
+          cache-targets: false
+          shared-key: pr-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}-magika
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Probe sccache & set RUSTC_WRAPPER
+        shell: bash
+        run: |
+          if sccache --start-server >/dev/null 2>&1; then
+            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+            echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          else
+            echo "sccache failed, falling back to plain rustc"
+          fi
+
+      - name: Fetch ONNX Runtime shared library
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -sL --fail -o /tmp/onnxruntime.tgz \
+            "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz"
+          echo "${ONNXRUNTIME_SHA256}  /tmp/onnxruntime.tgz" | sha256sum --check
+          tar xzf /tmp/onnxruntime.tgz -C /tmp
+          echo "ORT_DYLIB_PATH=/tmp/onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}/lib/libonnxruntime.so" >> "$GITHUB_ENV"
+
+      - name: cargo test (file-parser, magika feature)
+        shell: bash
+        timeout-minutes: 10
+        run: cargo test -p cf-gears-file-parser --features magika
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
+        with:
+          tool: cargo-deny@0.20.2
+
+      - name: cargo deny check (magika feature)
+        run: make deny-magika
 
   cfs:
     name: CFS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,12 +2211,15 @@ dependencies = [
  "http",
  "inventory",
  "kreuzberg",
+ "magika",
  "mime",
+ "ort",
  "serde",
  "tempfile",
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tokio-util",
  "tracing",
  "utoipa",
  "uuid",
@@ -6766,6 +6769,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "magika"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aee5ecdbd182547ca3dfcd74c5bcd7f8c57384ad03cb79ef6e3bdf8d56abcdf"
+dependencies = [
+ "ndarray",
+ "ort",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6796,6 +6811,16 @@ name = "matchit"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "maybe-owned"
@@ -6984,6 +7009,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
  "rand 0.8.5",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
 ]
 
 [[package]]
@@ -7542,6 +7582,25 @@ name = "org"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdf547b633735ad9d67353aba48b3e685ab5ffb3195aaa9a1b1d8613e11b98c"
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+dependencies = [
+ "libloading 0.9.0",
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 
 [[package]]
 name = "ouroboros"
@@ -8864,6 +8923,12 @@ checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags 2.11.1",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -658,6 +658,20 @@ docx-rust = "0.1.11"
 # `bundled-pdfium` downloads a prebuilt libpdfium at build time rather than vendoring one;
 # Cargo.lock does not pin it. The version lives in .cargo/config.toml as PDFIUM_VERSION.
 kreuzberg = { version = "=4.9.8", features = ["html", "excel", "office", "pdf", "bundled-pdfium"] }
+# Content-based file type detection (ONNX model, embedded weights). Used
+# only by file-parser's optional `magika` feature.
+magika = "1.1"
+# Pinned to match magika 1.1's own `ort` dependency exactly (`=2.0.0-rc.12`).
+# `load-dynamic` is added on top of magika's own feature set (`ndarray`, `std`) so the
+# ONNX Runtime shared library is resolved via `dlopen` at process start (`ORT_DYLIB_PATH`)
+# instead of being statically linked at build time — the gear's build environment never
+# needs the ONNX Runtime dev headers, only wherever the `magika`-enabled binary runs.
+# `download-binaries` (which would fetch a prebuilt runtime over the network during
+# `cargo build`) stays off; magika's own manifest already builds with default features off.
+# `api-24` is required to compile this rc — without it, `ort`'s own `ep/vitis.rs` (compiled
+# unconditionally, not feature-gated) references an `OrtApi` struct field that only exists
+# at the api-24 ABI level; this is unrelated to which execution providers we actually use.
+ort = { version = "=2.0.0-rc.12", default-features = false, features = ["load-dynamic", "api-24"] }
 
 # Additional testing utilities
 tokio-test = "0.4"

--- a/Makefile
+++ b/Makefile
@@ -355,13 +355,20 @@ check-release-config:
 
 # -------- Code security checks --------
 
-.PHONY: deny fips-policy security
+.PHONY: deny deny-magika fips-policy security
 
 # Check licenses and dependencies
 deny:
 	$(call check_tool,cargo-deny)
 	$(call check_deny_version)
 	cargo deny check
+
+# Same as `deny`, but with the file-parser `magika` feature enabled so the
+# ort/ndarray dependency tree it pulls in is also audited.
+deny-magika:
+	$(call check_tool,cargo-deny)
+	$(call check_deny_version)
+	cargo deny --features magika check
 
 ## FIPS dependency-graph policy (see deny-fips.toml + ADR 0005).
 ## Refuses the build if any non-FIPS-validated crypto crate enters the

--- a/apps/cf-gears-example-server/Cargo.toml
+++ b/apps/cf-gears-example-server/Cargo.toml
@@ -41,6 +41,9 @@ bss-rate-provider = [
 bss-ledger = ["dep:bss_ledger"]
 usage-collector = ["dep:usage_collector"]
 timescaledb-usage-collector = ["dep:timescaledb_usage_collector_plugin"]
+# Content-based file type detection in file-parser (see that crate's `magika`
+# feature doc comment for what it pulls in).
+magika = ["file_parser/magika"]
 
 [dependencies]
 mimalloc = { version = "0.1" }

--- a/gears/file-parser/docs/ADR/0001-cpt-cf-file-parser-adr-content-based-type-detection.md
+++ b/gears/file-parser/docs/ADR/0001-cpt-cf-file-parser-adr-content-based-type-detection.md
@@ -1,0 +1,151 @@
+---
+status: proposed
+date: 2026-08-13
+decision-makers: file-parser gear maintainers
+---
+
+# Add feature-gated, Magika-based content sniffing to resolve file type when filename/Content-Type are absent or wrong
+
+**ID**: `cpt-cf-file-parser-adr-content-based-type-detection`
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [Do nothing — keep extension/`Content-Type`-only detection](#do-nothing--keep-extensioncontent-type-only-detection)
+  - [Pure-Rust magic-byte sniffing (`infer` or `file-format`)](#pure-rust-magic-byte-sniffing-infer-or-file-format)
+  - [Delegate to Kreuzberg's own MIME detection](#delegate-to-kreuzbergs-own-mime-detection)
+  - [Magika (ONNX ML content classifier), feature-gated behind `magika`](#magika-onnx-ml-content-classifier-feature-gated-behind-magika)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+## Context and Problem Statement
+
+`FileParserService` (`domain/service.rs`) currently routes every request to a parser backend using only the filename extension, falling back to a client-supplied `Content-Type` header. It never inspects file bytes. This means `parse_local` hard-rejects extensionless files, `parse_bytes` rejects uploads that have neither a filename nor a recognized `Content-Type` (a case the SDK's own `ParseBytesRequest` doc comment already anticipates), a wrong extension silently routes to the wrong parser, and `ImageParser` trusts an `image/*` `Content-Type` header without checking the bytes — a trust boundary problem, since a caller-supplied header is never a substitute for verifying what the bytes actually are. `DESIGN.md:181-187` already assigns format detection to the gateway, not the plugins, so the gateway is where this must be fixed. How should the gateway determine file type when the filename/`Content-Type` hints are missing or wrong, without imposing a new mandatory runtime dependency on every consumer of the gear? Note that this ADR only *mitigates* the `ImageParser` trust-boundary problem rather than eliminating it — see the "Consequences" section below.
+
+## Decision Drivers
+
+* Callers cannot always be trusted to supply a correct filename or `Content-Type`
+* The three existing extension→MIME tables have already drifted and must collapse to one
+* Default build behavior and error messages must stay byte-for-byte identical for gear consumers who never opt in, with one intentional, narrowly-scoped exception from collapsing the three drifted tables into one canonical table (see "Consequences"): feature-off `Content-Type`-only routing now also resolves `xlsx`/`xls`/`xlsm`/`xlsb`/`pptx`. The canonical table is used only to fill in a *missing* `Content-Type` — an explicitly supplied `Content-Type` always passes through to the backend unchanged, regardless of whether the resolved extension has a canonical-table entry (an explicit header is a stronger signal than a filename extension, so the table must never silently override it). Both halves are pinned by tests in `detection_precedence_tests.rs`.
+* Callers that already know the exact type they're passing (in particular, in-process callers going through `ClientHub`/the SDK, e.g. `FileParserLocalClient::parse_bytes`) can set `ParseBytesRequest::detection` to `Detection::Skip` to bypass content-based detection entirely and route purely off `filename`/`content_type`, even when a detector is registered — detection there buys nothing but latency and a chance of misrouting a type the caller is certain of. The public REST upload endpoints do not expose this — every request through them is always detected, per the "callers are not trusted" driver above.
+* Detection must add bounded, predictable latency — parsing runs in a request path, not a batch job
+* Whatever mechanism is chosen must resolve the actual formats this gear supports today (PDF, HTML, DOCX, XLSX, PPTX, PNG/JPEG/WEBP/GIF, incl. OOXML formats that share a ZIP container)
+* No new dependency, binary size, or native-library requirement may land on the default build path
+* The gear has no ADRs yet; this sets the precedent for how model/runtime dependencies get introduced
+
+## Considered Options
+
+* Do nothing — keep extension/`Content-Type`-only detection
+* Pure-Rust magic-byte sniffing (e.g. `infer` or `file-format` crates)
+* Delegate to Kreuzberg's own MIME/format detection
+* Magika (ONNX ML content classifier), feature-gated behind `magika`
+
+## Decision Outcome
+
+Chosen option: "Magika (ONNX ML content classifier), feature-gated behind `magika`", because it is the only option that reliably distinguishes the OOXML-family formats this gear must support (DOCX/XLSX/PPTX are all ZIP containers that magic-byte sniffing cannot tell apart without deep-parsing the archive), and feature-gating confines its runtime/binary cost to deployments that actually need it, per `DESIGN.md:85`'s assignment of detection to the gateway.
+
+### Consequences
+
+* `infra/` gains a `MagikaDetector` implementing a new `domain`-defined `ContentTypeDetector` trait, injected into `FileParserService` as `Option<Arc<dyn ContentTypeDetector>>`; with the `magika` feature off, this is always `None` and every code path is identical to today's behavior, including error message text.
+* `EXTENSION_MIME_MAPPINGS` (`domain/service.rs:14-27`), the Kreuzberg-parser table (`infra/parsers/kreuzberg_parser.rs:44-57`), and the image-parser table (`infra/parsers/image_parser.rs:47-61`) collapse into one canonical extension↔MIME table in `domain/`; all three call sites (and the new Magika label→extension map) read from it. This is the union of the three previous tables, so it also changes feature-off routing: a `Content-Type`-only request (no filename) for `xlsx`, `xls`, `xlsm`, `xlsb`, or `pptx` now resolves to a MIME type and routes to `KreuzbergParser` even when the `magika` feature is not compiled in, whereas previously only `pdf`/`html`/`htm` resolved this way at the gateway. This is intentional: these formats were already routable via filename extension and via Kreuzberg's own table; the canonical table just makes `Content-Type`-only requests consistent with that.
+* Detection precedence becomes: (1) if the `magika` feature is compiled in and the detector loaded successfully, run content detection on every request, not only when the extension/`Content-Type` are missing; (2) if the detected label maps to a supported extension with confidence ≥ 0.90, that extension wins routing — this is what lets a wrong extension resolve to the correct parser; (3) below 0.90 confidence, or when the label maps to no supported extension, fall back to the extension/`Content-Type`-derived value exactly as today; (4) with the feature off, or with it on but the extension/`Content-Type` agreeing with a confident detection, behavior and routing are unchanged from today.
+* This ADR mitigates, but does not eliminate, the `ImageParser` trust-boundary problem: a caller-supplied `image/*` `Content-Type` hint still selects `ImageParser` without byte validation whenever Magika is not compiled in, doesn't run, or scores below 0.90 confidence on the actual bytes. Fully closing this gap (e.g. mandatory content validation before `ImageParser` selection regardless of detector confidence) is deferred to a future ADR.
+* Every disagreement between the detected type and the caller-supplied extension/`Content-Type` at ≥ 0.90 confidence is logged at `WARN` with both values, so operators can see when clients are sending an incorrect type hint without the gateway hard-failing the request. A metric on this signal is deferred to a future iteration.
+* `parse_bytes` runs detection on the full in-memory buffer after the existing `max_file_size_bytes` check, never before — the size check is cheap and must reject oversized uploads before any CPU is spent on inference.
+* `parse_local` runs detection whenever a detector is registered — not only when the extension is absent — mirroring `parse_bytes`'s precedence, so a present-but-wrong extension is corrected the same way for local files. Detection does **not** buffer the file: it goes through `ContentTypeDetector::detect_path`, backed by `magika::Session::identify_file_sync`, which seeks to the head/tail blocks the model needs instead of reading the whole file (and avoids duplicating the read the backend then performs itself).
+* The `max_file_size_bytes` limit is enforced in `parse_local` unconditionally, before a backend is selected and regardless of whether a detector is registered — a feature flag must not change the size-limit contract. That check reads `metadata().len()`, so it is not atomic against a file growing afterwards; it exists to reject oversized files early with a message naming the actual size. The actual memory bound is each backend's own bounded read (`infra::parsers::bounded_read::read_bounded`, a `Read::take` against a single open handle). `KreuzbergParser` is the exception: it hands the path to `kreuzberg`, which reads the file itself, so only the metadata check applies there.
+* Because `ort`'s inference call is synchronous and CPU-bound, `MagikaDetector` executes it inside `spawn_blocking`; the `magika::Session` is constructed once, eagerly, at gear startup (not lazily on first request), so cold-load latency and any missing-runtime/model failure surface at boot, not on a user request.
+* With the `magika` feature compiled in, failure to load the ONNX Runtime shared library or the embedded model is a **startup failure**, not a silent fallback to extension-only routing — a gear that silently disabled detection would reintroduce exactly the spoofable-`Content-Type` risk this ADR exists to close. Operators who need best-effort behavior must build without the feature.
+* `ort` 2.0.0-rc.12 does not fail cleanly on its own: when the runtime it loads is missing, the wrong architecture, or older than the ONNX Runtime C API level (`api-24`, i.e. the API surface shipped starting with ONNX Runtime 1.24.x — CI provisions 1.29.0) the `ort` build was compiled against, the call **hangs forever instead of returning an error**. Reproduced directly against a nonexistent `ORT_DYLIB_PATH`: `magika::Session::new()` returns neither `Ok` nor `Err`, and does not panic, within 45s. We deliberately do *not* claim a mechanism: an earlier version of this ADR attributed it to `ort`'s error-reporting path recursively re-entering the `OnceLock` behind `ort::api()`, but that explanation is contradicted by `ort::init_from(path)` — which never touches that lock — hanging on the same input, also verified at 45s. Treat it as an observed property of an unloadable `ORT_DYLIB_PATH`.
+* There is consequently **no pre-flight validation available**. `ort::init_from(path)` is the obvious candidate (it takes a dylib path and returns `Result`) and does not work; every `ort` entry point funnels through the same lazy dylib initialization. So the timeout-and-abandon workaround cannot be replaced by a cheap "check the runtime first" call, and anyone attempting that simplification should re-run the two 45s probes before concluding otherwise. No upstream issue has been filed as of 2026-08-18; the `init_from` reproduction is the useful thing to report against `pykeio/ort`.
+* `MagikaDetector`'s constructor (`with_config`) is therefore never called directly from `gear.rs`; it runs on a detached `std::thread` (not `tokio::task::spawn_blocking`, whose threads Tokio joins on runtime shutdown — a wedged one would hang shutdown too), with the result awaited through a `oneshot` channel under a 30s `tokio::time::timeout`. A broken runtime surfaces as a startup error after 30s instead of an indefinite hang, at the cost of leaking one OS thread for the life of the process in that failure case. That leak is only bounded because gear-init failure terminates the host; `MagikaInitError::leaked_init_thread()` encodes which failures carry the obligation, so a future non-fatal caller has to confront it in code rather than in a comment.
+* Exclusive access per inference is forced by `magika`'s API, not by ONNX Runtime. `ort::session::Session` is `Send + Sync` and ONNX Runtime is designed for one session shared across threads (the `&mut self` on `ort`'s `run` is a borrow-lifetime device for the returned outputs), but `magika::Session` keeps its inner session private and exposes only `&mut self` methods, so none of that is reachable. A mutex is unavoidable while going through `magika`; if detection throughput ever matters, the fix is upstream, not more sessions. The detector therefore holds **one** session, serialized behind a fair FIFO mutex, and exposes ONNX Runtime's intra-op thread count (`magika_intra_op_threads`) as the CPU knob instead of a session count. Measured: ~3.5 ms per detection and ~6 extra OS threads at ONNX Runtime's default, versus ~9.3 ms pinned to a single thread — so one session sustains ~285 detections/second against document extraction costing tens to hundreds of milliseconds on the same request.
+* `magika`'s async API (`identify_content_async` / `identify_file_async`) must **not** be used, despite being the obvious way to avoid `spawn_blocking`. `ort`'s `InferenceFut::drop` calls `RunOptions::terminate()`, which sets a sticky flag that only `unterminate()` clears, and `magika` passes a single process-wide `static OnceLock<RunOptions>` to every async run without ever unterminating. The first dropped async inference future would therefore disable async inference for the entire remaining process lifetime — in a request path, one client disconnect would silently kill detection. This is an upstream `magika` bug; until it is fixed, the `_sync` methods on `spawn_blocking` are mandatory rather than merely conventional.
+* `magika` 1.1.0's own manifest already pins `ort = "=2.0.0-rc.12"` with `default-features = false` and only `features = ["ndarray", "std"]` — `ort`'s `download-binaries` default is already off for every consumer of `magika`, with no action needed on our side to keep the network fetch out of `cargo build`. That resolved dependency set enables **neither** `download-binaries` **nor** `load-dynamic`, so by default `ort` falls back to build-time static linking against a system ONNX Runtime install, located via `ORT_LIB_LOCATION` (or `pkg-config`) — meaning the ONNX Runtime dev headers/libs would need to be present in *every* environment that compiles `file-parser` with `--features magika`, not just wherever it eventually runs.
+* We add an explicit `[workspace.dependencies]` entry, `ort = { version = "=2.0.0-rc.12", default-features = false, features = ["load-dynamic", "api-24"] }`, layered on top of Magika's own feature set — `ndarray` and `std` are not declared directly here because `magika` already contributes them transitively, while `api-24` **must** be declared (without it `ort`'s unconditionally-compiled `ep/vitis.rs` references an `OrtApi` field that only exists at that ABI level). Copy the entry as written; dropping `api-24` breaks the build. `load-dynamic` makes `ort` `dlopen` the ONNX Runtime shared library at process start (path supplied via the `ORT_DYLIB_PATH` env var, or a well-known default search path) instead of linking against it at compile time. This decouples "who builds the gear" from "who has the ONNX Runtime installed": CI here runs on plain GitHub-hosted `ubuntu-latest`/macOS runners with no per-gear container or custom base image (`.github/workflows/ci.yml`), so requiring onnxruntime dev headers at *build* time on every such runner is a heavier, more fragile ask than requiring the shared library only where the `magika`-enabled binary actually runs.
+* `ort/download-binaries` was considered and rejected for CI, not just for production: it always links **statically** (verified by reading `ort-sys`'s build script), which is incompatible with `load-dynamic` — already active for every `magika` build via the workspace `ort` entry — and reliably reproduces the deadlock above (a `dlopen` attempt against a static `.a` fails, triggering the same recursive-`OnceLock` hang). This isn't a macOS-only artifact of local testing; `ort-sys` links statically via `download-binaries` on every platform, so the originally-proposed CI job would have hung on Linux runners too.
+* CI instead downloads the official ONNX Runtime shared-library release directly (`onnxruntime-linux-x64-<version>.tgz` from `microsoft/onnxruntime`'s GitHub releases, pinned to 1.29.0, which satisfies the `api-24` C API level `ort` requires) and points `ORT_DYLIB_PATH` at the extracted `.so` — the same `load-dynamic` mechanism production uses, just with CI choosing to fetch the library itself rather than assuming it's preinstalled. This was verified end-to-end locally (macOS build, official `onnxruntime-osx-arm64` release): real Magika inference against a PDF byte stream succeeds with high confidence. The `cargo test` step also carries a `timeout-minutes` job-level backstop, since a future regression reintroducing the hang above would otherwise consume the runner indefinitely. Provisioning the shared library for actual deployments (which pinned release, fetched/installed how, on which runtime images) remains a separate, deploy-time decision out of scope for this ADR.
+* `deny.toml` needs no new `ignore` entries for Magika itself (Apache-2.0, already allow-listed via the existing Kreuzberg precedent), but `cargo deny check` must be run with `--features magika` in CI to catch any advisory or license issue in the `ort`/`ndarray` transitive tree; any suppression found gets a justification comment in the same style as the existing `kreuzberg` entries in `deny.toml:41-43`.
+* `file-parser-sdk`'s public types are unaffected, and so is rendered error text: an unsupported detected label never reaches routing at all. `MagikaDetector` intersects Magika's labels with the registered `supported_extensions()` and yields `None` for anything outside that set, and `FileParserService::reconcile_extension` independently requires a registered parser for the detected extension before letting it win — so a confident `"zip"` detection falls back to the caller's hint rather than producing an error naming `"zip"`. Golden error-message tests are therefore unchanged in **both** feature states.
+Surfacing detection confidence/label in the SDK response (`ParsedText`) is explicitly deferred to a future iteration/ADR — this decision does not change the plugin trait (`FileParserBackend`) or the SDK response shape.
+* Magika's ~200 output labels map through a single new `magika_label -> extension` table to only the extensions this gear's registered plugins already declare via `supported_extensions()`; a confidently-detected label with no entry in that table (e.g. `"zip"`, `"mp4"`) is treated as "detection did not help": it is discarded and routing falls back to the caller's extension / `Content-Type` hint, so such a request behaves exactly as it does today with the feature off, rather than producing a new error class.
+* `DESIGN.md:181-187` (the gateway routing algorithm) must be updated to describe the detector as an optional step 0 ahead of today's steps 1–3.
+
+### Confirmation
+
+* Unit tests for `MagikaDetector` (label→extension mapping, confidence threshold behavior) and for `FileParserService` precedence logic, run twice in CI — once with the `magika` feature off (detector absent, behavior identical to pre-ADR baseline) and once with it on.
+* Integration tests covering the three acceptance scenarios from the tracking issue: an extensionless local file parses; a byte upload with no filename and `Content-Type: application/octet-stream` parses; a file with a wrong extension (e.g. a DOCX saved with a `.pdf` name) routes to the DOCX parser and succeeds.
+* `cargo deny check --features magika` passes in CI with no new unjustified advisories.
+* Code review confirms the default-feature build has no new entries in `cargo tree` and that golden error-message tests (already covering `unsupported_file_type`/`no_parser_available`) pass unmodified **for default-feature (`magika` off) runs**; with the feature on, an unsupported *detected* type populates `extension` with the detected label rather than the literal `"no extension"`, per "Consequences" — that is an expected, feature-on-only change in rendered error text, not a regression.
+* **What would validate the 0.90 threshold, and what does not exist yet.** Nothing in this iteration produces the signal needed to tune it: the per-request `WARN` on a detected/hinted disagreement cannot be aggregated or alerted on, and the `file_parser_type_mismatch_total` counter this ADR originally committed to is explicitly deferred (see "Consequences"). Until a metric lands, the threshold is set by judgement, not evidence, and the honest position is that we do not know its false-override rate in production. What *does* exist is a `file_parser.detect` tracing span around every detection and a `magika.inference` span inside the detector, so detection's latency contribution is attributable in a trace without enabling `debug` logging — spans were chosen over a metric because this gear emits no metrics at all and adding that infrastructure is out of scope here. Revisiting the threshold should begin by adding the mismatch counter.
+
+## Pros and Cons of the Options
+
+### Do nothing — keep extension/`Content-Type`-only detection
+
+Leave `parse_local`/`parse_bytes` as they are; only consolidate the three MIME tables.
+
+* Good, because zero new dependencies, zero new runtime/CI/container work
+* Good, because zero risk of a new failure mode (model/runtime load failure)
+* Neutral, because the table consolidation (already useful on its own) still happens
+* Bad, because it does not fix any of the four concrete failure cases in the tracking issue — extensionless files, `octet-stream`-with-no-filename uploads, wrong-extension misrouting, and unchecked image `Content-Type` all remain unresolved
+* Bad, because the unresolved image-`Content-Type` trust gap leaves this gear returning parsed content for whatever type the caller *claims* the bytes are, not what they actually are — the primary reason this issue was filed
+
+### Pure-Rust magic-byte sniffing (`infer` or `file-format`)
+
+Sniff a small byte prefix against a table of known magic-number signatures; no ML model, no native runtime, pure Rust.
+
+* Good, because it is a pure-Rust dependency: no `ort`, no native shared library, no embedded model weights, trivially usable as a default (non-feature-gated) dependency
+* Good, because inference is a table lookup — sub-microsecond, no `spawn_blocking` needed
+* Good, because it fixes the extensionless-file and `octet-stream`-upload cases for formats with a distinct magic number (PDF, PNG, JPEG, GIF, WEBP)
+* Bad, because DOCX/XLSX/PPTX are all `PK\x03\x04` ZIP containers at the byte level; magic-byte sniffing alone cannot tell them apart, and these three formats are core to this gear's supported set — a signature crate would need bespoke ZIP-central-directory parsing to distinguish them, which is materially the same integration cost as adopting a purpose-built classifier
+* Bad, because plain-text-ish formats (HTML) have no reliable magic number and would still fall back to extension/`Content-Type` heuristics
+* Bad, because it does not close the `ImageParser` trust gap any better than "good enough for images" — it *would* fix that specific case, but leaves the office-document cases (the majority of this gear's traffic per `DESIGN.md`) unresolved
+
+### Delegate to Kreuzberg's own MIME detection
+
+Kreuzberg (already a dependency, MIT/Elastic-2.0-licensed, used for PDF/DOCX/etc.) reportedly does some internal format sniffing; call into that instead of adding a new dependency.
+
+* Good, because no new dependency if Kreuzberg's internal detection is reachable and licensable for this purpose
+* Bad, because Kreuzberg's detection is invoked *after* a parser is already selected — using it to *select* the parser would require restructuring Kreuzberg's own entry points or duplicating its internal logic outside the crate boundary, which is not something this gear controls (Kreuzberg is an upstream Elastic-2.0 dependency, not code we can extend)
+* Bad, because it does nothing for the `ImageParser`/non-Kreuzberg formats (PNG/JPEG/WEBP/GIF), which are handled by a separate, unrelated backend
+* Bad, because it couples this gear's routing logic to an upstream library's internal (and undocumented, for this purpose) behavior rather than a purpose-built, versioned API
+
+### Magika (ONNX ML content classifier), feature-gated behind `magika`
+
+Google's small ONNX model, ~200 content-type labels, wrapped by the `magika` crate (Apache-2.0). Chosen option — added as an optional dependency behind a new `magika` Cargo feature, off by default.
+
+* Good, because it distinguishes OOXML formats (DOCX/XLSX/PPTX) and the image/PDF/HTML formats this gear supports from content alone, addressing every case in the tracking issue including — per the confidence threshold and fallback behavior discussed in "Consequences" — mitigating (not eliminating) the `ImageParser` `Content-Type`-trust gap
+* Good, because feature-gating means the default build — and every consumer who does not opt in — pays zero cost: no `ort`, no `ndarray`, no embedded model bytes, and behavior/error messages identical to before this ADR (with the one exception noted in "Decision Drivers"/"Consequences": the canonical MIME table also widens feature-off `Content-Type`-only routing for `xlsx`/`xls`/`xlsm`/`xlsb`/`pptx`)
+* Good, because the model ships embedded in the crate (`include_bytes!`); no network fetch of weights at build or run time
+* Neutral, because it is the first ONNX/`ort` dependency in this workspace, setting precedent for how such dependencies are vetted, built, and shipped (this ADR is that precedent)
+* Bad, because it requires the ONNX Runtime shared library to be present wherever the `magika`-enabled binary runs (via `ort/load-dynamic`, resolved at process start) — a new ops dependency for the runtime/container image that `infer`/`file-format` would not need
+* Bad, because it adds ~2.8 MB of embedded model weight and pulls in `ort` + `ndarray` for any consumer who does enable the feature
+* Bad, because inference is CPU-bound and synchronous, requiring `spawn_blocking` discipline in the gateway that a pure lookup-table approach would not need
+* Bad, because confidence-threshold and mismatch-handling policy (this ADR's Consequences section) is new decision surface that a magic-byte or do-nothing approach would not introduce
+
+## More Information
+
+The 0.90 confidence threshold and the "log, don't hard-fail" mismatch policy are initial values, not empirically tuned; `TEST-ADR-002`-style validation (real-world mismatch-rate telemetry, were a metric added in a future iteration per "Consequences") may justify revisiting them without requiring a new ADR — see Confirmation. Because the threshold is expected to move, it is a configuration key (`detection_confidence_threshold`, default `0.90`) rather than a constant, so tuning it per deployment does not require a recompile; `Gear::init` rejects values outside `[0.0, 1.0]` at startup rather than clamping a value an operator plainly did not mean.
+
+## Traceability
+
+- **PRD**: [PRD.md](../PRD.md)
+- **DESIGN**: [DESIGN.md](../DESIGN.md)
+
+This decision directly addresses the following requirements or design elements:
+
+* `cpt-cf-file-parser-fr-formats` — content-based detection lets uploads reach the correct backend for a supported format even when the filename/`Content-Type` hint is absent or wrong, which is this requirement's actual intent
+* `cpt-cf-file-parser-fr-local-path-security` — detection for extensionless local paths runs only after the existing `..`-rejection/canonicalization/base-dir checks in `parse_local`; this decision does not relax that ordering
+* `cpt-cf-file-parser-fr-plugin-extensibility` — the `magika_label -> extension` map is validated against each registered plugin's `supported_extensions()`, not a hardcoded parser list, so new plugins are picked up without touching the detector
+* `cpt-cf-file-parser-nfr-response-time` — the eager, once-at-startup `Session` load and `spawn_blocking`-wrapped, per-request inference are chosen specifically to keep steady-state request latency bounded and predictable
+* `cpt-cf-file-parser-component-parser-service` (`fdd-file-parser-component-parser-v1`) — `FileParserService`'s routing algorithm gains an optional detection step; `DESIGN.md:181-187` must be updated to reflect it
+* `cpt-cf-file-parser-component-parser-backend` (`fdd-file-parser-component-backend-v1`) — type *resolution* stays entirely in the gateway, consistent with `DESIGN.md:85`, but the trait does change: `parse_local_path` gains a `resolved_content_type: Option<&str>` parameter so the gateway can hand a backend the type it resolved instead of the backend re-deriving one from a possibly-wrong on-disk extension. Implementations must accept the updated local-path signature; those that route purely by filename may ignore the argument

--- a/gears/file-parser/docs/DESIGN.md
+++ b/gears/file-parser/docs/DESIGN.md
@@ -46,6 +46,10 @@ Five plugins are shipped with this version, covering PDFs, HTML, spreadsheets, p
 
 `kreuzberg` ≥ 4.8.0 uses Elastic License 2.0 (EL-2.0). The dependency is pinned at `=4.9.4`. An explicit exception is declared in `deny.toml` with rationale: Gears' document parsing is not sold as a standalone competing product. Any upgrade requires re-verifying the exception still applies.
 
+#### Architecture Decisions
+
+- `cpt-cf-file-parser-adr-content-based-type-detection` — [ADR-0001](./ADR/0001-cpt-cf-file-parser-adr-content-based-type-detection.md): routing may be driven by *content* rather than by the caller-supplied filename extension / `Content-Type`, behind the optional `magika` feature. Records the confidence threshold and fallback policy, why detection failure is a startup failure rather than a silent degradation, and the ONNX Runtime constraints that shape the implementation.
+
 ### 1.3 Architecture Layers
 
 ```
@@ -178,13 +182,15 @@ REST endpoints: `/file-parser/v1/info`, `/file-parser/v1/upload`, `/file-parser/
 **ID**: [ ] `p1` `fdd-file-parser-component-parser-v1`
 
 <!-- fdd-id-content -->
-`FileParserService` (`src/domain/service.rs`) — the parsing gateway. Holds an ordered registry of `FileParserBackend` plugins populated at gear startup. For each request:
+`FileParserService` (`src/domain/service.rs`) — the parsing gateway. Holds an ordered registry of `FileParserBackend` plugins populated at gear startup, plus an optional `ContentTypeDetector` (see
+`docs/ADR/0001-cpt-cf-file-parser-adr-content-based-type-detection.md`). For each request:
+0. If a detector is registered (only possible with the gear built with `--features magika`), runs content-based detection on every request — including over a present-but-wrong filename extension / `Content-Type`. A detection at ≥ 0.90 confidence overrides routing **only when its label maps to an extension a registered parser actually claims** — enforced by the gateway itself (`reconcile_extension` re-checks `find_parser_by_extension`), not only by the detector implementation, so a third-party `ContentTypeDetector` that reports an unregistered extension cannot turn a request the hint would have satisfied into `no_parser_available`. A disagreement with the hint is logged at `WARN`. Below that confidence, or when the label maps to no supported extension, or with no detector registered, falls through to step 1 using the hint-derived extension unchanged.
 1. Determines the file extension from the filename hint or Content-Type header.
 2. Iterates the plugin registry and selects the first plugin whose `supported_extensions()` contains the extension.
 3. Returns HTTP 400 if no plugin matches.
 4. Delegates to the selected plugin's `parse_bytes` or `parse_local_path` method.
 
-The gateway also enforces file size limits and path-traversal protection. It has no format-specific logic of its own.
+The gateway also enforces file size limits and path-traversal protection. It has no format-specific logic of its own. With no detector registered — the default, and the only possibility without the `magika` feature — steps 1-4 are the entire algorithm and behavior is unchanged from before content-based detection existed.
 <!-- fdd-id-content -->
 
 #### Parser Plugins
@@ -255,7 +261,15 @@ Internal Rust trait (`src/domain/parser.rs`) that every parser plugin must imple
 pub trait FileParserBackend: Send + Sync {
     fn id(&self) -> &'static str;
     fn supported_extensions(&self) -> &'static [&'static str];
-    async fn parse_local_path(&self, path: &Path) -> Result<ParsedDocument, DomainError>;
+    /// `resolved_content_type` is the canonical MIME for the extension the
+    /// gateway used to select this backend — which may come from content
+    /// detection overriding the file's own extension. When `Some`, use it
+    /// instead of re-deriving a MIME from `path`.
+    async fn parse_local_path(
+        &self,
+        path: &Path,
+        resolved_content_type: Option<&str>,
+    ) -> Result<ParsedDocument, DomainError>;
     async fn parse_bytes(
         &self,
         filename_hint: Option<&str>,
@@ -264,6 +278,11 @@ pub trait FileParserBackend: Send + Sync {
     ) -> Result<ParsedDocument, DomainError>;
 }
 ```
+
+Backends that read a whole local file into memory must do so through
+`infra::parsers::bounded_read::read_bounded`, not `tokio::fs::read`: the
+service's up-front size check reads `metadata()` and so is not atomic against
+the file growing afterwards.
 
 Plugin registration is done at gear startup in `src/gear.rs`. The gateway selects the first registered plugin whose `supported_extensions()` contains the requested extension. Future versions may add a `priority() -> i32` method to allow explicit priority-based selection when multiple plugins claim the same extension.
 
@@ -316,6 +335,24 @@ File Parser is stateless and does not own any database tables or persistent stor
 file_parser:
   max_file_size_mb: 100              # optional; default 100 MB
   allowed_local_base_dir: /data/uploads   # required; gear fails to start if absent
+  detection_confidence_threshold: 0.90  # optional; default 0.90. Minimum detector confidence, in
+                                      # [0.0, 1.0], at which content detection may override the
+                                      # caller's filename / Content-Type hint. Below it the hint
+                                      # wins. Configurable because ADR-0001 records 0.90 as an
+                                      # initial value rather than a tuned one; the gear fails to
+                                      # start on a value outside [0.0, 1.0] instead of clamping.
+                                      # Only has effect when a detector is registered.
+  magika_intra_op_threads: 2         # optional; leave unset (recommended). Only used with the
+                                      # `magika` feature — ONNX Runtime intra-op thread count for
+                                      # the detector's single magika::Session. Unset leaves ONNX
+                                      # Runtime's own default: measured ~6 threads and ~3.5 ms per
+                                      # detection on a 10-core host. Lower it only when detection
+                                      # must not contend with other CPU-bound work, and note the
+                                      # latency cost: ~5.6 ms at 2, ~9.3 ms at 1. There is no
+                                      # session-count setting: magika::Session needs &mut self per
+                                      # inference and each session brings its own thread pool and
+                                      # model copy, so detection is serialized through one session
+                                      # and tuned here.
 ```
 
 ### Error Mapping

--- a/gears/file-parser/file-parser-sdk/src/lib.rs
+++ b/gears/file-parser/file-parser-sdk/src/lib.rs
@@ -14,4 +14,4 @@ pub mod models;
 
 pub use client::FileParserClientV1;
 pub use errors::FileParserClientError;
-pub use models::{ParseBytesRequest, ParsedText};
+pub use models::{Detection, ParseBytesRequest, ParsedText};

--- a/gears/file-parser/file-parser-sdk/src/models.rs
+++ b/gears/file-parser/file-parser-sdk/src/models.rs
@@ -1,5 +1,20 @@
 use bytes::Bytes;
 
+/// Whether `file-parser` should run content-based type detection on a
+/// request, or route purely off the caller-supplied `filename` /
+/// `content_type` hints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Detection {
+    /// Run content-based detection when a detector is registered — lets a
+    /// confident detection correct a wrong or missing hint.
+    #[default]
+    Auto,
+    /// Skip detection even when a detector is registered, for callers that
+    /// already know the exact type they're passing. Detection costs latency
+    /// and can misroute a type the caller is certain of.
+    Skip,
+}
+
 /// Raw bytes to extract text from, plus the hints `file-parser` uses to pick
 /// a backend (see `file_parser::domain::service::FileParserService::parse_bytes`).
 #[derive(Debug, Clone)]
@@ -11,12 +26,13 @@ pub struct ParseBytesRequest {
     pub content_type: Option<String>,
     /// Raw file bytes.
     pub bytes: Bytes,
+    /// Content-based type detection mode for this request.
+    pub detection: Detection,
 }
 
 /// Extracted text for a parsed attachment, rendered as Markdown so it can be
-/// scanned as plain text by consumers (e.g. `scan-gateway`'s detector
-/// plugins, which only operate on `String` payloads) or injected into an
-/// LLM prompt.
+/// scanned as plain text by consumers that only operate on `String` payloads,
+/// or injected into an LLM prompt.
 #[derive(Debug, Clone)]
 pub struct ParsedText {
     /// Markdown rendering of the parsed document.

--- a/gears/file-parser/file-parser/Cargo.toml
+++ b/gears/file-parser/file-parser/Cargo.toml
@@ -18,6 +18,15 @@ name = "file_parser"
 [lints]
 workspace = true
 
+[features]
+default = []
+# Content-based file type detection using the Magika ONNX model. Off by
+# default: pulls in ort (ONNX Runtime) + ndarray and ~3 MB of embedded model
+# weights, and needs libonnxruntime at runtime (dlopen via `ORT_DYLIB_PATH`).
+# Enable when callers cannot be trusted to send correct filenames or
+# Content-Type headers.
+magika = ["dep:magika", "dep:ort", "dep:tokio-util"]
+
 [dependencies]
 # Local dependencies
 file-parser-sdk = { package = "cf-gears-file-parser-sdk", version = "0.1.0", path = "../file-parser-sdk" }
@@ -61,6 +70,11 @@ tempfile = { workspace = true }
 
 # Document parsing libraries
 kreuzberg = { workspace = true }
+
+# Content-based file type detection (optional, behind the `magika` feature)
+magika = { workspace = true, optional = true }
+ort = { workspace = true, optional = true }
+tokio-util = { workspace = true, optional = true }
 
 # MIME type parsing
 mime = { workspace = true }

--- a/gears/file-parser/file-parser/src/api/rest/handlers.rs
+++ b/gears/file-parser/file-parser/src/api/rest/handlers.rs
@@ -16,6 +16,7 @@ use crate::api::rest::dto::{
 use crate::domain::error::DomainError;
 use crate::domain::markdown::MarkdownRenderer;
 use crate::domain::service::FileParserService;
+use file_parser_sdk::Detection;
 use toolkit::api::canonical_prelude::*;
 use toolkit_security::SecurityContext;
 
@@ -129,8 +130,16 @@ pub async fn upload_and_parse(
         .into());
     }
 
+    // REST is a public, untrusted-caller entry point — always detect,
+    // regardless of `Detection::Skip` (SDK/ClientHub-only, see
+    // `file_parser_sdk::ParseBytesRequest`).
     let document = svc
-        .parse_bytes(filename_opt, content_type_str.as_deref(), body)
+        .parse_bytes(
+            filename_opt,
+            content_type_str.as_deref(),
+            body,
+            Detection::Auto,
+        )
         .await?;
 
     // Optionally render markdown
@@ -239,7 +248,9 @@ pub async fn upload_and_parse_markdown(
         "Processing uploaded file for Markdown streaming"
     );
 
-    let document = svc.parse_bytes(Some(&file_name), None, file_bytes).await?;
+    let document = svc
+        .parse_bytes(Some(&file_name), None, file_bytes, Detection::Auto)
+        .await?;
 
     // Create streaming response - render_iter takes ownership of document
     let stream = stream::iter(

--- a/gears/file-parser/file-parser/src/config.rs
+++ b/gears/file-parser/file-parser/src/config.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -14,6 +15,34 @@ pub struct FileParserConfig {
     /// are allowed.  The gear will fail to start if this field is missing or
     /// the path cannot be resolved.
     pub allowed_local_base_dir: PathBuf,
+
+    /// ONNX Runtime intra-op threads for the detector's single
+    /// `magika::Session`. Only used with the `magika` feature.
+    ///
+    /// `None` (default, recommended) keeps ONNX Runtime's own default: measured
+    /// ~6 threads and ~3.5 ms per detection on a 10-core host. Lower it only to
+    /// stop detection contending with other CPU-bound work, at a real latency
+    /// cost — ~5.6 ms at `2`, ~9.3 ms at `1`.
+    ///
+    /// There is no session-*count* setting: `magika::Session` needs `&mut self`
+    /// per inference and each session carries its own thread pool and model
+    /// copy, so N sessions multiply both. See `infra::magika_detector`.
+    #[serde(default)]
+    pub magika_intra_op_threads: Option<NonZeroUsize>,
+
+    /// Minimum detector confidence, in `[0.0, 1.0]`, at which content detection
+    /// may override the caller's filename / `Content-Type` hint. Below it the
+    /// hint wins. Default `0.90`.
+    ///
+    /// Configurable because the default is an initial guess, not a tuned value.
+    /// Only has effect when a detector is registered. `Gear::init` rejects
+    /// out-of-range values and `NaN` at startup rather than clamping.
+    #[serde(default = "default_detection_confidence_threshold")]
+    pub detection_confidence_threshold: f32,
+}
+
+fn default_detection_confidence_threshold() -> f32 {
+    crate::domain::service::DEFAULT_DETECTION_CONFIDENCE_THRESHOLD
 }
 
 fn default_max_file_size_mb() -> u64 {

--- a/gears/file-parser/file-parser/src/domain/detector.rs
+++ b/gears/file-parser/file-parser/src/domain/detector.rs
@@ -1,0 +1,130 @@
+//! Optional content-based file type detection.
+//!
+//! `FileParserService` accepts an `Option<Arc<dyn ContentTypeDetector>>`.
+//! With none registered (the default, and the only possibility without the
+//! `magika` feature), routing behaves exactly as before this trait existed:
+//! filename extension, then `Content-Type`.
+
+use std::path::Path;
+
+use async_trait::async_trait;
+use toolkit_macros::domain_model;
+
+/// Detector confidence, validated to lie in `[0.0, 1.0]` at construction.
+///
+/// Values within [`Self::CLAMP_EPSILON`] of the range are clamped as
+/// floating-point drift; anything further out is rejected, so a detector with a
+/// scoring bug cannot gain the power to override a correct hint. `NaN` is
+/// rejected too.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct Confidence(f32);
+
+impl Confidence {
+    /// How far outside `[0.0, 1.0]` a value may drift and still count as
+    /// floating-point noise rather than a broken detector. Public because it is
+    /// the whole difference between a clamped score and a rejected one.
+    pub const CLAMP_EPSILON: f32 = 1e-4;
+
+    /// Builds a `Confidence` from `value`. Returns `None` if `value` is
+    /// `NaN`, or lies more than [`Self::CLAMP_EPSILON`] outside
+    /// `[0.0, 1.0]`; values within that margin are clamped into range.
+    #[must_use]
+    pub fn new(value: f32) -> Option<Self> {
+        // Rejecting `NaN` here is load-bearing, not incidental: comparisons
+        // against `NaN` are all false, so `contains` excludes it. A separate
+        // `is_nan()` check would say so more plainly but trips
+        // `clippy::manual_range_contains`.
+        if !(-Self::CLAMP_EPSILON..=1.0 + Self::CLAMP_EPSILON).contains(&value) {
+            return None;
+        }
+        Some(Self(value.clamp(0.0, 1.0)))
+    }
+
+    /// The underlying confidence value, guaranteed to lie in `[0.0, 1.0]`.
+    #[must_use]
+    pub fn get(self) -> f32 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for Confidence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod confidence_tests {
+    use super::Confidence;
+
+    #[test]
+    fn in_range_values_pass_through() {
+        assert!((Confidence::new(0.0).unwrap().get() - 0.0).abs() < f32::EPSILON);
+        assert!((Confidence::new(0.5).unwrap().get() - 0.5).abs() < f32::EPSILON);
+        assert!((Confidence::new(1.0).unwrap().get() - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn tiny_drift_outside_the_range_is_clamped() {
+        assert!((Confidence::new(-0.000_01).unwrap().get() - 0.0).abs() < f32::EPSILON);
+        assert!((Confidence::new(1.000_01).unwrap().get() - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn far_out_of_range_values_are_rejected_not_clamped() {
+        assert!(Confidence::new(5.0).is_none());
+        assert!(Confidence::new(-5.0).is_none());
+    }
+
+    #[test]
+    fn nan_is_rejected() {
+        assert!(Confidence::new(f32::NAN).is_none());
+    }
+}
+
+/// Result of inspecting file content to determine its type.
+#[domain_model]
+#[derive(Debug, Clone, PartialEq)]
+pub struct DetectedType {
+    /// File extension implied by the detected content type (e.g. `"pdf"`),
+    /// without the leading dot.
+    pub extension: String,
+    /// Detector confidence in `[0.0, 1.0]`.
+    pub confidence: Confidence,
+}
+
+/// Inspects raw file content and identifies its type, independent of any
+/// filename or `Content-Type` hint the caller supplied.
+///
+/// Implementations are expected to be CPU-bound and are therefore async so
+/// they can offload inference to a blocking thread pool internally (e.g. via
+/// `tokio::task::spawn_blocking`) rather than blocking the calling task.
+///
+/// # Contract
+///
+/// `detect` must return `None` — not a low-confidence [`DetectedType`] — for
+/// any content whose identified type has no corresponding registered
+/// [`FileParserBackend::supported_extensions`](crate::domain::parser::FileParserBackend::supported_extensions)
+/// entry. `FileParserService` does not re-validate this; it treats every
+/// returned [`DetectedType::extension`] as routable and falls back to the
+/// caller-supplied hint only when `detect` itself returns `None` or a
+/// confidence below its threshold. `MagikaDetector` upholds this by
+/// intersecting Magika's own label-to-extension list with the registered
+/// extensions it's constructed with.
+#[async_trait]
+pub trait ContentTypeDetector: Send + Sync {
+    /// Identify the type of `bytes`. Returns `None` if detection could not
+    /// produce any usable result — either because it found nothing, or
+    /// because what it found has no registered parser (see the contract
+    /// above) — as opposed to a low-confidence result, which is still
+    /// returned so the caller can apply its own threshold.
+    ///
+    /// Takes an owned, cheaply-cloneable [`bytes::Bytes`] rather than `&[u8]`
+    /// since the documented `spawn_blocking` offload strategy needs `'static`
+    /// data; cloning a `Bytes` is a ref-count bump, not a buffer copy.
+    async fn detect(&self, bytes: bytes::Bytes) -> Option<DetectedType>;
+
+    /// Identify the file at `path` without the caller reading it into memory
+    /// first. Same semantics as [`Self::detect`] otherwise.
+    async fn detect_path(&self, path: &Path) -> Option<DetectedType>;
+}

--- a/gears/file-parser/file-parser/src/domain/local_client.rs
+++ b/gears/file-parser/file-parser/src/domain/local_client.rs
@@ -1,14 +1,10 @@
 //! In-process implementation of `file_parser_sdk::FileParserClientV1`.
 //!
-//! Other gears (notably `scan-gateway`, so it can extract text from a raw
-//! attachment before running its detector fan-out — see
-//! `gears/scan-gateway/docs/DESIGN.md`) depend on `file-parser-sdk` and
-//! resolve this client from `ClientHub` instead of going over HTTP to
-//! `POST /file-parser/v1/upload`. This mirrors the in-process
-//! `ScanGatewayLocalClient` pattern used by `scan-gateway`
-//! (`gears/scan-gateway/scan-gateway/src/domain/local_client.rs`): the gear
-//! registers this client in `ClientHub` during `init()` (see `crate::gear`),
-//! and callers never see file-parser's own domain/infra types.
+//! Other gears depend on `file-parser-sdk` and resolve this client from
+//! `ClientHub` instead of going over HTTP to `POST /file-parser/v1/upload`.
+//! The gear registers this client in `ClientHub` during `init()` (see
+//! `crate::gear`), and callers never see file-parser's own domain/infra
+//! types.
 
 use std::sync::Arc;
 
@@ -66,6 +62,7 @@ impl FileParserClientV1 for FileParserLocalClient {
                 req.filename.as_deref(),
                 req.content_type.as_deref(),
                 req.bytes,
+                req.detection,
             )
             .await
             .map_err(|e| {
@@ -85,6 +82,7 @@ mod tests {
     use std::path::PathBuf;
 
     use bytes::Bytes;
+    use file_parser_sdk::Detection;
     use uuid::Uuid;
 
     use super::*;
@@ -117,6 +115,7 @@ mod tests {
             filename: Some("notes.txt".to_owned()),
             content_type: None,
             bytes: Bytes::from_static(b"hello world"),
+            detection: Detection::Auto,
         };
 
         let result = client.parse_bytes(&ctx(), req).await;
@@ -136,6 +135,7 @@ mod tests {
             filename: Some("archive.zip".to_owned()),
             content_type: None,
             bytes: Bytes::from_static(b"not really a zip"),
+            detection: Detection::Auto,
         };
 
         let result = client.parse_bytes(&ctx(), req).await;

--- a/gears/file-parser/file-parser/src/domain/mime_table.rs
+++ b/gears/file-parser/file-parser/src/domain/mime_table.rs
@@ -1,0 +1,146 @@
+//! Canonical extension `<->` MIME type mapping.
+//!
+//! This is the single source of truth for the gateway
+//! (`domain::service::FileParserService`) and every parser backend that
+//! needs to derive one from the other. It replaces three separately
+//! maintained tables that had already drifted (the gateway's own table, and
+//! the `KreuzbergParser`/`ImageParser` copies).
+
+/// `(extension, MIME type)` pairs. Extensions are lowercase, without the leading dot.
+const EXTENSION_MIME_TABLE: &[(&str, &str)] = &[
+    ("pdf", "application/pdf"),
+    ("html", "text/html"),
+    ("htm", "text/html"),
+    ("txt", "text/plain"),
+    (
+        "docx",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ),
+    (
+        "xlsx",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ),
+    ("xls", "application/vnd.ms-excel"),
+    ("xlsm", "application/vnd.ms-excel.sheet.macroEnabled.12"),
+    (
+        "xlsb",
+        "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+    ),
+    (
+        "pptx",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ),
+    ("png", "image/png"),
+    ("jpg", "image/jpeg"),
+    ("jpeg", "image/jpeg"),
+    ("webp", "image/webp"),
+    ("gif", "image/gif"),
+];
+
+/// Look up the canonical MIME type for a (case-insensitive) extension.
+#[must_use]
+pub fn mime_for_extension(ext: &str) -> Option<&'static str> {
+    EXTENSION_MIME_TABLE
+        .iter()
+        .find(|(e, _)| e.eq_ignore_ascii_case(ext))
+        .map(|(_, mime)| *mime)
+}
+
+/// Look up the extension for a MIME essence string (e.g. from a parsed
+/// `Content-Type` header). `application/xhtml+xml` is special-cased to
+/// `html` since it isn't a canonical MIME type for any extension in the
+/// table but should still route to the HTML parser.
+#[must_use]
+pub fn extension_for_mime(mime_essence: &str) -> Option<&'static str> {
+    if mime_essence.eq_ignore_ascii_case("application/xhtml+xml") {
+        return Some("html");
+    }
+    EXTENSION_MIME_TABLE
+        .iter()
+        .find(|(_, m)| m.eq_ignore_ascii_case(mime_essence))
+        .map(|(ext, _)| *ext)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mime_for_extension_is_case_insensitive() {
+        assert_eq!(mime_for_extension("PDF"), Some("application/pdf"));
+        assert_eq!(mime_for_extension("pdf"), Some("application/pdf"));
+    }
+
+    #[test]
+    fn mime_for_extension_unknown_returns_none() {
+        assert_eq!(mime_for_extension("zip"), None);
+    }
+
+    #[test]
+    fn extension_for_mime_round_trips_for_every_registered_extension() {
+        for (ext, mime) in EXTENSION_MIME_TABLE {
+            let round_tripped = extension_for_mime(mime).expect("mime should resolve");
+            assert_eq!(
+                mime_for_extension(round_tripped),
+                Some(*mime),
+                "round-tripping the MIME for extension {ext} should resolve to an \
+                 extension with the same canonical MIME type"
+            );
+        }
+    }
+
+    #[test]
+    fn extension_for_mime_resolves_aliases_to_their_canonical_extension() {
+        // Unlike the round-trip test above, this pins which alias
+        // (`jpg`/`jpeg`, `htm`/`html`) wins for each shared MIME type.
+        for (mime, expected_extension) in [
+            ("application/pdf", "pdf"),
+            ("text/html", "html"),
+            ("text/plain", "txt"),
+            (
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "docx",
+            ),
+            (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "xlsx",
+            ),
+            ("application/vnd.ms-excel", "xls"),
+            ("application/vnd.ms-excel.sheet.macroEnabled.12", "xlsm"),
+            (
+                "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+                "xlsb",
+            ),
+            (
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                "pptx",
+            ),
+            ("image/png", "png"),
+            ("image/jpeg", "jpg"),
+            ("image/webp", "webp"),
+            ("image/gif", "gif"),
+        ] {
+            assert_eq!(
+                extension_for_mime(mime),
+                Some(expected_extension),
+                "MIME {mime} should resolve to the canonical extension {expected_extension}"
+            );
+        }
+    }
+
+    #[test]
+    fn extension_for_mime_txt() {
+        assert_eq!(extension_for_mime("text/plain"), Some("txt"));
+        assert_eq!(mime_for_extension("txt"), Some("text/plain"));
+    }
+
+    #[test]
+    fn extension_for_mime_xhtml_special_case() {
+        assert_eq!(extension_for_mime("application/xhtml+xml"), Some("html"));
+    }
+
+    #[test]
+    fn extension_for_mime_unknown_returns_none() {
+        assert_eq!(extension_for_mime("application/zip"), None);
+    }
+}

--- a/gears/file-parser/file-parser/src/domain/mod.rs
+++ b/gears/file-parser/file-parser/src/domain/mod.rs
@@ -1,10 +1,13 @@
+pub mod detector;
 pub mod error;
 pub mod ir;
 pub mod local_client;
 pub mod markdown;
+pub mod mime_table;
 pub mod parser;
 pub mod service;
 
+pub use detector::*;
 pub use error::*;
 pub use ir::*;
 pub use markdown::*;

--- a/gears/file-parser/file-parser/src/domain/parser.rs
+++ b/gears/file-parser/file-parser/src/domain/parser.rs
@@ -13,8 +13,17 @@ pub trait FileParserBackend: Send + Sync {
     /// File extensions this parser supports (without the dot)
     fn supported_extensions(&self) -> &'static [&'static str];
 
-    /// Parse a file from a local path
-    async fn parse_local_path(&self, path: &Path) -> Result<ParsedDocument, DomainError>;
+    /// Parse a file from a local path.
+    ///
+    /// `resolved_content_type` is the canonical MIME for the extension that
+    /// selected this backend, which may come from detection overriding the
+    /// file's own extension. When `Some`, use it instead of re-deriving one from
+    /// `path`; `None` means route by `path`'s extension.
+    async fn parse_local_path(
+        &self,
+        path: &Path,
+        resolved_content_type: Option<&str>,
+    ) -> Result<ParsedDocument, DomainError>;
 
     /// Parse a file from bytes
     async fn parse_bytes(

--- a/gears/file-parser/file-parser/src/domain/service.rs
+++ b/gears/file-parser/file-parser/src/domain/service.rs
@@ -2,29 +2,22 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use bytes::Bytes;
+use file_parser_sdk::Detection;
 use toolkit_macros::domain_model;
 use tracing::{debug, info, instrument, warn};
 
+use crate::domain::detector::{Confidence, ContentTypeDetector, DetectedType};
 use crate::domain::error::DomainError;
 use crate::domain::ir::ParsedDocument;
+use crate::domain::mime_table;
 use crate::domain::parser::FileParserBackend;
 
-/// Mapping of file extensions to MIME types
-/// Format: `(extension, mime_type)`
-const EXTENSION_MIME_MAPPINGS: &[(&str, &str)] = &[
-    ("pdf", "application/pdf"),
-    ("html", "text/html"),
-    ("htm", "text/html"),
-    (
-        "docx",
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    ),
-    ("png", "image/png"),
-    ("jpg", "image/jpeg"),
-    ("jpeg", "image/jpeg"),
-    ("webp", "image/webp"),
-    ("gif", "image/gif"),
-];
+/// Default minimum confidence at which a detected type overrides the
+/// caller-supplied filename extension / `Content-Type`.
+///
+/// An initial guess rather than a tuned value, so it is overridable per
+/// deployment — see `FileParserConfig::detection_confidence_threshold`.
+pub const DEFAULT_DETECTION_CONFIDENCE_THRESHOLD: f32 = 0.90;
 
 /// File parser service that routes to appropriate backends
 #[domain_model]
@@ -32,6 +25,16 @@ const EXTENSION_MIME_MAPPINGS: &[(&str, &str)] = &[
 pub struct FileParserService {
     parsers: Vec<Arc<dyn FileParserBackend>>,
     config: ServiceConfig,
+    /// Optional content-based type detector. `None` unless a detector was
+    /// registered via [`FileParserService::with_detector`] — in particular,
+    /// always `None` when the gear is built without the `magika` feature, in
+    /// which case routing behaves exactly as it did before this field
+    /// existed.
+    detector: Option<Arc<dyn ContentTypeDetector>>,
+    /// Minimum confidence at which a detection may override the caller's hint.
+    /// Defaults to [`DEFAULT_DETECTION_CONFIDENCE_THRESHOLD`]; irrelevant when
+    /// no detector is registered.
+    detection_confidence_threshold: Confidence,
 }
 
 /// Configuration for the file parser service
@@ -52,10 +55,43 @@ pub struct FileParserInfo {
 }
 
 impl FileParserService {
-    /// Create a new service with the given parsers
+    /// Create a new service with the given parsers.
+    ///
+    /// No content-type detector is registered; routing relies solely on the
+    /// filename extension / `Content-Type` hint. Use
+    /// [`FileParserService::with_detector`] to opt in.
     #[must_use]
     pub fn new(parsers: Vec<Arc<dyn FileParserBackend>>, config: ServiceConfig) -> Self {
-        Self { parsers, config }
+        Self {
+            parsers,
+            config,
+            detector: None,
+            #[allow(clippy::expect_used)] // A const in [0.0, 1.0]; cannot fail.
+            detection_confidence_threshold: Confidence::new(
+                DEFAULT_DETECTION_CONFIDENCE_THRESHOLD,
+            )
+            .expect("the default detection threshold is a valid confidence"),
+        }
+    }
+
+    /// Register a content-based type detector, used to resolve or correct
+    /// the routing extension when the caller-supplied hint is missing or
+    /// wrong.
+    #[must_use]
+    pub fn with_detector(mut self, detector: Arc<dyn ContentTypeDetector>) -> Self {
+        self.detector = Some(detector);
+        self
+    }
+
+    /// Override the minimum confidence at which a detection takes routing
+    /// priority over the caller's hint.
+    ///
+    /// Takes a [`Confidence`], not an `f32`, so out-of-range and `NaN` are
+    /// rejected before they get here.
+    #[must_use]
+    pub fn with_detection_confidence_threshold(mut self, threshold: Confidence) -> Self {
+        self.detection_confidence_threshold = threshold;
+        self
     }
 
     /// Get information about available parsers
@@ -125,22 +161,56 @@ impl FileParserService {
             )));
         }
 
-        // Extract extension
-        let extension = canonical
+        // Unconditional, so local files can't bypass the limit. Rejects early
+        // and names the actual size; the memory bound is the backends' own
+        // bounded reads, since metadata-then-read is not atomic.
+        let metadata = tokio::fs::metadata(&canonical)
+            .await
+            .map_err(|e| DomainError::io_error(format!("Cannot read file metadata: {e}")))?;
+        self.check_size_limit(metadata.len())?;
+
+        // Extract the filename-hint extension, then apply the same
+        // detection precedence `parse_bytes` uses: run content-based
+        // detection whenever a detector is registered — not only when the
+        // extension is missing — so a confident detection can also correct
+        // a present-but-wrong extension. With no detector registered, this
+        // reads no file content and behaves exactly as before detection
+        // existed.
+        let extension_from_name = canonical
             .extension()
             .and_then(|s| s.to_str())
-            .ok_or_else(|| DomainError::unsupported_file_type("no extension"))?;
+            .map(str::to_owned);
+
+        let extension = if self.detector.is_some() {
+            let detected = self.detect_from_path(&canonical).await;
+            match self.reconcile_extension(extension_from_name.as_deref(), detected.as_ref()) {
+                Some(ext) => ext,
+                None => return Err(DomainError::unsupported_file_type("no extension")),
+            }
+        } else if let Some(ext) = extension_from_name {
+            ext
+        } else {
+            return Err(DomainError::unsupported_file_type("no extension"));
+        };
 
         // Find parser
         let parser = self
-            .find_parser_by_extension(extension)
-            .ok_or_else(|| DomainError::no_parser_available(extension))?;
+            .find_parser_by_extension(&extension)
+            .ok_or_else(|| DomainError::no_parser_available(&extension))?;
+
+        // Hand the backend the resolved MIME, not just use it to pick the
+        // backend: otherwise a wrongly-named file still fails once the backend
+        // re-derives its own MIME from the on-disk extension.
+        let resolved_content_type = mime_table::mime_for_extension(&extension);
 
         // Parse the file
-        let document = parser.parse_local_path(&canonical).await.map_err(|e| {
-            tracing::error!(?e, "FileParserService: parse_local failed");
-            e
-        })?;
+        let document = parser
+            .parse_local_path(&canonical, resolved_content_type)
+            .await
+            .map_err(|e| {
+                tracing::error!(?e, "FileParserService: parse_local failed");
+                e
+            })?;
 
         debug!("Successfully parsed file from local path");
         Ok(document)
@@ -163,53 +233,73 @@ impl FileParserService {
         Ok(())
     }
 
-    /// Parse a file from bytes
+    /// Parse a file from bytes.
+    ///
+    /// `detection` controls whether content-based detection runs even when
+    /// a detector is registered — `Detection::Skip` pins routing to
+    /// `filename_hint` / `content_type` for a caller that already knows the
+    /// exact type it's passing — see
+    /// [`FileParserService::reconcile_extension`].
     #[instrument(
         skip(self, bytes),
-        fields(filename_hint = ?filename_hint, content_type = ?content_type, size = bytes.len())
+        fields(
+            filename_hint = ?filename_hint,
+            content_type = ?content_type,
+            size = bytes.len(),
+            ?detection
+        )
     )]
     pub async fn parse_bytes(
         &self,
         filename_hint: Option<&str>,
         content_type: Option<&str>,
         bytes: Bytes,
+        detection: Detection,
     ) -> Result<ParsedDocument, DomainError> {
         info!("Parsing uploaded file");
 
         // Check file size
-        if bytes.len() > self.config.max_file_size_bytes {
-            return Err(DomainError::invalid_request(format!(
-                "File size {} exceeds maximum of {} bytes",
-                bytes.len(),
-                self.config.max_file_size_bytes
-            )));
-        }
+        self.check_size_limit(bytes.len() as u64)?;
 
-        // Determine extension by priority:
+        // Determine the caller-supplied hint by priority:
         // 1. From filename (if provided and has extension)
         // 2. From Content-Type (if provided and recognized)
-        // 3. Error if both fail
+        // `no_hint_reason` preserves today's exact error text for the case
+        // where hint resolution fails outright and detection doesn't save it.
         let extension_from_name = filename_hint
             .and_then(|name| Path::new(name).extension())
             .and_then(|s| s.to_str())
             .map(str::to_owned);
 
-        let extension = if let Some(ext) = extension_from_name {
-            // Priority 1: Use extension from filename
-            ext
+        let (hint_extension, no_hint_reason) = if let Some(ext) = extension_from_name {
+            (Some(ext), None)
         } else if let Some(ct) = content_type {
-            // Priority 2: Try to infer from Content-Type
-            if let Some(ext) = Self::extension_from_content_type(ct) {
-                ext
-            } else {
-                return Err(DomainError::unsupported_file_type(
-                    "no extension and unknown content-type",
-                ));
+            match Self::extension_from_content_type(ct) {
+                Some(ext) => (Some(ext), None),
+                None => (None, Some("no extension and unknown content-type")),
             }
         } else {
-            // Both failed
+            (None, Some("no extension and no content-type"))
+        };
+
+        // Run content-based detection on every request when a detector is
+        // registered — this is what lets a confident detection correct a
+        // wrong hint, not just fill in a missing one. With no detector
+        // registered (including always, when built without the `magika`
+        // feature), or when the caller opted out via `Detection::Skip`,
+        // this is a no-op and behavior is unchanged.
+        let detected = match &self.detector {
+            Some(detector) if detection == Detection::Auto => {
+                Self::detect_and_log("uploaded_bytes", detector.detect(bytes.clone())).await
+            }
+            _ => None,
+        };
+
+        let Some(extension) =
+            self.reconcile_extension(hint_extension.as_deref(), detected.as_ref())
+        else {
             return Err(DomainError::unsupported_file_type(
-                "no extension and no content-type",
+                no_hint_reason.unwrap_or("no extension and no content-type"),
             ));
         };
 
@@ -218,9 +308,26 @@ impl FileParserService {
             .find_parser_by_extension(&extension)
             .ok_or_else(|| DomainError::no_parser_available(&extension))?;
 
+        // True when detection replaced the caller's hint, so the caller's
+        // `Content-Type` describes a different type than the selected parser.
+        let detection_won = hint_extension
+            .as_deref()
+            .is_none_or(|hint| !hint.eq_ignore_ascii_case(&extension));
+
+        // Prefer the caller's explicit Content-Type while the routing
+        // extension still comes from the caller's own hint. Once a confident
+        // detection has overridden that hint, the caller's Content-Type
+        // describes the wrong type, so the detected extension's canonical
+        // MIME wins instead.
+        let resolved_content_type = if detection_won {
+            mime_table::mime_for_extension(&extension).or(content_type)
+        } else {
+            content_type.or_else(|| mime_table::mime_for_extension(&extension))
+        };
+
         // Parse the file
         let document = parser
-            .parse_bytes(filename_hint, content_type, bytes)
+            .parse_bytes(filename_hint, resolved_content_type, bytes)
             .await
             .map_err(|e| {
                 tracing::error!(?e, "FileParserService: parse_bytes failed");
@@ -235,18 +342,97 @@ impl FileParserService {
     #[must_use]
     pub fn extension_from_content_type(ct: &str) -> Option<String> {
         let mime: mime::Mime = ct.parse().ok()?;
-        let essence = mime.essence_str();
+        mime_table::extension_for_mime(mime.essence_str()).map(ToOwned::to_owned)
+    }
 
-        // Special case: application/xhtml+xml maps to html
-        if essence == "application/xhtml+xml" {
-            return Some("html".to_owned());
+    /// Reconciles a caller-supplied extension hint with a content-detection
+    /// result. A detection at or above `detection_confidence_threshold` with a
+    /// matching registered parser wins routing, logging any disagreement;
+    /// otherwise the hint is used unchanged.
+    ///
+    /// The parser check matters because `with_detector` is public API: a
+    /// third-party detector reporting an unregistered extension must not turn a
+    /// hint-satisfiable request into `no_parser_available`.
+    fn reconcile_extension(
+        &self,
+        hint: Option<&str>,
+        detected: Option<&DetectedType>,
+    ) -> Option<String> {
+        if let Some(detected) = detected
+            && detected.confidence >= self.detection_confidence_threshold
+            && self.find_parser_by_extension(&detected.extension).is_some()
+        {
+            if let Some(hint) = hint
+                && !hint.eq_ignore_ascii_case(&detected.extension)
+            {
+                warn!(
+                    hinted_extension = hint,
+                    detected_extension = %detected.extension,
+                    confidence = %detected.confidence,
+                    "file-parser: caller-supplied type hint disagrees with detected content \
+                     type; routing by detected type"
+                );
+            }
+            return Some(detected.extension.clone());
+        }
+        hint.map(str::to_owned)
+    }
+
+    /// Times `run` and logs its outcome at `debug`. Generic over the future so
+    /// both detection paths share it; `source` is what tells them apart in logs.
+    ///
+    /// Spanned because `debug` is normally off in production, and detection is a
+    /// synchronous inference on the request path whose latency has to be
+    /// attributable without one.
+    #[instrument(name = "file_parser.detect", skip(run))]
+    async fn detect_and_log<F>(source: &'static str, run: F) -> Option<DetectedType>
+    where
+        F: std::future::Future<Output = Option<DetectedType>>,
+    {
+        let started = std::time::Instant::now();
+        let result = run.await;
+        let elapsed_ms = started.elapsed().as_millis();
+
+        if let Some(detected) = &result {
+            debug!(
+                source,
+                extension = %detected.extension,
+                confidence = %detected.confidence,
+                elapsed_ms,
+                "file-parser: content detection ran"
+            );
+        } else {
+            debug!(
+                source,
+                elapsed_ms, "file-parser: content detection ran, no result"
+            );
         }
 
-        // Find extension by matching MIME type
-        EXTENSION_MIME_MAPPINGS
-            .iter()
-            .find(|(_, mime_type)| *mime_type == essence)
-            .map(|(ext, _)| (*ext).to_owned())
+        result
+    }
+
+    /// Detects via [`ContentTypeDetector::detect_path`] rather than reading the
+    /// file in and calling `detect`, which would buffer the whole file and
+    /// duplicate the backend's own read. `None` if no detector is registered.
+    //
+    // NOT cancel-safe: see `MagikaDetector::detect_path`.
+    async fn detect_from_path(&self, path: &Path) -> Option<DetectedType> {
+        let detector = self.detector.as_ref()?;
+        Self::detect_and_log("local_path", detector.detect_path(path)).await
+    }
+
+    /// Rejects `len` if it exceeds the configured `max_file_size_bytes`.
+    ///
+    /// Shared by `parse_bytes` and `parse_local` so the limit and its message
+    /// cannot drift between entry points, or with the `magika` feature.
+    fn check_size_limit(&self, len: u64) -> Result<(), DomainError> {
+        if len > self.config.max_file_size_bytes as u64 {
+            return Err(DomainError::invalid_request(format!(
+                "File size {len} exceeds maximum of {} bytes",
+                self.config.max_file_size_bytes
+            )));
+        }
+        Ok(())
     }
 
     /// Find a parser by file extension

--- a/gears/file-parser/file-parser/src/gear.rs
+++ b/gears/file-parser/file-parser/src/gear.rs
@@ -31,6 +31,157 @@ impl Default for FileParserGear {
     }
 }
 
+/// Why the Magika content-type detector failed to initialize.
+///
+/// A dedicated type rather than `anyhow::Error` because two variants leave an
+/// abandoned OS thread behind, which is only sound if the caller then terminates
+/// the process. [`Self::leaked_init_thread`] makes that checkable in code rather
+/// than documented in a comment.
+#[cfg(feature = "magika")]
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum MagikaInitError {
+    /// No result within the timeout — almost always the hang described on
+    /// [`init_magika_detector`]. The thread is abandoned, not killed.
+    #[error(
+        "Magika content-type detector did not finish loading within {}s; the ONNX Runtime is \
+         likely missing, the wrong architecture, or incompatible with the version `ort` was \
+         built against — check ORT_DYLIB_PATH (the init thread is abandoned, not killed, and \
+         will leak until the process exits)",
+        timeout.as_secs()
+    )]
+    Timeout { timeout: std::time::Duration },
+
+    /// `cancellation_token` fired before init finished. The init thread may
+    /// still be running, and may be wedged.
+    #[error("Magika content-type detector initialization cancelled by gear shutdown")]
+    Cancelled,
+
+    /// The init thread vanished without sending a result — it panicked, or the
+    /// `oneshot` sender was dropped. The thread is gone, so nothing leaks.
+    #[error("Magika detector init thread died unexpectedly: {0}")]
+    InitThreadDied(#[source] tokio::sync::oneshot::error::RecvError),
+
+    /// ONNX Runtime and the model loaded far enough to return a real error.
+    /// The init thread completed, so nothing leaks.
+    #[error("failed to load Magika content-type detector: {0}")]
+    SessionLoad(#[source] magika::Error),
+}
+
+#[cfg(feature = "magika")]
+impl MagikaInitError {
+    /// Whether this failure left an OS thread that will never be joined.
+    ///
+    /// `true` means the caller must terminate the process for the leak to stay
+    /// bounded. Note that exiting while that thread sits inside ONNX Runtime
+    /// init can abort rather than exit cleanly (ORT's `cpuinfo` asserts if
+    /// teardown races init), so the observable failure may be a signal rather
+    /// than an exit code.
+    #[must_use]
+    pub const fn leaked_init_thread(&self) -> bool {
+        match self {
+            // `Timeout` is wedged by definition. `Cancelled` may just be a
+            // thread still loading, but we cannot tell it apart from a wedged
+            // one here, so assume the worse case.
+            Self::Timeout { .. } | Self::Cancelled => true,
+            // Both mean the thread ran to completion and is gone.
+            Self::InitThreadDied(_) | Self::SessionLoad(_) => false,
+        }
+    }
+}
+
+/// Loads the Magika content-type detector eagerly at gear startup, so a
+/// missing model/runtime fails gear startup rather than the first request.
+///
+/// # The `ort` 2.0.0-rc.12 startup hang
+///
+/// Bounded by a timeout because `ort` 2.0.0-rc.12 **hangs forever instead of
+/// erroring** when the ONNX Runtime library it `dlopen`s via `ORT_DYLIB_PATH`
+/// cannot be loaded. Reproduced: against a nonexistent path,
+/// `magika::Session::new()` returns neither `Ok` nor `Err` nor panics in 45 s.
+///
+/// Before simplifying this away, two measured facts:
+///
+/// - **No pre-flight validation exists.** `ort::init_from(path)` looks like one
+///   (takes a path, returns `Result`) but hangs on the same input, also at 45 s.
+///   Every `ort` entry point funnels through the same lazy dylib init.
+/// - **The internal mechanism is unknown.** An earlier version of this comment
+///   blamed a reentrant `ort::api()` call, which the `init_from` result
+///   disproves. Treat the hang as an observed property of a bad
+///   `ORT_DYLIB_PATH`, not as something understood well enough to narrow.
+///
+/// Since the hang cannot be interrupted from inside, the blocked thread has to be
+/// abandoned. A raw `std::thread` rather than `spawn_blocking`, because Tokio
+/// joins blocking threads on shutdown, so a wedged one would hang the whole
+/// runtime's shutdown. Only the `oneshot` receiver is awaited. See
+/// [`MagikaInitError::leaked_init_thread`] for the caller's obligation.
+///
+/// TODO: drop this once `magika`/`ort` fix the hang or offer a safe way to
+/// validate the dylib first. No upstream issue filed as of 2026-08-18; the
+/// `init_from` reproduction above is what to report against `pykeio/ort`. Check
+/// for a fix above `2.0.0-rc.12` before bumping the workspace pin.
+///
+/// # Visibility
+///
+/// `#[doc(hidden)] pub` only so `tests/magika_timeout_tests.rs` can drive this
+/// exact path; an integration test cannot reach `pub(crate)`. Not public API.
+///
+/// # Errors
+///
+/// See [`MagikaInitError`] — two variants oblige the caller to terminate.
+#[cfg(feature = "magika")]
+#[doc(hidden)]
+pub async fn init_magika_detector(
+    parsers: &[Arc<dyn crate::domain::parser::FileParserBackend>],
+    intra_op_threads: Option<std::num::NonZeroUsize>,
+    cancellation_token: &tokio_util::sync::CancellationToken,
+) -> Result<Arc<dyn crate::domain::detector::ContentTypeDetector>, MagikaInitError> {
+    // Flat, not scaled — one session means one model load. A healthy one builds
+    // in well under a second and the hang never completes, so a longer timeout
+    // would only delay a legible startup failure.
+    const MAGIKA_INIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+    // Check before spawning, not just in the `select!` below. Abandoning a
+    // thread that is midway through ONNX Runtime init can abort the process on
+    // exit (ORT's `cpuinfo` asserts if teardown races init), so if shutdown has
+    // already begun, don't start work we know we are about to discard.
+    if cancellation_token.is_cancelled() {
+        return Err(MagikaInitError::Cancelled);
+    }
+
+    let supported_extensions: Vec<String> = parsers
+        .iter()
+        .flat_map(|p| p.supported_extensions().iter().map(|ext| (*ext).to_owned()))
+        .collect();
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    std::thread::spawn(move || {
+        // The receiver may already be gone if we timed out and moved on; a
+        // dropped receiver just means `send` fails harmlessly.
+        drop(tx.send(crate::infra::MagikaDetector::with_config(
+            supported_extensions,
+            intra_op_threads,
+        )));
+    });
+
+    // Race the bounded wait against shutdown, so it doesn't block graceful
+    // shutdown for the full timeout.
+    let detector = tokio::select! {
+        result = tokio::time::timeout(MAGIKA_INIT_TIMEOUT, rx) => {
+            result
+                .map_err(|_elapsed| MagikaInitError::Timeout { timeout: MAGIKA_INIT_TIMEOUT })?
+                .map_err(MagikaInitError::InitThreadDied)?
+                .map_err(MagikaInitError::SessionLoad)?
+        }
+        () = cancellation_token.cancelled() => {
+            return Err(MagikaInitError::Cancelled);
+        }
+    };
+
+    info!("Magika content-type detection enabled");
+    Ok(Arc::new(detector) as Arc<dyn crate::domain::detector::ContentTypeDetector>)
+}
+
 #[async_trait]
 impl Gear for FileParserGear {
     #[allow(clippy::cast_possible_truncation)]
@@ -44,13 +195,17 @@ impl Gear for FileParserGear {
             cfg.max_file_size_mb
         );
 
-        // Build parser backends
+        let max_file_size_bytes = cfg.max_file_size_mb.saturating_mul(BYTES_IN_MB);
+
+        // The two backends that read a whole local file into memory get the
+        // configured ceiling, so their bounded reads agree with the
+        // service-level check rather than a compiled-in default.
         let parsers: Vec<Arc<dyn crate::domain::parser::FileParserBackend>> = vec![
-            Arc::new(PlainTextParser::new()),
+            Arc::new(PlainTextParser::new().with_max_bytes(max_file_size_bytes)),
             Arc::new(KreuzbergParser::new()),
             Arc::new(DocxParser::new()),
             Arc::new(ImageParser::new()),
-            Arc::new(StubParser::new()),
+            Arc::new(StubParser::new().with_max_bytes(max_file_size_bytes)),
         ];
 
         info!("Registered {} parser backends", parsers.len());
@@ -75,18 +230,61 @@ impl Gear for FileParserGear {
 
         // Create service config from gear config
         let service_config = ServiceConfig {
-            max_file_size_bytes: usize::try_from(cfg.max_file_size_mb * BYTES_IN_MB)
-                .unwrap_or(usize::MAX),
+            max_file_size_bytes: usize::try_from(max_file_size_bytes).unwrap_or(usize::MAX),
             allowed_local_base_dir,
         };
 
-        // Create file parser service
-        let file_parser_service = Arc::new(FileParserService::new(parsers, service_config));
+        // With the `magika` feature, load the content-type detector eagerly
+        // so a missing model/runtime fails gear startup, not the first
+        // request. See `init_magika_detector` for why this is bounded by a
+        // timeout instead of a plain `.await`.
+        // `Err` from `Gear::init` terminates the process, which is what
+        // `leaked_init_thread` requires. Making this recoverable means dealing
+        // with the leaked thread.
+        #[cfg(feature = "magika")]
+        let detector = match init_magika_detector(
+            &parsers,
+            cfg.magika_intra_op_threads,
+            ctx.cancellation_token(),
+        )
+        .await
+        {
+            Ok(detector) => detector,
+            Err(e) => {
+                if e.leaked_init_thread() {
+                    tracing::error!(
+                        error = %e,
+                        "Magika init left an abandoned OS thread; this is only bounded because \
+                         gear init failure terminates the process"
+                    );
+                }
+                return Err(e.into());
+            }
+        };
 
-        // Register the in-process ClientHub client so other gears (e.g.
-        // scan-gateway, extracting text from an attachment before running
-        // its detector fan-out) can call file-parser without going over
-        // HTTP.
+        // Fail startup on a bad threshold rather than clamping a value the
+        // operator plainly did not mean (e.g. a percentage typed as `90`).
+        let detection_confidence_threshold =
+            crate::domain::detector::Confidence::new(cfg.detection_confidence_threshold)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "detection_confidence_threshold ({}) must be a number in [0.0, 1.0]",
+                        cfg.detection_confidence_threshold
+                    )
+                })?;
+
+        // Create file parser service
+        #[allow(unused_mut)]
+        let mut service = FileParserService::new(parsers, service_config)
+            .with_detection_confidence_threshold(detection_confidence_threshold);
+        #[cfg(feature = "magika")]
+        {
+            service = service.with_detector(detector);
+        }
+        let file_parser_service = Arc::new(service);
+
+        // Register the in-process ClientHub client so other gears can call
+        // file-parser without going over HTTP.
         let client: Arc<dyn FileParserClientV1> =
             Arc::new(FileParserLocalClient::new(file_parser_service.clone()));
         ctx.client_hub().register::<dyn FileParserClientV1>(client);

--- a/gears/file-parser/file-parser/src/infra/magika_detector.rs
+++ b/gears/file-parser/file-parser/src/infra/magika_detector.rs
@@ -1,0 +1,287 @@
+//! Magika-backed [`ContentTypeDetector`], compiled only behind the `magika`
+//! feature.
+
+use std::collections::HashSet;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+use tracing::{debug, warn};
+
+use crate::domain::detector::{Confidence, ContentTypeDetector, DetectedType};
+
+/// Wraps a single `magika::Session` and restricts Magika's ~200 output labels
+/// to the extensions this gear's registered parsers actually declare. Magika's
+/// own `TypeInfo` already lists each label's extensions, so we just intersect
+/// that with what's registered.
+///
+/// # Why one session and not a pool
+///
+/// `magika::Session` exposes only `&mut self` inference methods and keeps its
+/// inner `ort::session::Session` private, so every inference needs exclusive
+/// access however the sessions are held — `ort`'s session is itself
+/// `Send + Sync`, but that is not reachable through `magika`. So extra sessions
+/// buy concurrency only at the price of one ONNX intra-op thread pool and one
+/// resident model copy each (~6 extra threads per session on a 10-core host).
+///
+/// Not worth it: detection measures ~3.5 ms, against document extraction costing
+/// tens to hundreds of milliseconds on the same request. One serialized session
+/// sustains ~285 detections/second. Tune [`Self::with_config`]'s
+/// `intra_op_threads` to move detection's CPU use instead.
+///
+/// Requests queue on a fair FIFO mutex, so at most one inference is in flight
+/// and at most one blocking thread is occupied.
+pub struct MagikaDetector {
+    /// `Option` so an inference that panics leaves the slot empty rather than
+    /// leaving behind a session whose ONNX state is unknown; the next caller
+    /// rebuilds it. `Arc` so the guard can be moved into `spawn_blocking`.
+    session: Arc<Mutex<Option<magika::Session>>>,
+    supported_extensions: Arc<HashSet<String>>,
+    /// Kept so a session rebuilt after a panic gets the same thread config as
+    /// the one built at startup.
+    intra_op_threads: Option<NonZeroUsize>,
+}
+
+impl MagikaDetector {
+    /// Loads the embedded model and builds the session, leaving ONNX
+    /// Runtime's own thread defaults in place. See [`Self::with_config`].
+    pub fn new(
+        supported_extensions: impl IntoIterator<Item = impl Into<String>>,
+    ) -> magika::Result<Self> {
+        Self::with_config(supported_extensions, None)
+    }
+
+    /// Loads the embedded model and builds the session. `intra_op_threads` is
+    /// ONNX Runtime's per-inference thread count; `None` keeps its default —
+    /// not the host core count, ~6 threads on a 10-core host. See
+    /// `FileParserConfig::magika_intra_op_threads`.
+    ///
+    /// Eager and fallible on purpose: a missing model or runtime must fail gear
+    /// startup, not degrade silently.
+    ///
+    /// Must not be called on the async runtime — against an unloadable ONNX
+    /// Runtime this hangs rather than erroring. See `init_magika_detector`.
+    ///
+    /// `supported_extensions` should be every registered backend's
+    /// `supported_extensions()`; a label outside that set is "no detection".
+    pub fn with_config(
+        supported_extensions: impl IntoIterator<Item = impl Into<String>>,
+        intra_op_threads: Option<NonZeroUsize>,
+    ) -> magika::Result<Self> {
+        Ok(Self {
+            session: Arc::new(Mutex::new(Some(Self::build_session(intra_op_threads)?))),
+            supported_extensions: Arc::new(
+                supported_extensions
+                    .into_iter()
+                    .map(|ext| ext.into().to_lowercase())
+                    .collect(),
+            ),
+            intra_op_threads,
+        })
+    }
+
+    fn build_session(intra_op_threads: Option<NonZeroUsize>) -> magika::Result<magika::Session> {
+        let mut builder = magika::Session::builder();
+        if let Some(threads) = intra_op_threads {
+            builder = builder.with_intra_threads(threads.get());
+        }
+        builder.build()
+    }
+}
+
+/// Turns a raw inference outcome into a [`DetectedType`], swallowing an `Err`,
+/// an unmapped label (the routine "detection did not help" case) and a `NaN`
+/// score rather than propagating them. Split out so it can be unit-tested with
+/// synthetic values, without a real `Session` or ONNX Runtime.
+fn map_inference_result(
+    result: magika::Result<magika::FileType>,
+    supported_extensions: &HashSet<String>,
+) -> Option<DetectedType> {
+    let file_type = result
+        // Neutral wording: this serves both `detect` (`identify_content_sync`)
+        // and `detect_path` (`identify_file_sync`).
+        .inspect_err(|e| warn!(error = %e, "magika inference failed"))
+        .ok()?;
+
+    let info = file_type.info();
+    let Some(extension) = info
+        .extensions
+        .iter()
+        .find(|ext| supported_extensions.contains(&ext.to_lowercase()))
+    else {
+        debug!(
+            label = info.label,
+            candidate_extensions = ?info.extensions,
+            "magika: detected label maps to no registered extension; falling back to hint"
+        );
+        return None;
+    };
+
+    let score = file_type.score();
+    let Some(confidence) = Confidence::new(score) else {
+        warn!(
+            score,
+            label = info.label,
+            "magika: inference returned a NaN score"
+        );
+        return None;
+    };
+
+    Some(DetectedType {
+        extension: extension.to_lowercase(),
+        confidence,
+    })
+}
+
+impl MagikaDetector {
+    /// Takes exclusive use of the session and runs `infer` on the blocking pool.
+    /// Shared by `detect`/`detect_path`, which differ only in which
+    /// `identify_*_sync` they call.
+    ///
+    /// The session never leaves the mutex; the *guard* moves into the closure.
+    /// That is what makes cancellation safe — the guard is released by `Drop`
+    /// when the blocking task ends, whether or not anyone still awaits the
+    /// result, so a dropped future cannot strand or destroy the session.
+    #[tracing::instrument(
+        name = "magika.inference",
+        skip(self, infer),
+        fields(intra_op_threads = ?self.intra_op_threads)
+    )]
+    async fn run_inference(
+        &self,
+        infer: impl FnOnce(&mut magika::Session) -> magika::Result<magika::FileType> + Send + 'static,
+    ) -> Option<DetectedType> {
+        // Fair FIFO queueing, on the async side rather than on a blocking
+        // thread. `lock_owned` because `spawn_blocking` needs `'static`.
+        let mut guard = Arc::clone(&self.session).lock_owned().await;
+
+        if guard.is_none() {
+            // A previous inference panicked and left the slot empty.
+            *guard = Self::rebuild_session(self.intra_op_threads).await;
+            if guard.is_none() {
+                return None;
+            }
+        }
+
+        let supported_extensions = Arc::clone(&self.supported_extensions);
+        tokio::task::spawn_blocking(move || {
+            let mut guard = guard;
+            // `take` so a panic inside `infer` leaves the slot empty instead
+            // of leaving a session whose ONNX state is unknown after unwind.
+            let mut session = guard.take()?;
+            let result = map_inference_result(infer(&mut session), &supported_extensions);
+            *guard = Some(session);
+            result
+        })
+        .await
+        .unwrap_or_else(|join_err| {
+            warn!(error = %join_err, "magika inference task panicked; session will be rebuilt");
+            None
+        })
+    }
+
+    /// Builds a fresh session on the blocking pool, swallowing either failure
+    /// mode: detection degrades to "no detection", which the service already
+    /// handles by falling back to the caller's hint.
+    ///
+    /// Safe to build directly here, unlike at startup: the hang only affects a
+    /// first, failing runtime load, and reaching this code means one already
+    /// succeeded.
+    async fn rebuild_session(intra_op_threads: Option<NonZeroUsize>) -> Option<magika::Session> {
+        match tokio::task::spawn_blocking(move || Self::build_session(intra_op_threads)).await {
+            Ok(Ok(fresh_session)) => Some(fresh_session),
+            Ok(Err(e)) => {
+                warn!(error = %e, "failed to rebuild the magika session");
+                None
+            }
+            Err(join_err) => {
+                warn!(error = %join_err, "rebuilding the magika session panicked");
+                None
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl ContentTypeDetector for MagikaDetector {
+    // Cancel-safe with respect to the session: dropping the future does not
+    // stop the in-flight inference (its result is simply discarded), but the
+    // session is released back for the next caller either way, because the
+    // blocking task owns the mutex guard and drops it on completion.
+    async fn detect(&self, bytes: bytes::Bytes) -> Option<DetectedType> {
+        self.run_inference(move |session| session.identify_content_sync(bytes.as_ref()))
+            .await
+    }
+
+    // Cancel-safe with respect to the session: see `detect` above.
+    async fn detect_path(&self, path: &std::path::Path) -> Option<DetectedType> {
+        let path = path.to_path_buf();
+        self.run_inference(move |session| session.identify_file_sync(&path))
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inferred(content_type: magika::ContentType, score: f32) -> magika::FileType {
+        magika::FileType::Inferred(magika::InferredType {
+            content_type: None,
+            inferred_type: content_type,
+            score,
+        })
+    }
+
+    #[test]
+    fn inference_error_is_swallowed_to_none() {
+        let err = magika::Error::IOError(std::io::Error::other("simulated inference failure"));
+
+        assert!(map_inference_result(Err(err), &HashSet::new()).is_none());
+    }
+
+    #[test]
+    fn label_present_in_supported_extensions_maps_to_detected_type() {
+        let supported: HashSet<String> = ["pdf", "html"].into_iter().map(str::to_owned).collect();
+
+        let detected =
+            map_inference_result(Ok(inferred(magika::ContentType::Pdf, 0.97)), &supported)
+                .expect("pdf is in supported_extensions, so this must resolve");
+
+        assert_eq!(detected.extension, "pdf");
+        assert!((detected.confidence.get() - 0.97).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn label_absent_from_supported_extensions_returns_none() {
+        // No registered backend declares "pdf" here.
+        let supported: HashSet<String> = ["html"].into_iter().map(str::to_owned).collect();
+
+        assert!(
+            map_inference_result(Ok(inferred(magika::ContentType::Pdf, 0.97)), &supported)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn nan_score_returns_none() {
+        let supported: HashSet<String> = ["pdf"].into_iter().map(str::to_owned).collect();
+
+        assert!(
+            map_inference_result(Ok(inferred(magika::ContentType::Pdf, f32::NAN)), &supported)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn label_extension_is_lowercased() {
+        let supported: HashSet<String> = ["PDF".to_lowercase()].into_iter().collect();
+
+        let detected =
+            map_inference_result(Ok(inferred(magika::ContentType::Pdf, 0.5)), &supported)
+                .expect("lowercased supported_extensions must still match");
+
+        assert_eq!(detected.extension, "pdf");
+    }
+}

--- a/gears/file-parser/file-parser/src/infra/mod.rs
+++ b/gears/file-parser/file-parser/src/infra/mod.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "magika")]
+pub mod magika_detector;
 pub mod parsers;
 
+#[cfg(feature = "magika")]
+pub use magika_detector::MagikaDetector;
 pub use parsers::*;

--- a/gears/file-parser/file-parser/src/infra/parsers/bounded_read.rs
+++ b/gears/file-parser/file-parser/src/infra/parsers/bounded_read.rs
@@ -1,0 +1,90 @@
+//! Shared bounded read for backends that load a whole local file into memory.
+
+use std::path::Path;
+
+use tokio::io::AsyncReadExt;
+
+use crate::domain::error::DomainError;
+
+/// Reads `path` into memory, refusing files larger than `max_bytes`.
+///
+/// One bounded read against a single open handle, not a `metadata()` check
+/// followed by `fs::read`: that pair is not atomic, so a file growing in between
+/// would still be read in full. `parse_local`'s metadata check rejects oversized
+/// files early with a better message, but cannot be the memory bound.
+///
+/// # Errors
+///
+/// [`DomainError::IoError`] if the file cannot be opened or read;
+/// [`DomainError::InvalidRequest`] if it holds more than `max_bytes`.
+pub async fn read_bounded(path: &Path, max_bytes: u64) -> Result<Vec<u8>, DomainError> {
+    let file = tokio::fs::File::open(path)
+        .await
+        .map_err(|e| DomainError::io_error(format!("Failed to read file: {e}")))?;
+
+    // One byte past the limit, so an oversized file is distinguishable from one
+    // that exactly fills it.
+    let mut content = Vec::new();
+    let read = file
+        .take(max_bytes.saturating_add(1))
+        .read_to_end(&mut content)
+        .await
+        .map_err(|e| DomainError::io_error(format!("Failed to read file: {e}")))?;
+
+    if read as u64 > max_bytes {
+        return Err(DomainError::invalid_request(format!(
+            "File size exceeds maximum of {max_bytes} bytes"
+        )));
+    }
+
+    Ok(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_bounded;
+
+    #[tokio::test]
+    async fn reads_a_file_that_fits() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("small.txt");
+        std::fs::write(&path, b"hello").expect("write");
+
+        let content = read_bounded(&path, 5).await.expect("exactly at the limit");
+
+        assert_eq!(content, b"hello");
+    }
+
+    #[tokio::test]
+    async fn rejects_a_file_over_the_limit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("big.txt");
+        std::fs::write(&path, b"hello world").expect("write");
+
+        let err = read_bounded(&path, 5)
+            .await
+            .expect_err("one byte over the limit must be rejected");
+
+        assert!(
+            matches!(
+                err,
+                crate::domain::error::DomainError::InvalidRequest { .. }
+            ),
+            "expected InvalidRequest, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_file_is_an_io_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let err = read_bounded(&dir.path().join("nope.txt"), 1024)
+            .await
+            .expect_err("a missing file must error");
+
+        assert!(
+            matches!(err, crate::domain::error::DomainError::IoError { .. }),
+            "expected IoError, got {err:?}"
+        );
+    }
+}

--- a/gears/file-parser/file-parser/src/infra/parsers/docx_parser.rs
+++ b/gears/file-parser/file-parser/src/infra/parsers/docx_parser.rs
@@ -34,6 +34,7 @@ impl FileParserBackend for DocxParser {
     async fn parse_local_path(
         &self,
         path: &Path,
+        _resolved_content_type: Option<&str>,
     ) -> Result<crate::domain::ir::ParsedDocument, DomainError> {
         let path_buf = path.to_path_buf();
 

--- a/gears/file-parser/file-parser/src/infra/parsers/image_parser.rs
+++ b/gears/file-parser/file-parser/src/infra/parsers/image_parser.rs
@@ -43,21 +43,15 @@ impl ImageParser {
         Self
     }
 
-    /// Determine MIME type from file extension
+    /// Determine MIME type from file extension, restricted to the formats
+    /// this parser actually handles (the canonical table also carries
+    /// non-image extensions used by other backends).
     fn mime_type_from_extension(extension: &str) -> Option<&'static str> {
-        if extension.eq_ignore_ascii_case("png") {
-            return Some("image/png");
+        let extension = extension.to_lowercase();
+        if !SUPPORTED_EXTENSIONS.iter().any(|ext| *ext == extension) {
+            return None;
         }
-        if extension.eq_ignore_ascii_case("jpg") || extension.eq_ignore_ascii_case("jpeg") {
-            return Some("image/jpeg");
-        }
-        if extension.eq_ignore_ascii_case("webp") {
-            return Some("image/webp");
-        }
-        if extension.eq_ignore_ascii_case("gif") {
-            return Some("image/gif");
-        }
-        None
+        crate::domain::mime_table::mime_for_extension(&extension)
     }
 
     /// Determine MIME type from filename or provided content type
@@ -112,6 +106,7 @@ impl FileParserBackend for ImageParser {
     async fn parse_local_path(
         &self,
         path: &Path,
+        resolved_content_type: Option<&str>,
     ) -> Result<crate::domain::ir::ParsedDocument, DomainError> {
         // Check file size before reading
         let metadata = tokio::fs::metadata(path)
@@ -126,19 +121,27 @@ impl FileParserBackend for ImageParser {
             )));
         }
 
-        // Read file bytes
-        let bytes = tokio::fs::read(path)
-            .await
-            .map_err(|e| DomainError::io_error(format!("Failed to read image file: {e}")))?;
+        // The check above gives the precise "too large" message; this is what
+        // bounds the allocation, since metadata-then-read is not atomic.
+        let bytes = super::bounded_read::read_bounded(path, MAX_IMAGE_SIZE_BYTES).await?;
 
-        // Determine MIME type from extension
-        let extension = path
-            .extension()
-            .and_then(|s| s.to_str())
-            .ok_or_else(|| DomainError::unsupported_file_type("no extension"))?;
-
-        let mime_type = Self::mime_type_from_extension(extension)
-            .ok_or_else(|| DomainError::unsupported_file_type(extension))?;
+        // Prefer the resolved MIME, but require it to be an image type — the
+        // same guard `determine_mime_type` applies on the `parse_bytes` path. It
+        // cannot fire today; keeping both paths symmetric is what stops that
+        // from quietly becoming untrue.
+        let mime_type = match resolved_content_type {
+            Some(mime) if mime.starts_with("image/") => mime.to_owned(),
+            _ => {
+                let extension = path
+                    .extension()
+                    .and_then(|s| s.to_str())
+                    .ok_or_else(|| DomainError::unsupported_file_type("no extension"))?;
+                Self::mime_type_from_extension(extension)
+                    .ok_or_else(|| DomainError::unsupported_file_type(extension))?
+                    .to_owned()
+            }
+        };
+        let mime_type = mime_type.as_str();
 
         // Build data URI
         let data_uri = Self::build_data_uri(mime_type, &bytes);

--- a/gears/file-parser/file-parser/src/infra/parsers/kreuzberg_parser.rs
+++ b/gears/file-parser/file-parser/src/infra/parsers/kreuzberg_parser.rs
@@ -26,6 +26,11 @@ use super::ir_convert::result_to_blocks;
 /// | `pptx`                 | `application/vnd.openxmlformats-officedocument.presentationml.presentation`  |
 pub struct KreuzbergParser;
 
+/// Extensions this backend can extract; standalone so `mime_for_ext` can
+/// filter against it too.
+const SUPPORTED_EXTENSIONS: &[&str] =
+    &["pdf", "html", "htm", "xlsx", "xls", "xlsm", "xlsb", "pptx"];
+
 impl KreuzbergParser {
     #[must_use]
     pub fn new() -> Self {
@@ -39,21 +44,18 @@ impl KreuzbergParser {
         }
     }
 
-    /// Map a file extension to its canonical MIME type.
+    /// Map an extension to its canonical MIME, restricted to
+    /// `supported_extensions()`: the shared table also carries extensions other
+    /// backends own, which Kreuzberg would extract wrong.
     #[must_use]
     fn mime_for_ext(ext: &str) -> Option<&'static str> {
-        match ext.to_lowercase().as_str() {
-            "pdf" => Some("application/pdf"),
-            "html" | "htm" => Some("text/html"),
-            "xlsx" => Some("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
-            "xls" => Some("application/vnd.ms-excel"),
-            "xlsm" => Some("application/vnd.ms-excel.sheet.macroEnabled.12"),
-            "xlsb" => Some("application/vnd.ms-excel.sheet.binary.macroEnabled.12"),
-            "pptx" => {
-                Some("application/vnd.openxmlformats-officedocument.presentationml.presentation")
-            }
-            _ => None,
+        if !SUPPORTED_EXTENSIONS
+            .iter()
+            .any(|e| e.eq_ignore_ascii_case(ext))
+        {
+            return None;
         }
+        crate::domain::mime_table::mime_for_extension(ext)
     }
 }
 
@@ -70,19 +72,23 @@ impl FileParserBackend for KreuzbergParser {
     }
 
     fn supported_extensions(&self) -> &'static [&'static str] {
-        &["pdf", "html", "htm", "xlsx", "xls", "xlsm", "xlsb", "pptx"]
+        SUPPORTED_EXTENSIONS
     }
 
     async fn parse_local_path(
         &self,
         path: &Path,
+        resolved_content_type: Option<&str>,
     ) -> Result<crate::domain::ir::ParsedDocument, DomainError> {
         let path_str = path
             .to_str()
             .ok_or_else(|| DomainError::io_error("File path is not valid UTF-8"))?;
 
-        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-        let mime = Self::mime_for_ext(ext);
+        // Prefer the resolved MIME type over re-deriving one from `path`.
+        let mime = resolved_content_type.or_else(|| {
+            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+            Self::mime_for_ext(ext)
+        });
 
         let config = Self::config();
         let result = extract_file(path_str, mime, &config)

--- a/gears/file-parser/file-parser/src/infra/parsers/mod.rs
+++ b/gears/file-parser/file-parser/src/infra/parsers/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod bounded_read;
 pub mod docx_parser;
 pub mod image_parser;
 pub mod ir_convert;

--- a/gears/file-parser/file-parser/src/infra/parsers/plain_text.rs
+++ b/gears/file-parser/file-parser/src/infra/parsers/plain_text.rs
@@ -5,13 +5,33 @@ use crate::domain::error::DomainError;
 use crate::domain::ir::{DocumentBuilder, Inline, ParsedBlock, ParsedSource};
 use crate::domain::parser::FileParserBackend;
 
+use super::bounded_read::read_bounded;
+
 /// Plain text parser that handles text files
-pub struct PlainTextParser;
+pub struct PlainTextParser {
+    max_bytes: u64,
+}
+
+/// Ceiling applied by [`PlainTextParser::new`], matching `FileParserConfig`'s
+/// `max_file_size_mb` default. `Gear::init` replaces it with the configured
+/// value via [`PlainTextParser::with_max_bytes`].
+const DEFAULT_MAX_BYTES: u64 = 100 * 1024 * 1024;
 
 impl PlainTextParser {
     #[must_use]
     pub fn new() -> Self {
-        Self
+        Self {
+            max_bytes: DEFAULT_MAX_BYTES,
+        }
+    }
+
+    /// Caps how much this parser reads from a local file into memory. The
+    /// service's up-front `metadata()` check is not atomic against the file
+    /// growing; this is what actually bounds the allocation.
+    #[must_use]
+    pub fn with_max_bytes(mut self, max_bytes: u64) -> Self {
+        self.max_bytes = max_bytes;
+        self
     }
 }
 
@@ -34,10 +54,9 @@ impl FileParserBackend for PlainTextParser {
     async fn parse_local_path(
         &self,
         path: &Path,
+        _resolved_content_type: Option<&str>,
     ) -> Result<crate::domain::ir::ParsedDocument, DomainError> {
-        let content = tokio::fs::read(path)
-            .await
-            .map_err(|e| DomainError::io_error(format!("Failed to read file: {e}")))?;
+        let content = read_bounded(path, self.max_bytes).await?;
 
         let text = String::from_utf8(content)
             .map_err(|e| DomainError::parse_error(format!("Failed to decode UTF-8: {e}")))?;

--- a/gears/file-parser/file-parser/src/infra/parsers/stub.rs
+++ b/gears/file-parser/file-parser/src/infra/parsers/stub.rs
@@ -5,14 +5,34 @@ use crate::domain::error::DomainError;
 use crate::domain::ir::{DocumentBuilder, Inline, ParsedBlock, ParsedSource};
 use crate::domain::parser::FileParserBackend;
 
+use super::bounded_read::read_bounded;
+
 /// Stub parser that provides placeholder parsing for various file types
 /// This is a temporary implementation until proper parsers are integrated
-pub struct StubParser;
+pub struct StubParser {
+    max_bytes: u64,
+}
+
+/// Ceiling applied by [`StubParser::new`], matching `FileParserConfig`'s
+/// `max_file_size_mb` default. `Gear::init` replaces it with the configured
+/// value via [`StubParser::with_max_bytes`].
+const DEFAULT_MAX_BYTES: u64 = 100 * 1024 * 1024;
 
 impl StubParser {
     #[must_use]
     pub fn new() -> Self {
-        Self
+        Self {
+            max_bytes: DEFAULT_MAX_BYTES,
+        }
+    }
+
+    /// Caps how much this parser reads from a local file into memory. The
+    /// service's up-front `metadata()` check is not atomic against the file
+    /// growing; this is what actually bounds the allocation.
+    #[must_use]
+    pub fn with_max_bytes(mut self, max_bytes: u64) -> Self {
+        self.max_bytes = max_bytes;
+        self
     }
 }
 
@@ -35,10 +55,9 @@ impl FileParserBackend for StubParser {
     async fn parse_local_path(
         &self,
         path: &Path,
+        _resolved_content_type: Option<&str>,
     ) -> Result<crate::domain::ir::ParsedDocument, DomainError> {
-        let content = tokio::fs::read(path)
-            .await
-            .map_err(|e| DomainError::io_error(format!("Failed to read file: {e}")))?;
+        let content = read_bounded(path, self.max_bytes).await?;
 
         let bytes = bytes::Bytes::from(content);
         let file_name = path

--- a/gears/file-parser/file-parser/src/lib.rs
+++ b/gears/file-parser/file-parser/src/lib.rs
@@ -2,12 +2,11 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 // === PUBLIC API (from SDK) ===
-// Other gears (e.g. scan-gateway) should prefer depending on
-// `cf-gears-file-parser-sdk` directly rather than this implementation crate
-// (it pulls in kreuzberg/docx-rust transitively); these re-exports exist for
-// convenience/back-compat only.
+// Other gears should prefer depending on `cf-gears-file-parser-sdk` directly
+// rather than this implementation crate (it pulls in kreuzberg/docx-rust
+// transitively); these re-exports exist for convenience/back-compat only.
 pub use file_parser_sdk::{
-    FileParserClientError, FileParserClientV1, ParseBytesRequest, ParsedText,
+    Detection, FileParserClientError, FileParserClientV1, ParseBytesRequest, ParsedText,
 };
 
 // === MODULE DEFINITION ===

--- a/gears/file-parser/file-parser/tests/detection_precedence_tests.rs
+++ b/gears/file-parser/file-parser/tests/detection_precedence_tests.rs
@@ -1,0 +1,705 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Exercises `FileParserService`'s content-detection precedence logic against
+//! a fake `ContentTypeDetector`, independent of the `magika` feature — no
+//! real model/ONNX Runtime needed, so these run in every build.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use file_parser::Detection;
+use file_parser::domain::detector::{Confidence, ContentTypeDetector, DetectedType};
+use file_parser::domain::error::DomainError;
+use file_parser::domain::parser::FileParserBackend;
+use file_parser::domain::service::{FileParserService, ServiceConfig};
+use file_parser::infra::parsers::{ImageParser, KreuzbergParser, PlainTextParser, StubParser};
+
+/// Always returns the same canned detection result.
+struct FixedDetector(Option<DetectedType>);
+
+#[async_trait]
+impl ContentTypeDetector for FixedDetector {
+    async fn detect(&self, _bytes: Bytes) -> Option<DetectedType> {
+        self.0.clone()
+    }
+
+    async fn detect_path(&self, _path: &std::path::Path) -> Option<DetectedType> {
+        self.0.clone()
+    }
+}
+
+/// One `parse_bytes` invocation, as the backend saw it.
+struct ReceivedHints {
+    #[allow(dead_code)] // captured for debugging; assertions target content_type
+    filename: Option<String>,
+    content_type: Option<String>,
+}
+
+/// Records the hints the service handed it, so a test can assert on what the
+/// backend actually received rather than inferring it from parsed output.
+struct RecordingParser {
+    extensions: &'static [&'static str],
+    received: std::sync::Mutex<Vec<ReceivedHints>>,
+}
+
+impl RecordingParser {
+    fn new(extensions: &'static [&'static str]) -> Self {
+        Self {
+            extensions,
+            received: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// The `content_type` handed to the most recent `parse_bytes` call.
+    fn last_content_type(&self) -> Option<String> {
+        self.received
+            .lock()
+            .expect("no test panics while holding this lock")
+            .last()
+            .and_then(|hints| hints.content_type.clone())
+    }
+}
+
+#[async_trait]
+impl FileParserBackend for RecordingParser {
+    fn id(&self) -> &'static str {
+        "recording"
+    }
+
+    fn supported_extensions(&self) -> &'static [&'static str] {
+        self.extensions
+    }
+
+    async fn parse_local_path(
+        &self,
+        _path: &std::path::Path,
+        _resolved_content_type: Option<&str>,
+    ) -> Result<file_parser::domain::ir::ParsedDocument, DomainError> {
+        unimplemented!("this fake is only used on the parse_bytes path")
+    }
+
+    async fn parse_bytes(
+        &self,
+        filename_hint: Option<&str>,
+        content_type: Option<&str>,
+        _bytes: Bytes,
+    ) -> Result<file_parser::domain::ir::ParsedDocument, DomainError> {
+        self.received
+            .lock()
+            .expect("no test panics while holding this lock")
+            .push(ReceivedHints {
+                filename: filename_hint.map(ToOwned::to_owned),
+                content_type: content_type.map(ToOwned::to_owned),
+            });
+
+        Ok(file_parser::domain::ir::DocumentBuilder::new(
+            file_parser::domain::ir::ParsedSource::Uploaded {
+                original_name: filename_hint.unwrap_or("unknown").to_owned(),
+            },
+        )
+        .blocks(Vec::new())
+        .build())
+    }
+}
+
+fn detected(extension: &str, confidence: f32) -> DetectedType {
+    DetectedType {
+        extension: extension.to_owned(),
+        confidence: Confidence::new(confidence).expect("test confidence must not be NaN"),
+    }
+}
+
+/// Registers `PlainTextParser` (txt/log/md) and `StubParser` (doc/rtf/...)
+/// so tests can tell which one handled a request from `meta.is_stub`.
+fn service_with_detector(
+    detected: Option<DetectedType>,
+    base_dir: std::path::PathBuf,
+) -> FileParserService {
+    let parsers: Vec<Arc<dyn FileParserBackend>> = vec![
+        Arc::new(PlainTextParser::new()),
+        Arc::new(StubParser::new()),
+    ];
+    let config = ServiceConfig {
+        max_file_size_bytes: 10 * 1024 * 1024,
+        allowed_local_base_dir: base_dir,
+    };
+    FileParserService::new(parsers, config).with_detector(Arc::new(FixedDetector(detected)))
+}
+
+fn service_without_detector(base_dir: std::path::PathBuf) -> FileParserService {
+    let parsers: Vec<Arc<dyn FileParserBackend>> = vec![Arc::new(PlainTextParser::new())];
+    let config = ServiceConfig {
+        max_file_size_bytes: 10 * 1024 * 1024,
+        allowed_local_base_dir: base_dir,
+    };
+    FileParserService::new(parsers, config)
+}
+
+// ---------------------------------------------------------------------
+// parse_bytes
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn confident_detection_fills_in_missing_hint() {
+    let svc = service_with_detector(Some(detected("txt", 0.99)), std::env::temp_dir());
+
+    let doc = svc
+        .parse_bytes(None, None, Bytes::from_static(b"hello"), Detection::Auto)
+        .await
+        .expect("confident detection should resolve a missing hint");
+
+    assert!(
+        !doc.meta.is_stub,
+        "should have routed to PlainTextParser via detection, not the stub"
+    );
+}
+
+#[tokio::test]
+async fn confident_detection_overrides_a_wrong_extension_hint() {
+    let svc = service_with_detector(Some(detected("txt", 0.99)), std::env::temp_dir());
+
+    // The filename says `.doc` (routes to StubParser by extension alone),
+    // but detection confidently says `txt`.
+    let doc = svc
+        .parse_bytes(
+            Some("report.doc"),
+            None,
+            Bytes::from_static(b"hello"),
+            Detection::Auto,
+        )
+        .await
+        .expect("confident detection should override the wrong extension");
+
+    assert!(
+        !doc.meta.is_stub,
+        "a confident detection must win over a present-but-wrong extension hint"
+    );
+}
+
+#[tokio::test]
+async fn a_raised_threshold_makes_a_previously_confident_detection_fall_back() {
+    // Pin that the configurable threshold takes effect: a 0.95 detection wins
+    // at the default and loses once the bar is raised above it.
+    let detection = detected("txt", 0.95);
+
+    let permissive = service_with_detector(Some(detection.clone()), std::env::temp_dir());
+    let doc = permissive
+        .parse_bytes(
+            Some("report.doc"),
+            None,
+            Bytes::from_static(b"hello"),
+            Detection::Auto,
+        )
+        .await
+        .expect("0.95 clears the default 0.90 threshold");
+    assert!(
+        !doc.meta.is_stub,
+        "at the default threshold, detection wins"
+    );
+
+    let strict = service_with_detector(Some(detection), std::env::temp_dir())
+        .with_detection_confidence_threshold(
+            Confidence::new(0.99).expect("0.99 is a valid confidence"),
+        );
+    let doc = strict
+        .parse_bytes(
+            Some("report.doc"),
+            None,
+            Bytes::from_static(b"hello"),
+            Detection::Auto,
+        )
+        .await
+        .expect("falling back to the .doc hint must still parse, via StubParser");
+    assert!(
+        doc.meta.is_stub,
+        "raising the threshold above the detection's confidence must fall back to the hint"
+    );
+}
+
+#[tokio::test]
+async fn confidence_exactly_at_threshold_is_treated_as_confident() {
+    // Mirrors the default threshold (`DEFAULT_DETECTION_CONFIDENCE_THRESHOLD`,
+    // 0.90); the comparison is `>=`, so this exact value must win.
+    let svc = service_with_detector(Some(detected("txt", 0.90)), std::env::temp_dir());
+
+    let doc = svc
+        .parse_bytes(
+            Some("report.doc"),
+            None,
+            Bytes::from_static(b"hello"),
+            Detection::Auto,
+        )
+        .await
+        .expect("confidence exactly at the threshold should be treated as confident");
+
+    assert!(
+        !doc.meta.is_stub,
+        "a detection exactly at the threshold must override the extension hint"
+    );
+}
+
+#[tokio::test]
+async fn low_confidence_detection_falls_back_to_the_hint() {
+    let svc = service_with_detector(Some(detected("txt", 0.50)), std::env::temp_dir());
+
+    let doc = svc
+        .parse_bytes(
+            Some("report.doc"),
+            None,
+            Bytes::from_static(b"hello"),
+            Detection::Auto,
+        )
+        .await
+        .expect("should fall back to the extension hint");
+
+    assert!(
+        doc.meta.is_stub,
+        "below the confidence threshold, the caller-supplied hint must win"
+    );
+}
+
+#[tokio::test]
+async fn low_confidence_detection_with_no_hint_errors_like_before_detection_existed() {
+    let svc = service_with_detector(Some(detected("txt", 0.10)), std::env::temp_dir());
+
+    let err = svc
+        .parse_bytes(None, None, Bytes::from_static(b"hello"), Detection::Auto)
+        .await
+        .expect_err("no usable hint and a low-confidence detection must still fail");
+
+    assert!(matches!(
+        err,
+        DomainError::UnsupportedFileType { extension } if extension == "no extension and no content-type"
+    ));
+}
+
+#[tokio::test]
+async fn no_detection_result_falls_back_to_hint() {
+    // Detectors return `None` rather than an extension with no matching
+    // registered parser — simulate that directly here.
+    let svc = service_with_detector(None, std::env::temp_dir());
+
+    let doc = svc
+        .parse_bytes(
+            Some("notes.txt"),
+            None,
+            Bytes::from_static(b"hello"),
+            Detection::Auto,
+        )
+        .await
+        .expect("should fall back to the extension hint");
+
+    assert!(!doc.meta.is_stub);
+}
+
+#[tokio::test]
+async fn no_detection_result_and_unsupported_hint_yields_no_parser_available() {
+    // An unmapped detection degrades to today's behavior: if the hint
+    // itself isn't supported either, it's the pre-existing error, not a new one.
+    let svc = service_with_detector(None, std::env::temp_dir());
+
+    let err = svc
+        .parse_bytes(
+            Some("archive.zip"),
+            None,
+            Bytes::from_static(b"hello"),
+            Detection::Auto,
+        )
+        .await
+        .expect_err("an unsupported hint with no rescuing detection must still fail");
+
+    assert!(matches!(
+        err,
+        DomainError::NoParserAvailable { extension } if extension == "zip"
+    ));
+}
+
+#[tokio::test]
+async fn no_detector_registered_behaves_exactly_as_before() {
+    let svc = service_without_detector(std::env::temp_dir());
+
+    let err = svc
+        .parse_bytes(None, None, Bytes::from_static(b"hello"), Detection::Auto)
+        .await
+        .expect_err("no hint and no detector must fail exactly as before detection existed");
+
+    assert!(matches!(
+        err,
+        DomainError::UnsupportedFileType { extension } if extension == "no extension and no content-type"
+    ));
+}
+
+#[tokio::test]
+async fn content_type_only_txt_upload_routes_without_detector() {
+    // Regression test: the canonical MIME table must map `text/plain` to
+    // `txt` so a `Content-Type`-only upload (no filename, no detector)
+    // still resolves to `PlainTextParser`.
+    let svc = service_without_detector(std::env::temp_dir());
+
+    let doc = svc
+        .parse_bytes(
+            None,
+            Some("text/plain"),
+            Bytes::from_static(b"hello"),
+            Detection::Auto,
+        )
+        .await
+        .expect("a text/plain Content-Type with no filename should resolve to PlainTextParser");
+
+    assert!(!doc.meta.is_stub);
+}
+
+#[tokio::test]
+async fn content_type_only_xlsx_upload_routes_without_detector() {
+    // Regression test: collapsing the three MIME tables into one canonical
+    // table intentionally extends Content-Type-only routing to formats
+    // (xlsx/xls/xlsm/xlsb/pptx) that were previously only resolvable via
+    // filename extension at the gateway. This must keep working even with
+    // no detector registered (i.e. without the `magika` feature).
+    let parsers: Vec<Arc<dyn FileParserBackend>> = vec![Arc::new(StubParser::new())];
+    let config = ServiceConfig {
+        max_file_size_bytes: 10 * 1024 * 1024,
+        allowed_local_base_dir: std::env::temp_dir(),
+    };
+    let svc = FileParserService::new(parsers, config);
+
+    let doc = svc
+        .parse_bytes(
+            None,
+            Some("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+            Bytes::from_static(b"hello"),
+            Detection::Auto,
+        )
+        .await
+        .expect("a Content-Type-only xlsx upload should resolve without a detector");
+
+    assert!(doc.meta.is_stub);
+}
+
+#[tokio::test]
+async fn detected_type_is_passed_to_the_backend_not_the_stale_hint() {
+    // Regression test: the backend selected via the *detected* extension
+    // must receive a `content_type` consistent with that extension, not the
+    // original (missing/wrong) hint. `ImageParser::parse_bytes` requires a
+    // `content_type` starting with `image/` or a filename extension to
+    // determine its MIME type; with no filename and no `Content-Type`
+    // hint, it fails unless the resolved extension's canonical MIME is
+    // threaded through.
+    let parsers: Vec<Arc<dyn FileParserBackend>> = vec![Arc::new(ImageParser::new())];
+    let config = ServiceConfig {
+        max_file_size_bytes: 10 * 1024 * 1024,
+        allowed_local_base_dir: std::env::temp_dir(),
+    };
+    let svc = FileParserService::new(parsers, config)
+        .with_detector(Arc::new(FixedDetector(Some(detected("png", 0.99)))));
+
+    let doc = svc
+        .parse_bytes(
+            None,
+            None,
+            Bytes::from_static(b"fake-png-bytes"),
+            Detection::Auto,
+        )
+        .await
+        .expect(
+            "a confident png detection with no hint must route to ImageParser AND supply it \
+             a usable content_type",
+        );
+
+    assert_eq!(doc.meta.content_type.as_deref(), Some("image/png"));
+}
+
+#[tokio::test]
+async fn detected_html_overrides_a_wrong_extension_and_still_parses_via_kreuzberg() {
+    // Real KreuzbergParser, not the hint-agnostic backends the other tests use:
+    // detection must leave it able to extract, not just able to be selected.
+    let parsers: Vec<Arc<dyn FileParserBackend>> = vec![Arc::new(KreuzbergParser::new())];
+    let config = ServiceConfig {
+        max_file_size_bytes: 10 * 1024 * 1024,
+        allowed_local_base_dir: std::env::temp_dir(),
+    };
+    let svc = FileParserService::new(parsers, config)
+        .with_detector(Arc::new(FixedDetector(Some(detected("html", 0.99)))));
+
+    let doc = svc
+        .parse_bytes(
+            Some("report.doc"),
+            None,
+            Bytes::from_static(b"<html><body><p>hello</p></body></html>"),
+            Detection::Auto,
+        )
+        .await
+        .expect("detection should route to KreuzbergParser and supply an extractable MIME");
+
+    assert_eq!(doc.meta.content_type.as_deref(), Some("text/html"));
+}
+
+#[tokio::test]
+async fn detected_extension_override_replaces_the_stale_caller_content_type() {
+    // Regression test: when a confident detection overrides the caller's
+    // hint extension, the caller's `Content-Type` describes the *old*
+    // (wrong) type and must not be threaded through to the backend — the
+    // canonical MIME for the *detected* extension must win instead. This is
+    // the mirror case of `explicit_content_type_survives_a_conflicting_canonical_mime_for_the_extension`,
+    // which only covers the no-detector / hint-wins path.
+    let recorder = Arc::new(RecordingParser::new(&["html", "htm"]));
+    let parsers: Vec<Arc<dyn FileParserBackend>> = vec![recorder.clone()];
+    let config = ServiceConfig {
+        max_file_size_bytes: 10 * 1024 * 1024,
+        allowed_local_base_dir: std::env::temp_dir(),
+    };
+    let svc = FileParserService::new(parsers, config)
+        .with_detector(Arc::new(FixedDetector(Some(detected("html", 0.99)))));
+
+    svc.parse_bytes(
+        Some("notes.txt"),
+        Some("text/plain"),
+        Bytes::from_static(b"<html></html>"),
+        Detection::Auto,
+    )
+    .await
+    .expect("the detected html extension must route to the recording backend");
+
+    assert_eq!(
+        recorder.last_content_type().as_deref(),
+        Some("text/html"),
+        "once detection overrides the .txt hint, the stale text/plain Content-Type must not \
+         reach the backend, it must be replaced by the detected extension's canonical MIME"
+    );
+}
+
+#[tokio::test]
+async fn explicit_content_type_survives_a_conflicting_canonical_mime_for_the_extension() {
+    // An explicitly supplied Content-Type must win over a value derived from
+    // the filename's extension — the filename is the weaker signal. The
+    // table only fills in a *missing* Content-Type (see
+    // `content_type_only_txt_upload_routes_without_detector` et al.). No
+    // detector here, so this is the default build.
+    let recorder = Arc::new(RecordingParser::new(&["html", "htm"]));
+    let parsers: Vec<Arc<dyn FileParserBackend>> = vec![recorder.clone()];
+    let config = ServiceConfig {
+        max_file_size_bytes: 10 * 1024 * 1024,
+        allowed_local_base_dir: std::env::temp_dir(),
+    };
+    let svc = FileParserService::new(parsers, config);
+
+    svc.parse_bytes(
+        Some("report.html"),
+        Some("text/plain"),
+        Bytes::from_static(b"<html></html>"),
+        Detection::Auto,
+    )
+    .await
+    .expect("the html extension must route to the recording backend");
+
+    assert_eq!(
+        recorder.last_content_type().as_deref(),
+        Some("text/plain"),
+        "an explicitly supplied Content-Type must not be silently replaced by the canonical \
+         MIME for `html`"
+    );
+}
+
+#[tokio::test]
+async fn caller_content_type_survives_when_the_extension_is_not_in_the_canonical_table() {
+    // The other half: with no canonical entry for `rtf`, the caller's
+    // Content-Type passes through untouched regardless.
+    let recorder = Arc::new(RecordingParser::new(&["rtf"]));
+    let parsers: Vec<Arc<dyn FileParserBackend>> = vec![recorder.clone()];
+    let config = ServiceConfig {
+        max_file_size_bytes: 10 * 1024 * 1024,
+        allowed_local_base_dir: std::env::temp_dir(),
+    };
+    let svc = FileParserService::new(parsers, config);
+
+    svc.parse_bytes(
+        Some("notes.rtf"),
+        Some("application/rtf"),
+        Bytes::from_static(b"{\\rtf1}"),
+        Detection::Auto,
+    )
+    .await
+    .expect("the rtf extension must route to the recording backend");
+
+    assert_eq!(
+        recorder.last_content_type().as_deref(),
+        Some("application/rtf"),
+        "with no canonical entry for `rtf`, the caller's Content-Type must be preserved"
+    );
+}
+
+#[tokio::test]
+async fn skip_detection_bypasses_a_registered_detector_and_routes_by_hint() {
+    // A caller that already knows the exact type (in-process/SDK path) can
+    // opt out of detection entirely, even though a detector is registered
+    // and would otherwise confidently override the hint. `doc` is
+    // registered (StubParser) so, without `Detection::Skip`, this exact
+    // detection would win per `confident_detection_overrides_a_wrong_extension_hint`.
+    let svc = service_with_detector(Some(detected("doc", 0.99)), std::env::temp_dir());
+
+    let doc = svc
+        .parse_bytes(
+            Some("notes.txt"),
+            None,
+            Bytes::from_static(b"hello"),
+            Detection::Skip,
+        )
+        .await
+        .expect("Detection::Skip must still route via the hint");
+
+    assert!(
+        !doc.meta.is_stub,
+        "Detection::Skip must route by the .txt hint, ignoring the confident doc detection"
+    );
+}
+
+// ---------------------------------------------------------------------
+// parse_local
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn extensionless_local_file_resolved_via_confident_detection() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("mystery");
+    std::fs::write(&path, b"hello").expect("write temp file");
+
+    let svc = service_with_detector(
+        Some(detected("txt", 0.99)),
+        tmp.path().canonicalize().expect("canonicalize tempdir"),
+    );
+
+    let doc = svc
+        .parse_local(&path)
+        .await
+        .expect("extensionless file should resolve via detection");
+
+    assert!(!doc.meta.is_stub);
+}
+
+#[tokio::test]
+async fn extensionless_local_file_without_a_detector_still_errors() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("mystery");
+    std::fs::write(&path, b"hello").expect("write temp file");
+
+    let svc = service_without_detector(tmp.path().canonicalize().expect("canonicalize tempdir"));
+
+    let err = svc
+        .parse_local(&path)
+        .await
+        .expect_err("no extension and no detector must fail exactly as before detection existed");
+
+    assert!(matches!(err, DomainError::UnsupportedFileType { .. }));
+}
+
+#[tokio::test]
+async fn extensionless_local_file_with_low_confidence_detection_still_errors() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("mystery");
+    std::fs::write(&path, b"hello").expect("write temp file");
+
+    let svc = service_with_detector(
+        Some(detected("txt", 0.10)),
+        tmp.path().canonicalize().expect("canonicalize tempdir"),
+    );
+
+    let err = svc
+        .parse_local(&path)
+        .await
+        .expect_err("a low-confidence detection must not rescue an extensionless file");
+
+    assert!(matches!(err, DomainError::UnsupportedFileType { .. }));
+}
+
+#[tokio::test]
+async fn confident_detection_overrides_a_wrong_extension_for_local_files() {
+    // Regression test: a local file with a present-but-wrong extension must
+    // still be corrected by a confident detection, matching parse_bytes's
+    // precedence — not routed by the extension unconditionally.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("report.doc");
+    std::fs::write(&path, b"hello").expect("write temp file");
+
+    let svc = service_with_detector(
+        Some(detected("txt", 0.99)),
+        tmp.path().canonicalize().expect("canonicalize tempdir"),
+    );
+
+    let doc = svc
+        .parse_local(&path)
+        .await
+        .expect("confident detection should override the wrong extension");
+
+    assert!(
+        !doc.meta.is_stub,
+        "a confident detection must win over a present-but-wrong extension for local files too"
+    );
+}
+
+#[tokio::test]
+async fn low_confidence_detection_falls_back_to_the_extension_for_local_files() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("report.doc");
+    std::fs::write(&path, b"hello").expect("write temp file");
+
+    let svc = service_with_detector(
+        Some(detected("txt", 0.10)),
+        tmp.path().canonicalize().expect("canonicalize tempdir"),
+    );
+
+    let doc = svc
+        .parse_local(&path)
+        .await
+        .expect("should fall back to the extension hint");
+
+    assert!(
+        doc.meta.is_stub,
+        "below the confidence threshold, the file's own extension must win"
+    );
+}
+
+#[tokio::test]
+async fn detected_type_is_passed_to_the_backend_for_local_files_too() {
+    // parse_local counterpart to detected_type_is_passed_to_the_backend_not_the_stale_hint.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("report.doc");
+    std::fs::write(&path, b"fake-png-bytes").expect("write temp file");
+
+    let parsers: Vec<Arc<dyn FileParserBackend>> = vec![Arc::new(ImageParser::new())];
+    let config = ServiceConfig {
+        max_file_size_bytes: 10 * 1024 * 1024,
+        allowed_local_base_dir: tmp.path().canonicalize().expect("canonicalize tempdir"),
+    };
+    let svc = FileParserService::new(parsers, config)
+        .with_detector(Arc::new(FixedDetector(Some(detected("png", 0.99)))));
+
+    let doc = svc
+        .parse_local(&path)
+        .await
+        .expect("detection should route to ImageParser and supply a usable content_type");
+
+    assert_eq!(doc.meta.content_type.as_deref(), Some("image/png"));
+}
+
+#[tokio::test]
+async fn local_file_over_the_size_limit_is_rejected_even_without_a_detector() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("big.txt");
+    std::fs::write(&path, vec![b'a'; 20]).expect("write temp file");
+
+    let parsers: Vec<Arc<dyn FileParserBackend>> = vec![Arc::new(PlainTextParser::new())];
+    let config = ServiceConfig {
+        max_file_size_bytes: 10,
+        allowed_local_base_dir: tmp.path().canonicalize().expect("canonicalize tempdir"),
+    };
+    let svc = FileParserService::new(parsers, config);
+
+    let err = svc
+        .parse_local(&path)
+        .await
+        .expect_err("a local file over the configured size limit must be rejected");
+
+    assert!(matches!(err, DomainError::InvalidRequest { .. }));
+}

--- a/gears/file-parser/file-parser/tests/docx_parser_tests.rs
+++ b/gears/file-parser/file-parser/tests/docx_parser_tests.rs
@@ -35,7 +35,7 @@ async fn test_docx_parser_with_working_file() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(
         result.is_ok(),
@@ -64,7 +64,7 @@ async fn test_docx_parser_with_two_page_file() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     // Note: docx-rust has issues with files containing gradient fills without
     // the "rotate_with_shape" field, so this may fail
@@ -92,7 +92,7 @@ async fn test_docx_parser_with_big_english_file() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     // Note: docx-rust has issues with files containing gradient fills without
     // the "rotate_with_shape" field, so this may fail
@@ -121,7 +121,7 @@ async fn test_docx_parser_with_edge_cases_file_returns_error() {
     }
 
     // This should return an error due to parser limitations
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
     assert!(
         result.is_ok(),
         "Failed to parse DOCX from bytes: {:?}",
@@ -145,7 +145,7 @@ async fn test_docx_parser_with_image_multilingual_file() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(
         result.is_ok(),
@@ -232,7 +232,7 @@ async fn test_docx_parser_nonexistent_file() {
     let parser = DocxParser::new();
     let nonexistent = PathBuf::from("/nonexistent/path/to/file.docx");
 
-    let result = parser.parse_local_path(&nonexistent).await;
+    let result = parser.parse_local_path(&nonexistent, None).await;
 
     assert!(result.is_err(), "Should fail on nonexistent file");
 
@@ -279,7 +279,7 @@ async fn test_docx_parser_extracts_tables() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
     assert!(
         result.is_ok(),
         "Failed to parse DOCX file: {:?}",
@@ -343,7 +343,7 @@ async fn test_docx_parser_table_edge_cases() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
     assert!(
         result.is_ok(),
         "Failed to parse DOCX file: {:?}",

--- a/gears/file-parser/file-parser/tests/image_parser_tests.rs
+++ b/gears/file-parser/file-parser/tests/image_parser_tests.rs
@@ -39,7 +39,7 @@ async fn test_image_parser_png() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(
         result.is_ok(),
@@ -90,7 +90,7 @@ async fn test_image_parser_jpg() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(
         result.is_ok(),
@@ -123,7 +123,7 @@ async fn test_image_parser_webp() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(
         result.is_ok(),
@@ -159,7 +159,7 @@ async fn test_image_parser_gif() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(
         result.is_ok(),
@@ -252,7 +252,7 @@ async fn test_image_parser_unsupported_extension() {
     // Create a temporary path with unsupported extension
     let temp_path = PathBuf::from("/tmp/test.bmp");
 
-    let result = parser.parse_local_path(&temp_path).await;
+    let result = parser.parse_local_path(&temp_path, None).await;
 
     // Should fail with unsupported file type error
     assert!(result.is_err(), "Should fail for unsupported extension");

--- a/gears/file-parser/file-parser/tests/magika_detector_tests.rs
+++ b/gears/file-parser/file-parser/tests/magika_detector_tests.rs
@@ -1,0 +1,141 @@
+#![cfg(feature = "magika")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Runtime smoke tests for the real `MagikaDetector`. Only compiled with
+//! `--features magika`; needs an ONNX Runtime shared library at run time,
+//! pointed to via `ORT_DYLIB_PATH` (minor version >= 24 — see the workspace
+//! `ort` dependency comment in Cargo.toml).
+//!
+//! `MagikaDetector::new` is called through [`new_detector`], not directly:
+//! `ort` 2.0.0-rc.12 deadlocks instead of erroring when the runtime it loads
+//! is missing/incompatible (confirmed via stack sampling), so a bare call
+//! here would hang `cargo test` forever for anyone running this without
+//! `ORT_DYLIB_PATH` set to a compatible library. See the matching mitigation
+//! in `gear.rs`.
+
+use std::time::Duration;
+
+use file_parser::domain::detector::ContentTypeDetector;
+use file_parser::infra::MagikaDetector;
+
+const INIT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Bounded wrapper around `MagikaDetector::new`. Panics with a clear message
+/// on timeout or load failure instead of ever hanging the test binary.
+async fn new_detector(
+    extensions: impl IntoIterator<Item = impl Into<String>> + Send + 'static,
+) -> MagikaDetector {
+    let extensions: Vec<String> = extensions.into_iter().map(Into::into).collect();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    std::thread::spawn(move || {
+        drop(tx.send(MagikaDetector::new(extensions)));
+    });
+
+    tokio::time::timeout(INIT_TIMEOUT, rx)
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "Magika detector init did not finish within {}s — set ORT_DYLIB_PATH to a \
+                 compatible (minor version >= 24) ONNX Runtime shared library",
+                INIT_TIMEOUT.as_secs()
+            )
+        })
+        .expect("init thread died unexpectedly")
+        .expect("Magika session should load")
+}
+
+#[tokio::test]
+async fn identifies_pdf_content_with_high_confidence() {
+    let detector = new_detector(["txt", "log", "md", "pdf", "html", "docx", "png", "jpg"]).await;
+
+    // A structurally complete single-page PDF (catalog, page tree, content
+    // stream, and xref table) — Magika is a content classifier, not a
+    // magic-byte matcher, so a too-minimal fixture risks lower/unstable
+    // confidence on model updates. Larger and closer to a real document
+    // keeps this assertion stable.
+    let pdf_bytes: &[u8] = b"%PDF-1.4\n\
+1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
+2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\
+3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\nendobj\n\
+4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n\
+5 0 obj\n<< /Length 68 >>\nstream\nBT /F1 24 Tf 72 712 Td (Hello, Magika detection test!) Tj ET\nendstream\nendobj\n\
+xref\n0 6\n\
+0000000000 65535 f \n\
+0000000009 00000 n \n\
+0000000058 00000 n \n\
+0000000114 00000 n \n\
+0000000265 00000 n \n\
+0000000336 00000 n \n\
+trailer\n<< /Size 6 /Root 1 0 R >>\n\
+startxref\n456\n\
+%%EOF";
+
+    let result = detector
+        .detect(bytes::Bytes::from_static(pdf_bytes))
+        .await
+        .expect("should detect a PDF-like byte stream");
+
+    assert_eq!(result.extension, "pdf");
+    assert!(
+        result.confidence.get() > 0.5,
+        "expected reasonably confident PDF detection, got {}",
+        result.confidence
+    );
+}
+
+/// The detector must survive callers that give up mid-inference.
+///
+/// An earlier design moved the session out of a pool and returned it by hand
+/// after the `.await`, so a dropped future skipped the return and destroyed it;
+/// enough cancellations drained the pool and later requests hung forever.
+/// Holding the mutex guard inside the blocking task releases it via `Drop`.
+///
+/// Asserts observable behaviour, not internals, and is bounded by a timeout so a
+/// regression fails an assertion instead of hanging the binary.
+#[tokio::test]
+async fn detector_survives_cancelled_detections() {
+    let detector = new_detector(["txt", "pdf", "html"]).await;
+    let html = bytes::Bytes::from_static(
+        b"<!DOCTYPE html><html><head><title>t</title></head><body><p>hi</p></body></html>",
+    );
+
+    // Drop enough pre-poll detections that any per-cancellation session loss
+    // would exhaust a pool of any plausible size.
+    for _ in 0..8 {
+        let pending = detector.detect(html.clone());
+        drop(pending);
+    }
+
+    // Then cancel one that has actually begun, so the drop lands after
+    // `spawn_blocking` rather than before the first poll.
+    let started = detector.detect(html.clone());
+    let timed_out = tokio::time::timeout(Duration::from_millis(1), started).await;
+    drop(timed_out);
+
+    let result = tokio::time::timeout(INIT_TIMEOUT, detector.detect(html))
+        .await
+        .expect("detector must still respond after cancelled detections, not hang");
+
+    assert_eq!(
+        result.map(|d| d.extension),
+        Some("html".to_owned()),
+        "a cancelled detection must not consume the session permanently"
+    );
+}
+
+#[tokio::test]
+async fn unmapped_detection_returns_none() {
+    // Constructed with no registered extensions at all, so nothing this
+    // detector identifies can ever have a matching entry.
+    let detector = new_detector(Vec::<String>::new()).await;
+
+    let pdf_bytes =
+        b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\ntrailer\n<< /Root 1 0 R >>\n%%EOF";
+
+    assert!(
+        detector
+            .detect(bytes::Bytes::from_static(pdf_bytes))
+            .await
+            .is_none()
+    );
+}

--- a/gears/file-parser/file-parser/tests/magika_timeout_tests.rs
+++ b/gears/file-parser/file-parser/tests/magika_timeout_tests.rs
@@ -1,0 +1,67 @@
+#![cfg(feature = "magika")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Proves the startup timeout in `gear.rs` bounds the `ort` 2.0.0-rc.12 hang on
+//! an unloadable runtime. Needs `ORT_DYLIB_PATH` pointed at an ONNX Runtime
+//! older than `api-24` requires (e.g. Firefox's bundled 1.22.x); run manually,
+//! since CI has no known-bad runtime to hand:
+//!
+//! ```text
+//! ORT_DYLIB_PATH=/Applications/Firefox.app/Contents/MacOS/libonnxruntime.dylib \
+//!   cargo test -p cf-gears-file-parser --features magika --test magika_timeout_tests -- --ignored
+//! ```
+//!
+//! So **the timeout arm is not covered by CI** — `test-magika` provisions a
+//! compatible runtime, which cannot trigger the hang. Only the cancellation arm
+//! below runs automatically. Fixing that needs a CI fixture pinning a
+//! deliberately old runtime alongside the good one.
+
+use file_parser::gear::init_magika_detector;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+#[ignore = "needs ORT_DYLIB_PATH pointed at an incompatible ONNX Runtime; see module docs"]
+async fn incompatible_runtime_times_out_instead_of_hanging() {
+    // Calls the real production startup path, not a re-implementation of
+    // its timeout wrapping, so a regression there (e.g. dropping the
+    // timeout) is actually caught.
+    let result = init_magika_detector(&[], None, &CancellationToken::new()).await;
+
+    let Err(err) = result else {
+        panic!("expected the detector init to fail (via timeout) against an incompatible runtime");
+    };
+    let message = err.to_string();
+    assert!(
+        message.contains("did not finish loading"),
+        "expected a timeout-shaped error message, got: {message}"
+    );
+}
+
+/// A token already cancelled at entry must return early *without starting init*,
+/// so shutdown does not block on a model load whose result is about to be thrown
+/// away.
+///
+/// This covers the pre-spawn check specifically. An earlier version of this test
+/// relied on the `select!` arm instead, which meant the init thread had already
+/// been spawned: the test passed, then the process aborted on exit with SIGABRT
+/// from ONNX Runtime's `cpuinfo` because teardown raced an in-flight init. That
+/// is the same hazard `MagikaInitError::leaked_init_thread` describes, so the
+/// mid-init cancellation path is deliberately left untested — exercising it means
+/// reproducing that abort.
+#[tokio::test]
+async fn cancellation_during_init_returns_early() {
+    let token = CancellationToken::new();
+    token.cancel();
+
+    // `let Err(..) else` rather than `expect_err`: the success type is a
+    // `dyn ContentTypeDetector`, which is not `Debug`.
+    let Err(err) = init_magika_detector(&[], None, &token).await else {
+        panic!("a cancelled token must abort init rather than wait for the timeout");
+    };
+
+    let message = err.to_string();
+    assert!(
+        message.contains("cancelled"),
+        "expected a cancellation-shaped error message, got: {message}"
+    );
+}

--- a/gears/file-parser/file-parser/tests/pptx_parser_tests.rs
+++ b/gears/file-parser/file-parser/tests/pptx_parser_tests.rs
@@ -36,7 +36,7 @@ async fn test_pptx_parser_with_simple_file() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(
         result.is_ok(),
@@ -73,7 +73,7 @@ async fn test_pptx_parser_with_multislide_file() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(
         result.is_ok(),
@@ -112,7 +112,7 @@ async fn test_pptx_parser_nonexistent_file() {
     let parser = KreuzbergParser::new();
     let test_file = PathBuf::from("/nonexistent/path/to/file.pptx");
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(result.is_err(), "Should fail for non-existent file");
 }
@@ -166,7 +166,7 @@ async fn test_pptx_parser_extracts_text() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
     let document = result.expect("Failed to parse PPTX");
 
     // Find paragraph blocks with text content
@@ -196,7 +196,7 @@ async fn test_pptx_parser_with_tables() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(
         result.is_ok(),
@@ -229,7 +229,7 @@ async fn test_pptx_parser_with_lists() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(
         result.is_ok(),

--- a/gears/file-parser/file-parser/tests/xlsx_parser_tests.rs
+++ b/gears/file-parser/file-parser/tests/xlsx_parser_tests.rs
@@ -44,7 +44,7 @@ async fn test_xlsx_parser_with_simple_file() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(
         result.is_ok(),
@@ -77,7 +77,7 @@ async fn test_xlsx_parser_with_multisheet_file() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(
         result.is_ok(),
@@ -106,7 +106,7 @@ async fn test_xlsx_parser_nonexistent_file() {
     let parser = KreuzbergParser::new();
     let test_file = PathBuf::from("/nonexistent/path/to/file.xlsx");
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(result.is_err(), "Should fail for non-existent file");
 }
@@ -190,7 +190,7 @@ async fn test_xlsx_parser_extracts_tables() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
     let document = result.expect("Failed to parse XLSX");
 
     // Find table blocks
@@ -216,7 +216,7 @@ async fn test_xlsx_parser_merged_cells() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(
         result.is_ok(),
@@ -262,7 +262,7 @@ async fn test_xlsx_parser_formula_cells() {
         return;
     }
 
-    let result = parser.parse_local_path(&test_file).await;
+    let result = parser.parse_local_path(&test_file, None).await;
 
     assert!(
         result.is_ok(),


### PR DESCRIPTION
## Add Magika content-based file type detection

Adds an optional `magika` feature to `file-parser` that detects file type from content (via ONNX-backed Magika model) instead of relying solely on the extension hint. Confident detections (`score >= 0.90`) override a wrong/missing extension; low-confidence or unmapped detections fall back to today's extension-hint behavior unchanged.

- `domain/detector.rs`: `ContentTypeDetector` trait + `Confidence` newtype (validated `[0.0, 1.0]`, rejects NaN/out-of-range at construction).
- `infra/magika_detector.rs`: `MagikaDetector` — pool of `magika::Session`s (round-robin, avoids serializing concurrent inference on one mutex), each behind its own poison-recovering `Mutex`. Errors, poisoned locks, and `spawn_blocking` panics are logged via `tracing::warn!` and swallowed to `None` rather than surfacing.
- `domain/service.rs`: wires detection into `parse_bytes`/`parse_local` precedence logic.
- `gear.rs`: eager fallible init at gear startup, bounded by a 30s timeout.
- Tests: `detection_precedence_tests.rs` (fake detector, no ORT needed), `magika_detector_tests.rs` (real-model smoke tests, needs `ORT_DYLIB_PATH`), unit test for the error-swallow path via a synthetic `magika::Error`.

## ONNX Runtime init deadlock workaround

`ort` 2.0.0-rc.12's `magika::S instead of erroring** when theloaded ONNX Runtime dylib is missing/incompatible — a reentrant `OnceLock` inside `ort::api()` blocks on itself.ing.

Mitigation in `init_magika_det
- Session init runs on a raw detached `std::thread::spawn`, **not** `tokio::task::spawn_blocking` awn_blocking` thread would hangthe whole Tokio runtime's shutdown; a raw thread just leaks silently.
- The async side awaits only tr a 30s `tokio::time::timeout`.
- Safe to abandon the thread because init failure here is fatal to the whole host
process — process exit reclaim, at most, the sub-second window before exit. **Caveat**: this safety only holds if the caller treats failure as fatal;
a future hot-reload/non-fatal de would leak for the process'sfull remaining lifetime.
- `TODO` left in-code to drop a`/`ort` ship a non-deadlockinginit path (watch `ort` upstream for a fix above `2.0.0-rc.12`).                      - The only automated test for s.rs`) was `#[ignore]`d andnever ran in CI; deleted in favor of the detailed in-code comment — a synthetic test would exercise the timeout plu` deadlock it guards against.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional content-based file type detection for uploaded and local files.
  * High-confidence detection can correct missing or inaccurate filename and MIME hints.
  * Added controls to enable or skip detection, configure confidence thresholds, and tune runtime behavior.
  * Improved case-insensitive extension and MIME recognition.
  * Added bounded local-file reads to enforce size limits.

* **Documentation**
  * Documented detection behavior, fallback rules, configuration, and supported formats.

* **Tests**
  * Added coverage for routing precedence, fallback behavior, runtime initialization, cancellations, and timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->