### PR TITLE
chore(toolkit-db)!: make the transactional outbox unconditional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,19 +249,24 @@ export PATH := $(HOME)/.local/bin:$(PATH)
 # Use `make clippy-deep` for the full 182-run matrix (nightly / pre-release).
 CLIPPY_FLAGS := -- -D warnings -D clippy::perf
 CLIPPY_HACK_CRATES := -p cf-gears-toolkit -p cf-gears-toolkit-db -p cf-gears-toolkit-http
+# `_any-backend` is toolkit-db's internal "some backend is on" marker (see its
+# [features] block); enabling it *alone* asserts a driver exists while none does,
+# which the outbox benchmarks reject with a compile_error!. Not a configuration
+# anyone can ship, so it is not worth a lint pass.
+CLIPPY_HACK_EXCLUDE := --exclude-features _any-backend
 
 clippy:
 	$(call check_rustup_component,clippy)
 	$(call check_tool,cargo-hack)
 	cargo clippy --workspace --all-targets --all-features $(CLIPPY_FLAGS)
-	cargo hack clippy $(CLIPPY_HACK_CRATES) --all-targets --each-feature $(CLIPPY_FLAGS)
+	cargo hack clippy $(CLIPPY_HACK_CRATES) --all-targets --each-feature $(CLIPPY_HACK_EXCLUDE) $(CLIPPY_FLAGS)
 
 ## Full feature-matrix clippy: one pass per (crate × feature).
 ## ~182 runs — intended for nightly CI and pre-release validation, not PRs.
 clippy-deep:
 	$(call check_rustup_component,clippy)
 	$(call check_tool,cargo-hack)
-	cargo hack clippy --workspace --all-targets --each-feature $(CLIPPY_FLAGS)
+	cargo hack clippy --workspace --all-targets --each-feature $(CLIPPY_HACK_EXCLUDE) $(CLIPPY_FLAGS)
 
 # Run markdown checks with 'lychee'
 lychee: ensure-submodules
@@ -475,16 +480,16 @@ test-macros: install-tools
 
 ## Run SQLite integration tests
 test-sqlite: install-tools
-	cargo nextest run -p cf-gears-toolkit-db --features sqlite,integration,preview-outbox
-	cargo build -p cf-gears-toolkit-db --examples --features sqlite,preview-outbox
+	cargo nextest run -p cf-gears-toolkit-db --features sqlite,integration
+	cargo build -p cf-gears-toolkit-db --examples --features sqlite
 
 ## Run PostgreSQL integration tests
 test-pg: install-tools
-	cargo nextest run -p cf-gears-toolkit-db --features pg,integration,preview-outbox
+	cargo nextest run -p cf-gears-toolkit-db --features pg,integration
 
 ## Run MySQL integration tests
 test-mysql: install-tools
-	cargo nextest run -p cf-gears-toolkit-db --features mysql,integration,preview-outbox
+	cargo nextest run -p cf-gears-toolkit-db --features mysql,integration
 
 # Run all database integration tests
 test-db: test-sqlite test-pg test-mysql
@@ -564,38 +569,38 @@ check-windows-fips:
 
 ## Run outbox throughput benchmarks against PostgreSQL
 bench-pg:
-	cargo bench -p cf-gears-toolkit-db --features pg,preview-outbox --bench outbox_throughput -- postgres
+	cargo bench -p cf-gears-toolkit-db --features pg --bench outbox_throughput -- postgres
 
 ## Run outbox throughput benchmarks against MySQL
 bench-mysql:
-	cargo bench -p cf-gears-toolkit-db --features mysql,preview-outbox --bench outbox_throughput -- mysql
+	cargo bench -p cf-gears-toolkit-db --features mysql --bench outbox_throughput -- mysql
 
 ## Run outbox throughput benchmarks against MariaDB
 bench-mariadb:
-	cargo bench -p cf-gears-toolkit-db --features mysql,preview-outbox --bench outbox_throughput -- mariadb
+	cargo bench -p cf-gears-toolkit-db --features mysql --bench outbox_throughput -- mariadb
 
 # Run outbox throughput benchmarks against SQLite
 bench-sqlite:
-	cargo bench -p cf-gears-toolkit-db --features sqlite,preview-outbox --bench outbox_throughput -- sqlite
+	cargo bench -p cf-gears-toolkit-db --features sqlite --bench outbox_throughput -- sqlite
 
 ## Run outbox throughput benchmarks against all database engines
 bench-db: bench-pg bench-mysql bench-mariadb bench-sqlite
 
 ## Run long-haul (1M+10M) outbox benchmarks against PostgreSQL
 bench-pg-longhaul:
-	cargo bench -p cf-gears-toolkit-db --features pg,preview-outbox --bench outbox_throughput -- postgres_longhaul
+	cargo bench -p cf-gears-toolkit-db --features pg --bench outbox_throughput -- postgres_longhaul
 
 ## Run long-haul (1M+10M) outbox benchmarks against MySQL
 bench-mysql-longhaul:
-	cargo bench -p cf-gears-toolkit-db --features mysql,preview-outbox --bench outbox_throughput -- mysql_longhaul
+	cargo bench -p cf-gears-toolkit-db --features mysql --bench outbox_throughput -- mysql_longhaul
 
 ## Run long-haul (1M+10M) outbox benchmarks against MariaDB
 bench-mariadb-longhaul:
-	cargo bench -p cf-gears-toolkit-db --features mysql,preview-outbox --bench outbox_throughput -- mariadb_longhaul
+	cargo bench -p cf-gears-toolkit-db --features mysql --bench outbox_throughput -- mariadb_longhaul
 
 ## Run long-haul (100K 1P) outbox benchmarks against SQLite
 bench-sqlite-longhaul:
-	cargo bench -p cf-gears-toolkit-db --features sqlite,preview-outbox --bench outbox_throughput -- sqlite_longhaul
+	cargo bench -p cf-gears-toolkit-db --features sqlite --bench outbox_throughput -- sqlite_longhaul
 
 ## Run long-haul outbox benchmarks against all database engines
 bench-db-longhaul: bench-pg-longhaul bench-mysql-longhaul bench-mariadb-longhaul bench-sqlite-longhaul

--- a/gears/bss/ledger/ledger/Cargo.toml
+++ b/gears/bss/ledger/ledger/Cargo.toml
@@ -55,7 +55,7 @@ opentelemetry_sdk = { workspace = true, features = [
 # `db` enables the `DatabaseCapability` trait; the REST API layer is not
 # feature-gated, so no toolkit feature bump is needed for `rest`.
 toolkit = { workspace = true, features = ["db"] }
-toolkit-db = { workspace = true, features = ["pg", "sqlite", "preview-outbox"] }
+toolkit-db = { workspace = true, features = ["pg", "sqlite"] }
 toolkit-db-macros = { workspace = true }
 # Canonical OData list surface: the `FilterField` / `FieldKind` traits, the
 # `OData` query, `Page<T>` (with-utoipa for the `OpenAPI` response schema), and

--- a/gears/mini-chat/mini-chat/Cargo.toml
+++ b/gears/mini-chat/mini-chat/Cargo.toml
@@ -97,7 +97,7 @@ toolkit-gts = { workspace = true }
 # `::gts::*` paths (the compile-time `<S as GtsSchema>::SCHEMA_ID` prefix
 # assert plus `GtsInstanceId::new(...)`).
 gts = { workspace = true }
-toolkit-db = { workspace = true, features = ["sqlite", "pg", "preview-outbox"] }
+toolkit-db = { workspace = true, features = ["sqlite", "pg"] }
 toolkit-db-macros = { workspace = true }
 toolkit-security = { workspace = true }
 toolkit-macros = { workspace = true }

--- a/gears/system/event-broker/event-broker-sdk/Cargo.toml
+++ b/gears/system/event-broker/event-broker-sdk/Cargo.toml
@@ -21,7 +21,9 @@ path = "src/lib.rs"
 [features]
 default = []
 db = ["dep:sea-orm", "dep:toolkit-db", "toolkit-db/sqlite"]
-outbox = ["db", "toolkit-db/preview-outbox"]
+# Gates this SDK's own transactional-outbox producer surface (see src/producer/).
+# `toolkit-db`'s outbox pipeline is unconditional, so `db` is all this needs.
+outbox = ["db"]
 integration = []
 test-util = ["dep:async-stream"]
 

--- a/gears/system/event-broker/event-broker-sdk/README.md
+++ b/gears/system/event-broker/event-broker-sdk/README.md
@@ -340,5 +340,5 @@ custom table, remote sink, or in-memory parking can still implement
 |---|---|---|
 | (default) | DB-free direct producer, consumer | — |
 | `db` | `LocalDbOffsetManager`, `TxCommitHandle` | `toolkit-db` |
-| `outbox` | DB-aware producer outbox helper | `db`, `toolkit-db/preview-outbox` |
+| `outbox` | DB-aware producer outbox helper | `db` |
 | `integration` | Integration tests (gated) | — |

--- a/libs/toolkit-db/Cargo.toml
+++ b/libs/toolkit-db/Cargo.toml
@@ -55,9 +55,6 @@ mysql = [
 
 integration = []
 
-# Transactional outbox pipeline (preview — API may change)
-preview-outbox = ["dep:tokio-util", "dep:futures-util"]
-
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -85,40 +82,41 @@ serde_json = { workspace = true }
 dashmap = { workspace = true }
 figment = { workspace = true }
 sqlx = { workspace = true, optional = true }
-tokio-util = { workspace = true, optional = true }
-futures-util = { workspace = true, optional = true }
+# Unconditional: the transactional outbox pipeline is always compiled in.
+tokio-util = { workspace = true }
+futures-util = { workspace = true }
 
 [[example]]
 name = "outbox_transactional"
-required-features = ["sqlite", "preview-outbox"]
+required-features = ["sqlite"]
 
 [[example]]
 name = "outbox_retry_reject"
-required-features = ["sqlite", "preview-outbox"]
+required-features = ["sqlite"]
 
 [[example]]
 name = "outbox_dead_letters"
-required-features = ["sqlite", "preview-outbox"]
+required-features = ["sqlite"]
 
 [[example]]
 name = "outbox_batch_multi_queue"
-required-features = ["sqlite", "preview-outbox"]
+required-features = ["sqlite"]
 
 [[example]]
 name = "outbox_custom_prefix"
-required-features = ["sqlite", "preview-outbox"]
+required-features = ["sqlite"]
 
 [[bench]]
 name = "outbox_throughput"
 harness = false
 # `_any-backend` is a virtual OR over pg/mysql/sqlite (see [features] above).
 # The bench body compile-errors out if no backend is present.
-required-features = ["preview-outbox", "_any-backend"]
+required-features = ["_any-backend"]
 
 [[bench]]
 name = "worker_overhead"
 harness = false
-required-features = ["preview-outbox", "_any-backend"]
+required-features = ["_any-backend"]
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }

--- a/libs/toolkit-db/benches/outbox_throughput.rs
+++ b/libs/toolkit-db/benches/outbox_throughput.rs
@@ -40,10 +40,10 @@
 //!
 //! **Run examples:**
 //!   ```sh
-//!   cargo bench --bench outbox_throughput --features preview-outbox,pg
-//!   cargo bench --bench outbox_throughput --features preview-outbox,pg -- "16p16c"
-//!   BENCH_LONGHAUL=1 cargo bench --bench outbox_throughput --features preview-outbox,pg
-//!   BENCH_STRESS=1 cargo bench --bench outbox_throughput --features preview-outbox,pg -- "2i"
+//!   cargo bench --bench outbox_throughput --features pg
+//!   cargo bench --bench outbox_throughput --features pg -- "16p16c"
+//!   BENCH_LONGHAUL=1 cargo bench --bench outbox_throughput --features pg
+//!   BENCH_STRESS=1 cargo bench --bench outbox_throughput --features pg -- "2i"
 //!   ```
 
 use std::collections::HashSet;

--- a/libs/toolkit-db/benches/worker_overhead.rs
+++ b/libs/toolkit-db/benches/worker_overhead.rs
@@ -6,7 +6,7 @@
 //! handling, notifier wakeup, semaphore acquire — with no-op actions.
 //! This isolates infrastructure overhead from action (business logic) cost.
 //!
-//! Run: `cargo bench -p cf-gears-toolkit-db --features preview-outbox --bench worker_overhead`
+//! Run: `cargo bench -p cf-gears-toolkit-db --features sqlite --bench worker_overhead`
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/libs/toolkit-db/examples/outbox_batch_multi_queue.rs
+++ b/libs/toolkit-db/examples/outbox_batch_multi_queue.rs
@@ -7,7 +7,7 @@
 //! Both queues process independently within the same `OutboxBuilder`.
 //!
 //! Run:
-//!   cargo run -p cf-gears-toolkit-db --example `outbox_batch_multi_queue` --features sqlite,preview-outbox
+//!   cargo run -p cf-gears-toolkit-db --example `outbox_batch_multi_queue` --features sqlite
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/libs/toolkit-db/examples/outbox_custom_prefix.rs
+++ b/libs/toolkit-db/examples/outbox_custom_prefix.rs
@@ -1,7 +1,7 @@
 //! Custom table-prefix outbox example.
 //!
 //! Run:
-//!   cargo run -p cf-gears-toolkit-db --example `outbox_custom_prefix` --features sqlite,preview-outbox
+//!   cargo run -p cf-gears-toolkit-db --example `outbox_custom_prefix` --features sqlite
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};

--- a/libs/toolkit-db/examples/outbox_dead_letters.rs
+++ b/libs/toolkit-db/examples/outbox_dead_letters.rs
@@ -3,7 +3,7 @@
 //! Dead letter lifecycle: reject -> list -> replay -> resolve -> cleanup.
 //!
 //! Run:
-//!   cargo run -p cf-gears-toolkit-db --example `outbox_dead_letters` --features sqlite,preview-outbox
+//!   cargo run -p cf-gears-toolkit-db --example `outbox_dead_letters` --features sqlite
 
 use std::time::Duration;
 

--- a/libs/toolkit-db/examples/outbox_retry_reject.rs
+++ b/libs/toolkit-db/examples/outbox_retry_reject.rs
@@ -5,7 +5,7 @@
 //! The handler retries twice (transient failure), then rejects on the 3rd attempt.
 //!
 //! Run:
-//!   cargo run -p cf-gears-toolkit-db --example `outbox_retry_reject` --features sqlite,preview-outbox
+//!   cargo run -p cf-gears-toolkit-db --example `outbox_retry_reject` --features sqlite
 
 use std::time::{Duration, Instant};
 

--- a/libs/toolkit-db/examples/outbox_transactional.rs
+++ b/libs/toolkit-db/examples/outbox_transactional.rs
@@ -6,7 +6,7 @@
 //! so handler side-effects and cursor advance commit atomically.
 //!
 //! Run:
-//!   cargo run -p cf-gears-toolkit-db --example `outbox_transactional` --features sqlite,preview-outbox
+//!   cargo run -p cf-gears-toolkit-db --example `outbox_transactional` --features sqlite
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/libs/toolkit-db/src/lib.rs
+++ b/libs/toolkit-db/src/lib.rs
@@ -9,7 +9,9 @@
 //! # Features
 //! - `pg`, `mysql`, `sqlite`: enable `SQLx` backends
 //! - `sea-orm`: add `SeaORM` integration for type-safe operations
-//! - `preview-outbox`: enable the transactional outbox pipeline (experimental — API may change)
+//!
+//! The transactional outbox pipeline ([`outbox`]) is always available — it is no
+//! longer behind a preview feature flag.
 //!
 //! # New Architecture
 //! The crate now supports:
@@ -81,8 +83,6 @@ pub mod manager;
 pub mod migration_runner;
 pub mod odata;
 pub mod options;
-
-#[cfg(feature = "preview-outbox")]
 pub mod outbox;
 pub mod secure;
 

--- a/libs/toolkit-db/src/outbox/README.md
+++ b/libs/toolkit-db/src/outbox/README.md
@@ -405,10 +405,12 @@ else is infrastructure noise that will resolve itself.
 
 ### Worker Overhead
 
-Infrastructure overhead (scheduling, notifiers, semaphores) with no-op actions:
+Infrastructure overhead (scheduling, notifiers, semaphores) with no-op actions.
+A backend feature is still required: the bench declares
+`required-features = ["_any-backend"]`, which `sqlite`/`pg`/`mysql` activate.
 
 ```bash
-cargo bench -p cf-gears-toolkit-db --features preview-outbox --bench worker_overhead
+cargo bench -p cf-gears-toolkit-db --features sqlite --bench worker_overhead
 ```
 
 ### Outbox Throughput
@@ -418,13 +420,13 @@ Requires a database feature flag:
 
 ```bash
 # SQLite (local, no external DB needed)
-cargo bench -p cf-gears-toolkit-db --features preview-outbox,sqlite --bench outbox_throughput
+cargo bench -p cf-gears-toolkit-db --features sqlite --bench outbox_throughput
 
 # PostgreSQL
-cargo bench -p cf-gears-toolkit-db --features preview-outbox,pg --bench outbox_throughput -- postgres
+cargo bench -p cf-gears-toolkit-db --features pg --bench outbox_throughput -- postgres
 
 # MySQL
-cargo bench -p cf-gears-toolkit-db --features preview-outbox,mysql --bench outbox_throughput -- mysql
+cargo bench -p cf-gears-toolkit-db --features mysql --bench outbox_throughput -- mysql
 ```
 
 ### Makefile Targets
@@ -442,6 +444,6 @@ make bench-db-longhaul     # All engines, long-haul
 
 ```bash
 systemd-run --user --scope -p MemoryMax=4G -p CPUQuota=200% \
-  cargo bench -p cf-gears-toolkit-db --features preview-outbox --bench worker_overhead \
+  cargo bench -p cf-gears-toolkit-db --features sqlite --bench worker_overhead \
   -- --warm-up-time 1 --measurement-time 3 --sample-size 10
 ```

--- a/libs/toolkit-db/src/outbox/migrations.rs
+++ b/libs/toolkit-db/src/outbox/migrations.rs
@@ -11,16 +11,11 @@ use super::types::OutboxError;
 ///
 /// # Idempotency
 ///
-/// All `CREATE TABLE` statements use `IF NOT EXISTS` so the migration is safe
-/// to re-run (e.g., after a partial failure). `CREATE INDEX` statements do
-/// **not** -- `MySQL` has no `IF NOT EXISTS` syntax for indexes, and keeping the
-/// Pg/SQLite paths consistent avoids a false sense of safety on only some
-/// backends. Because each index immediately follows its `CREATE TABLE IF NOT
-/// EXISTS`, the index can only pre-exist if the migration crashed between the
-/// two statements *and* the migration runner retries without rolling back.
-/// The sea-orm migration framework tracks completed migrations, so this edge
-/// case requires a crash mid-transaction -- acceptable for a `preview-outbox`
-/// alpha feature with no production deployments.
+/// The whole migration is safe to re-run, e.g. after a partial failure. All
+/// `CREATE TABLE` statements use `IF NOT EXISTS`, and every index goes through
+/// [`create_index_if_absent`], which is idempotent on all three backends --
+/// `IF NOT EXISTS` on Postgres/SQLite and an `information_schema` probe on
+/// `MySQL`, which has no such syntax for indexes.
 struct CreateOutboxSchema {
     tables: OutboxTables,
 }
@@ -103,6 +98,117 @@ fn unsupported_backend(backend: DatabaseBackend) -> DbErr {
         "outbox migrations support Postgres, SQLite and MySQL only; \
          got unsupported database backend {backend:?}"
     ))
+}
+
+/// One index to create, in a backend-agnostic form.
+///
+/// `columns` and `filter` are already backend-appropriate: the call sites that
+/// differ per engine (see [`create_dead_letters`]) pick them before building the
+/// spec.
+struct IndexSpec<'a> {
+    /// Emit `CREATE UNIQUE INDEX` instead of `CREATE INDEX`.
+    unique: bool,
+    name: &'a str,
+    table: &'a str,
+    /// Column list exactly as it appears inside the parentheses.
+    columns: &'a str,
+    /// Partial-index predicate without the leading `WHERE`. Postgres only.
+    filter: Option<&'a str>,
+}
+
+/// Looks up one index by name in the current `MySQL` schema.
+///
+/// Parameterised rather than interpolated: the two `?` placeholders are compared
+/// as *values* against `information_schema` columns, not spliced in as identifiers.
+const MYSQL_INDEX_PROBE_SQL: &str = "SELECT 1 FROM information_schema.STATISTICS \
+     WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ? \
+     LIMIT 1";
+
+/// How to create one index idempotently on one backend.
+///
+/// Separating the plan from its execution keeps every per-backend decision --
+/// which engines support `IF NOT EXISTS`, whether a partial filter survives,
+/// whether the probe binds parameters -- assertable without a live database.
+#[derive(Debug, PartialEq, Eq)]
+enum IndexPlan {
+    /// Backend supports `CREATE INDEX IF NOT EXISTS`: one statement, no pre-check.
+    Guarded { create: String },
+    /// Backend has no such syntax: probe for the index, create it only if absent.
+    ProbeThenCreate {
+        probe_sql: &'static str,
+        /// `[table, index_name]`, bound to the probe's placeholders in order.
+        probe_args: [String; 2],
+        create: String,
+    },
+}
+
+/// Decide how to create `spec` on `backend`.
+///
+/// Postgres and `SQLite` get `CREATE INDEX IF NOT EXISTS`. `MySQL` has no such
+/// syntax for indexes, so it is probed through `information_schema.STATISTICS`
+/// first. The probe is preferred over tolerating error 1061 (`ER_DUP_KEYNAME`)
+/// because it needs no error-code matching, and it also covers `MariaDB` — which
+/// `DatabaseBackend::MySql` does not distinguish, and whose `IF NOT EXISTS`
+/// support differs. The check-then-create race is irrelevant here: the migration
+/// runner does not run two migrations against one schema at once.
+fn plan_create_index(backend: DatabaseBackend, spec: &IndexSpec<'_>) -> Result<IndexPlan, DbErr> {
+    let unique = if spec.unique { "UNIQUE " } else { "" };
+    // Appended verbatim on every backend. Only the Postgres call sites pass a
+    // filter; a backend that cannot express one must fail loudly rather than
+    // silently create a non-partial index under the requested name.
+    let filter = spec
+        .filter
+        .map_or_else(String::new, |f| format!(" WHERE {f}"));
+    let tail = format!("{} ON {} ({}){filter}", spec.name, spec.table, spec.columns);
+
+    match backend {
+        DatabaseBackend::Postgres | DatabaseBackend::Sqlite => Ok(IndexPlan::Guarded {
+            create: format!("CREATE {unique}INDEX IF NOT EXISTS {tail}"),
+        }),
+        DatabaseBackend::MySql => Ok(IndexPlan::ProbeThenCreate {
+            probe_sql: MYSQL_INDEX_PROBE_SQL,
+            probe_args: [spec.table.to_owned(), spec.name.to_owned()],
+            create: format!("CREATE {unique}INDEX {tail}"),
+        }),
+        _ => Err(unsupported_backend(backend)),
+    }
+}
+
+/// Create an index, skipping it if one of that name already exists.
+///
+/// Thin executor over [`plan_create_index`], which owns the per-backend logic.
+async fn create_index_if_absent(
+    conn: &DatabaseExecutor<'_>,
+    backend: DatabaseBackend,
+    spec: &IndexSpec<'_>,
+) -> Result<(), DbErr> {
+    match plan_create_index(backend, spec)? {
+        IndexPlan::Guarded { create } => {
+            conn.execute_raw(Statement::from_string(backend, create))
+                .await?;
+        }
+        IndexPlan::ProbeThenCreate {
+            probe_sql,
+            probe_args: [table, index_name],
+            create,
+        } => {
+            let existing = conn
+                .query_one_raw(Statement::from_sql_and_values(
+                    backend,
+                    probe_sql,
+                    [
+                        sea_orm::Value::from(table),
+                        sea_orm::Value::from(index_name),
+                    ],
+                ))
+                .await?;
+            if existing.is_none() {
+                conn.execute_raw(Statement::from_string(backend, create))
+                    .await?;
+            }
+        }
+    }
+    Ok(())
 }
 
 async fn create_body(
@@ -245,26 +351,32 @@ async fn create_incoming(
     ))
     .await?;
 
-    conn.execute_raw(Statement::from_string(
+    create_index_if_absent(
+        conn,
         backend,
-        format!(
-            "CREATE INDEX {} ON {} (partition_id, id)",
-            tables.idx_incoming_partition(),
-            tables.incoming()
-        ),
-    ))
+        &IndexSpec {
+            unique: false,
+            name: tables.idx_incoming_partition(),
+            table: tables.incoming(),
+            columns: "partition_id, id",
+            filter: None,
+        },
+    )
     .await?;
 
     // Index on body_id to accelerate FK constraint checks during
     // DELETE FROM outbox body WHERE id IN (...).
-    conn.execute_raw(Statement::from_string(
+    create_index_if_absent(
+        conn,
         backend,
-        format!(
-            "CREATE INDEX {} ON {} (body_id)",
-            tables.idx_incoming_body_id(),
-            tables.incoming()
-        ),
-    ))
+        &IndexSpec {
+            unique: false,
+            name: tables.idx_incoming_body_id(),
+            table: tables.incoming(),
+            columns: "body_id",
+            filter: None,
+        },
+    )
     .await?;
     Ok(())
 }
@@ -320,26 +432,32 @@ async fn create_outgoing(
     ))
     .await?;
 
-    conn.execute_raw(Statement::from_string(
+    create_index_if_absent(
+        conn,
         backend,
-        format!(
-            "CREATE UNIQUE INDEX {} ON {} (partition_id, seq)",
-            tables.idx_outgoing_partition_seq(),
-            tables.outgoing()
-        ),
-    ))
+        &IndexSpec {
+            unique: true,
+            name: tables.idx_outgoing_partition_seq(),
+            table: tables.outgoing(),
+            columns: "partition_id, seq",
+            filter: None,
+        },
+    )
     .await?;
 
     // Index on body_id to accelerate FK constraint checks during
     // DELETE FROM outbox body WHERE id IN (...).
-    conn.execute_raw(Statement::from_string(
+    create_index_if_absent(
+        conn,
         backend,
-        format!(
-            "CREATE INDEX {} ON {} (body_id)",
-            tables.idx_outgoing_body_id(),
-            tables.outgoing()
-        ),
-    ))
+        &IndexSpec {
+            unique: false,
+            name: tables.idx_outgoing_body_id(),
+            table: tables.outgoing(),
+            columns: "body_id",
+            filter: None,
+        },
+    )
     .await?;
     Ok(())
 }
@@ -415,50 +533,44 @@ async fn create_dead_letters(
     .await?;
 
     // Index for replay query (status = 'pending' OR (status = 'reprocessing' AND deadline < now()))
-    conn.execute_raw(Statement::from_string(
-        backend,
-        match backend {
-            DatabaseBackend::Postgres => {
-                format!(
-                    "CREATE INDEX {} ON {} (status, deadline) WHERE status IN ('pending', 'reprocessing')",
-                    tables.idx_dl_replayable(),
-                    tables.dead_letters()
-                )
-            }
-            DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
-                format!(
-                    "CREATE INDEX {} ON {} (status, deadline)",
-                    tables.idx_dl_status_deadline(),
-                    tables.dead_letters()
-                )
-            }
-            _ => return Err(unsupported_backend(backend)),
+    //
+    // Postgres gets a *partial* index, under its own name. MySQL has no partial
+    // indexes at all; SQLite has them (3.8.0+) but has never used one here, so
+    // both get a plain index under a different name. Preserved as-is: switching
+    // SQLite over would rename an index on existing databases.
+    let replay_index = match backend {
+        DatabaseBackend::Postgres => IndexSpec {
+            unique: false,
+            name: tables.idx_dl_replayable(),
+            table: tables.dead_letters(),
+            columns: "status, deadline",
+            filter: Some("status IN ('pending', 'reprocessing')"),
         },
-    ))
-    .await?;
+        DatabaseBackend::Sqlite | DatabaseBackend::MySql => IndexSpec {
+            unique: false,
+            name: tables.idx_dl_status_deadline(),
+            table: tables.dead_letters(),
+            columns: "status, deadline",
+            filter: None,
+        },
+        _ => return Err(unsupported_backend(backend)),
+    };
+    create_index_if_absent(conn, backend, &replay_index).await?;
 
-    // Index for list queries with status filter + ORDER BY failed_at DESC
-    conn.execute_raw(Statement::from_string(
-        backend,
-        match backend {
-            DatabaseBackend::Postgres => {
-                format!(
-                    "CREATE INDEX {} ON {} (status, failed_at DESC)",
-                    tables.idx_dl_status_failed(),
-                    tables.dead_letters()
-                )
-            }
-            DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
-                format!(
-                    "CREATE INDEX {} ON {} (status, failed_at)",
-                    tables.idx_dl_status_failed(),
-                    tables.dead_letters()
-                )
-            }
+    // Index for list queries with status filter + ORDER BY failed_at DESC.
+    // Only Postgres records the DESC direction.
+    let status_failed_index = IndexSpec {
+        unique: false,
+        name: tables.idx_dl_status_failed(),
+        table: tables.dead_letters(),
+        columns: match backend {
+            DatabaseBackend::Postgres => "status, failed_at DESC",
+            DatabaseBackend::Sqlite | DatabaseBackend::MySql => "status, failed_at",
             _ => return Err(unsupported_backend(backend)),
         },
-    ))
-    .await?;
+        filter: None,
+    };
+    create_index_if_absent(conn, backend, &status_failed_index).await?;
     Ok(())
 }
 
@@ -679,6 +791,161 @@ mod tests {
         assert!(!incoming_create.contains("toolkit_outbox_incoming_id_sequence"));
     }
 
+    /// Every backend the outbox supports DDL for.
+    const BACKENDS: [DatabaseBackend; 3] = [
+        DatabaseBackend::Postgres,
+        DatabaseBackend::MySql,
+        DatabaseBackend::Sqlite,
+    ];
+
+    fn plan(backend: DatabaseBackend, spec: &IndexSpec<'_>) -> IndexPlan {
+        plan_create_index(backend, spec).unwrap()
+    }
+
+    /// The `create` statement of a plan, whichever variant it is.
+    fn create_sql(plan: &IndexPlan) -> &str {
+        match plan {
+            IndexPlan::Guarded { create } | IndexPlan::ProbeThenCreate { create, .. } => create,
+        }
+    }
+
+    fn simple_spec<'a>(name: &'a str, table: &'a str) -> IndexSpec<'a> {
+        IndexSpec {
+            unique: false,
+            name,
+            table,
+            columns: "status, deadline",
+            filter: None,
+        }
+    }
+
+    #[test]
+    fn plan_create_index_is_idempotent_on_every_backend() {
+        // The point of the helper: re-running the migration must not fail on a
+        // pre-existing index, on any backend. Postgres/SQLite express that with
+        // IF NOT EXISTS; MySQL has no such syntax and must probe instead.
+        for backend in BACKENDS {
+            let spec = simple_spec("idx_x", "tbl");
+            match plan(backend, &spec) {
+                IndexPlan::Guarded { create } => {
+                    assert!(
+                        matches!(backend, DatabaseBackend::Postgres | DatabaseBackend::Sqlite),
+                        "{backend:?} should not use the guarded path"
+                    );
+                    assert!(
+                        create.contains("IF NOT EXISTS"),
+                        "{backend:?} guarded DDL must be conditional, got: {create}"
+                    );
+                }
+                IndexPlan::ProbeThenCreate {
+                    probe_sql,
+                    probe_args,
+                    create,
+                } => {
+                    assert_eq!(
+                        backend,
+                        DatabaseBackend::MySql,
+                        "only MySQL lacks CREATE INDEX IF NOT EXISTS"
+                    );
+                    // MySQL would reject IF NOT EXISTS on an index, so the
+                    // guard must come from the probe, not the DDL.
+                    assert!(
+                        !create.contains("IF NOT EXISTS"),
+                        "MySQL DDL must not use IF NOT EXISTS, got: {create}"
+                    );
+                    assert!(probe_sql.contains("information_schema.STATISTICS"));
+                    assert_eq!(probe_args, ["tbl".to_owned(), "idx_x".to_owned()]);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn mysql_index_probe_binds_identifiers_instead_of_interpolating_them() {
+        // A regression here would splice table/index names into the probe SQL.
+        // They are compared as values against information_schema, so they must
+        // stay bound to the two placeholders.
+        let spec = simple_spec("idx_dl_status_deadline", "toolkit_outbox_dead_letters");
+        let IndexPlan::ProbeThenCreate {
+            probe_sql,
+            probe_args,
+            ..
+        } = plan(DatabaseBackend::MySql, &spec)
+        else {
+            panic!("MySQL must use the probe path")
+        };
+
+        assert_eq!(probe_sql.matches('?').count(), 2, "probe: {probe_sql}");
+        assert!(
+            !probe_sql.contains("toolkit_outbox_dead_letters")
+                && !probe_sql.contains("idx_dl_status_deadline"),
+            "names must not appear in the SQL text, got: {probe_sql}"
+        );
+        assert_eq!(
+            probe_args,
+            [
+                "toolkit_outbox_dead_letters".to_owned(),
+                "idx_dl_status_deadline".to_owned()
+            ],
+            "table then index name, matching placeholder order"
+        );
+    }
+
+    #[test]
+    fn plan_create_index_preserves_partial_index_filter() {
+        // The Postgres replay index is partial. Routing it through the shared
+        // helper must not drop the predicate -- that would silently widen the
+        // index and change the replay query's access path.
+        let spec = IndexSpec {
+            unique: false,
+            name: "idx_dl_replayable",
+            table: "toolkit_outbox_dead_letters",
+            columns: "status, deadline",
+            filter: Some("status IN ('pending', 'reprocessing')"),
+        };
+
+        assert_eq!(
+            create_sql(&plan(DatabaseBackend::Postgres, &spec)),
+            "CREATE INDEX IF NOT EXISTS idx_dl_replayable ON toolkit_outbox_dead_letters \
+             (status, deadline) WHERE status IN ('pending', 'reprocessing')"
+        );
+    }
+
+    #[test]
+    fn plan_create_index_omits_where_clause_when_unfiltered() {
+        // Negative space: an unfiltered spec must not grow a WHERE clause.
+        for backend in BACKENDS {
+            let spec = simple_spec("idx_x", "tbl");
+            let plan = plan(backend, &spec);
+            assert!(
+                !create_sql(&plan).contains("WHERE"),
+                "{backend:?} emitted a WHERE for an unfiltered index: {}",
+                create_sql(&plan)
+            );
+        }
+    }
+
+    #[test]
+    fn plan_create_index_keeps_unique_on_every_backend() {
+        // The outgoing (partition_id, seq) index is UNIQUE and that uniqueness
+        // is a correctness invariant, not an optimisation.
+        for backend in BACKENDS {
+            let spec = IndexSpec {
+                unique: true,
+                name: "idx_outgoing_partition_seq",
+                table: "toolkit_outbox_outgoing",
+                columns: "partition_id, seq",
+                filter: None,
+            };
+            let plan = plan(backend, &spec);
+            assert!(
+                create_sql(&plan).starts_with("CREATE UNIQUE INDEX "),
+                "{backend:?} dropped UNIQUE: {}",
+                create_sql(&plan)
+            );
+        }
+    }
+
     #[test]
     fn mysql_sequence_table_sql_has_singleton_primary_key_and_seed() {
         let tables = OutboxTables::default();
@@ -692,5 +959,113 @@ mod tests {
             seed,
             "INSERT IGNORE INTO toolkit_outbox_body_id_sequence (slot, next_id) VALUES (1, 1)"
         );
+    }
+
+    /// Live-database checks. The unit tests above pin the *emitted SQL*; these
+    /// pin what the database actually ends up with.
+    #[cfg(feature = "sqlite")]
+    mod sqlite_tests {
+        use super::*;
+        use crate::{ConnectOpts, Db, connect_db};
+        use sea_orm::DbBackend;
+
+        /// Single pooled connection over a shared-cache in-memory database, so
+        /// two sequential `up()` calls hit the *same* schema. With a larger pool
+        /// the second call could land on a fresh empty database and the test
+        /// would pass without proving anything.
+        async fn setup_shared_db(name: &str) -> Db {
+            let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+            let opts = ConnectOpts {
+                max_conns: Some(1),
+                min_conns: Some(1),
+                ..Default::default()
+            };
+            connect_db(&url, opts).await.expect("connect")
+        }
+
+        async fn outbox_index_names(conn: &sea_orm::DatabaseConnection) -> Vec<String> {
+            let rows = conn
+                .query_all_raw(Statement::from_string(
+                    DbBackend::Sqlite,
+                    "SELECT name FROM sqlite_master \
+                     WHERE type = 'index' AND name LIKE 'idx_toolkit_outbox%' \
+                     ORDER BY name",
+                ))
+                .await
+                .expect("list indexes");
+            rows.iter()
+                .map(|row| row.try_get::<String>("", "name").expect("index name"))
+                .collect()
+        }
+
+        #[tokio::test]
+        async fn migration_up_is_rerunnable_over_a_fully_created_schema() {
+            // This is the scenario the schema DDL has to survive: the runner
+            // applied the migration, crashed before recording it, and retries.
+            // Before `create_index_if_absent`, the second run died on the first
+            // pre-existing index.
+            let db = setup_shared_db("outbox_migration_rerun").await;
+            let conn = db.sea_internal();
+            let manager = SchemaManager::new(&conn);
+            let migration = CreateOutboxSchema::default();
+
+            migration.up(&manager).await.expect("first up");
+            let after_first = outbox_index_names(&conn).await;
+
+            migration
+                .up(&manager)
+                .await
+                .expect("second up must succeed over an existing schema");
+            let after_second = outbox_index_names(&conn).await;
+
+            // Non-empty guards against a vacuous pass: if the first run had
+            // created nothing, re-running would trivially succeed.
+            assert!(
+                !after_first.is_empty(),
+                "first up() created no outbox indexes"
+            );
+            assert_eq!(
+                after_first, after_second,
+                "re-running the migration changed the index set"
+            );
+        }
+
+        #[tokio::test]
+        async fn migration_up_completes_after_indexes_were_created_but_tables_were_not_recorded() {
+            // Narrower version of the above: drop one index between runs and
+            // confirm the retry re-creates exactly that one rather than either
+            // failing on the survivors or leaving the dropped one missing.
+            let db = setup_shared_db("outbox_migration_partial").await;
+            let conn = db.sea_internal();
+            let manager = SchemaManager::new(&conn);
+            let migration = CreateOutboxSchema::default();
+
+            migration.up(&manager).await.expect("first up");
+            let complete = outbox_index_names(&conn).await;
+
+            let tables = OutboxTables::default();
+            conn.execute_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                format!("DROP INDEX {}", tables.idx_incoming_body_id()),
+            ))
+            .await
+            .expect("drop one index");
+            assert_ne!(
+                outbox_index_names(&conn).await,
+                complete,
+                "the DROP INDEX did not take effect"
+            );
+
+            migration
+                .up(&manager)
+                .await
+                .expect("retry after partial loss");
+
+            assert_eq!(
+                outbox_index_names(&conn).await,
+                complete,
+                "retry did not restore the dropped index"
+            );
+        }
     }
 }

--- a/libs/toolkit-db/src/outbox/store.rs
+++ b/libs/toolkit-db/src/outbox/store.rs
@@ -433,7 +433,10 @@ impl<'a> OutboxStore<'a> {
         self.statements.vacuum().decrement_counter()
     }
 
-    #[cfg(test)]
+    /// Only the `SQLite` integration suite resets the counter, so the gate
+    /// matches that module's (`#[cfg(test)] #[cfg(feature = "sqlite")]`) —
+    /// otherwise this is dead code in a pg- or mysql-only build.
+    #[cfg(all(test, feature = "sqlite"))]
     pub(super) fn reset_vacuum_counter(&self) -> &str {
         self.statements.vacuum().reset_counter()
     }

--- a/libs/toolkit-db/src/secure/runner.rs
+++ b/libs/toolkit-db/src/secure/runner.rs
@@ -26,11 +26,6 @@ pub enum SeaOrmRunner<'a> {
     Tx(&'a sea_orm::DatabaseTransaction),
 }
 
-// Only the outbox module needs `executor()` today; the whole impl block is
-// gated to match so it isn't flagged as dead code (and the block itself
-// doesn't trip an elidable-lifetime warning once empty) when `preview-outbox`
-// is off.
-#[cfg(feature = "preview-outbox")]
 impl<'a> SeaOrmRunner<'a> {
     /// Erase the connection/transaction distinction into `SeaORM`'s own executor enum.
     ///

--- a/libs/toolkit-db/tests/db_generic.rs
+++ b/libs/toolkit-db/tests/db_generic.rs
@@ -121,6 +121,70 @@ async fn generic_mysql() -> Result<()> {
     run_common_suite(&dut.url).await
 }
 
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn outbox_schema_reapplies_cleanly_sqlite() -> Result<()> {
+    let dut = common::bring_up_sqlite();
+    run_outbox_reapply_suite(&dut.url).await
+}
+
+#[cfg(feature = "pg")]
+#[tokio::test]
+async fn outbox_schema_reapplies_cleanly_postgres() -> Result<()> {
+    let dut = common::bring_up_postgres().await?;
+    run_outbox_reapply_suite(&dut.url).await
+}
+
+#[cfg(feature = "mysql")]
+#[tokio::test]
+async fn outbox_schema_reapplies_cleanly_mysql() -> Result<()> {
+    let dut = common::bring_up_mysql().await?;
+    run_outbox_reapply_suite(&dut.url).await
+}
+
+/// Applies the identical outbox DDL twice over the same database.
+///
+/// This is the crash-before-recording-then-retry path: every `CREATE TABLE` and
+/// `CREATE INDEX` in the outbox schema meets an object that already exists. Two
+/// *gear* names are used because each gear tracks its migration history
+/// independently, so the second run genuinely re-executes the DDL instead of
+/// skipping it -- which the `applied` assertions below pin down.
+///
+/// Covers the backend that the unit tests can only assert at the SQL-string
+/// level: on `MySQL` there is no `CREATE INDEX IF NOT EXISTS`, so idempotency
+/// rests on the `information_schema` probe actually working against a live
+/// server.
+async fn run_outbox_reapply_suite(database_url: &str) -> Result<()> {
+    let db = toolkit_db::connect_db(database_url, toolkit_db::ConnectOpts::default()).await?;
+
+    let first = toolkit_db::migration_runner::run_migrations_for_gear(
+        &db,
+        "outbox_reapply_first",
+        toolkit_db::outbox::outbox_migrations(),
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    assert_eq!(first.applied, 1, "first run should create the schema");
+
+    // Same DDL, fresh migration history -> re-executed against the schema the
+    // first run just built. Fails on the very first index without idempotent
+    // index creation.
+    let second = toolkit_db::migration_runner::run_migrations_for_gear(
+        &db,
+        "outbox_reapply_second",
+        toolkit_db::outbox::outbox_migrations(),
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    assert_eq!(
+        second.applied, 1,
+        "second run must actually re-execute the DDL, not skip it"
+    );
+    assert_eq!(second.skipped, 0);
+
+    Ok(())
+}
+
 /// Runs the same assertions for any backend.
 async fn run_common_suite(database_url: &str) -> Result<()> {
     // Test basic connection

--- a/libs/toolkit/Cargo.toml
+++ b/libs/toolkit/Cargo.toml
@@ -80,8 +80,6 @@ otel = [
     "dep:opentelemetry-otlp",
     "dep:tonic",
 ]
-# Transactional outbox pipeline (preview — API may change)
-preview-outbox = ["db", "toolkit-db/preview-outbox"]
 
 bootstrap = [
     "db",


### PR DESCRIPTION
- Removes the `preview-outbox` feature flag: the outbox pipeline is now always compiled and always available. `tokio-util` and `futures-util` become non-optional dependencies.

- Dependent crates: `toolkit`'s forwarding `preview-outbox` feature is deleted (nothing enabled it, it gated no source). `event-broker-sdk` keeps its own `outbox` feature -- it gates that SDK's producer surface in src/producer/ and src/lib.rs -- but narrowed to `["db"]`.

- All 8 index statements now route through `plan_create_index`, which returns an `IndexPlan`: `CREATE INDEX IF NOT EXISTS` on Postgres/SQLite, and an `information_schema.STATISTICS` probe followed by a plain CREATE on MySQL, which has no such syntax for indexes. The probe is preferred over tolerating error 1061 (ER_DUP_KEYNAME) because it needs no error-code matching and it also covers MariaDB, which `DatabaseBackend::MySql` does not distinguish and whose `IF NOT EXISTS` support differs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transactional outbox functionality is now available by default without requiring an additional preview option.
  * Database migrations can be safely rerun and will restore missing indexes automatically across supported databases.

* **Bug Fixes**
  * Improved migration reliability by preventing duplicate index errors and supporting consistent recovery after incomplete database setup.

* **Documentation**
  * Updated outbox examples, benchmarks, and setup instructions to reflect the simplified configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->