### PR TITLE
feat(toolkit-db): safe CTE support in the Secure ORM (ADR-0001)

### DIFF
--- a/docs/arch/secure-orm/ADR/0001-secure-cte-policy.md
+++ b/docs/arch/secure-orm/ADR/0001-secure-cte-policy.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-07-24
 decision-makers: Constructor Fabric steering committee
 ---
@@ -50,13 +50,14 @@ There is real, tracked demand for capabilities that today would reach for a CTE:
 
 **Scope of this ADR.** This policy governs **standard user gears** — the
 handlers / services / repos that build queries against their own domain tables. It
-does **not** govern `toolkit-db` itself. The one existing CTE in the crate is the
-outbox writer
-([outbox/store.rs:264-273](../../../../libs/toolkit-db/src/outbox/store.rs#L264-L273)):
-that is raw dialect-specific SQL living **inside the system library that implements the
-Secure ORM**, where sea_query and hand-written SQL are the implementation substrate.
-That is correct and out of scope here — it is not user-gear code and is not a precedent
-for user-gear code.
+does **not** govern `toolkit-db` itself. The one pre-existing CTE in the crate is the
+outbox writer's: the raw dialect-specific `WITH` strings live in
+[outbox/dialect.rs:130-145](../../../../libs/toolkit-db/src/outbox/dialect.rs#L130-L145)
+(`outbox/store.rs` is only the caller). That is raw SQL **inside the system library that
+implements the Secure ORM**, where sea_query and hand-written SQL are the implementation
+substrate. It is correct, out of scope here, and not a precedent for user-gear code.
+(Note: the outbox is no longer behind a preview feature flag, but that changes nothing
+about this boundary — it was never user-gear code.)
 
 Today there is **no CTE support in the Secure ORM's user-facing API** and no policy
 governing it for user gears. This ADR settles the policy and the API shape **before**
@@ -75,15 +76,15 @@ ad-hoc solutions accrete in gears.
   ([cond.rs:104-185](../../../../libs/toolkit-db/src/secure/cond.rs#L104-L185)); the
   "scope as a sea_query expression" mechanic is proven.
 - **Do not regress hierarchy handling** — hierarchy traversal already works via
-  materialized closure tables (`tenant_closure`, `resource_group_closure`); do not
-  reintroduce recursion the isolation model cannot cover.
+  materialized closure tables (`tenant_closure`, `resource_group_closure`); any recursion
+  offered must be covered by the isolation model, not an exception to it.
 - **Reviewability** — any escape from the safe path must be visible at the API surface
   so a reviewer sees that isolation was considered.
 
 ## Considered Options
 
-- **Option A** — `SecureCte`, constructible only from `SecureSelect<E, Scoped>`; scope
-  is embedded inside each CTE body.
+- **Option A** — a CTE type constructible only from `SecureSelect<E, Scoped>`; scope is
+  embedded inside each CTE body.
 - **Option B** — Controlled escape-hatch: a CTE over a non-`Scopable` source with a
   mandatory `.scope_via_exists::<J>()` join predicate to a scoped entity.
 - **Option C** — Raw `WITH` from a string in gear code.
@@ -98,47 +99,93 @@ inside the body of every CTE.** Then any table a CTE touches is already filtered
 
 ### API shape
 
+**As implemented** ([`libs/toolkit-db/src/secure/cte.rs`](../../../../libs/toolkit-db/src/secure/cte.rs)).
+This is a builder rather than the free-standing `into_cte(name)` → `with_ctes(ctes)`
+pair originally sketched. Reason: a free-standing `SecureCte` value can be built from
+query A and passed to query B, which is exactly the scope mismatch the structural design
+exists to make unrepresentable — closing that hole would have required the runtime
+check enforcement option 1 exists to avoid. Tying construction to the outer query
+removes it with no check and no `Result`.
+
 ```rust
-// 1. A CTE body can be built ONLY from an already-scoped query.
-//    scope is already baked into the body via build_scope_condition.
-//    The name is `&'static str` (see "CTE name"); injection safety comes from
-//    sea_query identifier quoting, not from the lifetime.
-impl<E: ScopableEntity + EntityTrait> SecureSelect<E, Scoped> {
-    /// Turn a scoped query into a named CTE. Retains the query's `Arc<AccessScope>`
-    /// so `with_ctes` can enforce that every CTE shares the outer query's scope.
-    pub fn into_cte(self, name: &'static str) -> SecureCte { /* ... */ }
+// 1. A CTE query is reachable ONLY from an already-scoped select, which is what
+//    carries the `Arc<AccessScope>` every body inherits.
+impl<E: EntityTrait> SecureSelect<E, Scoped> {
+    pub fn with_ctes(self) -> SecureCteSelect<E>;
 }
 
-// 2. The outer query accepts CTEs and returns a DISTINCT type — NOT `Self`.
-//    `SecureSelect<E, Scoped>` is backed by `sea_orm::Select<E>`, whose
-//    `.all()/.one()/.count()` never see a `WithClause` (see "Feasibility
-//    constraint"). Returning `Self` would let the `WITH` silently vanish at
-//    execution. `SecureCteSelect` instead wraps a `sea_query::SelectStatement`
-//    + `WithClause` and executes through `find_by_statement` / `FromQueryResult`.
-impl<E: ScopableEntity + EntityTrait> SecureSelect<E, Scoped> {
-    pub fn with_ctes(
+// 2. Bodies are registered on the builder and scoped with the outer query's own
+//    Arc, so a differently-scoped CTE cannot be constructed -- nothing to compare,
+//    no error case. `SecureCteSelect` wraps a `sea_query::SelectStatement` +
+//    `WithClause` and does NOT reuse `Select<E>`'s execution path, so a `WITH`
+//    clause cannot silently vanish at execution time.
+impl<E: EntityTrait> SecureCteSelect<E> {
+    /// Non-recursive CTE over `J`. Scope is applied *after* `body` returns, so a
+    /// body cannot filter the scope predicate back off.
+    pub fn cte<J: ScopableEntity + EntityTrait>(
         self,
-        ctes: impl IntoIterator<Item = SecureCte>,
-    ) -> SecureCteSelect<E, Scoped> { /* ... */ }
-}
+        name: &'static str,
+        body: impl FnOnce(sea_orm::Select<J>) -> sea_orm::Select<J>,
+    ) -> Self;
 
-// 3. The CTE-aware result type: its own execution path, separate from `Select<E>`.
-impl<E: EntityTrait> SecureCteSelect<E, Scoped> {
-    pub async fn all(self, runner: &impl DBRunner) -> Result<Vec<E::Model>, ScopeError> { /* find_by_statement */ }
-    pub async fn one(self, runner: &impl DBRunner) -> Result<Option<E::Model>, ScopeError> { /* find_by_statement */ }
+    /// Recursive CTE. See "Recursive CTE" below.
+    pub fn recursive_cte<J: ScopableEntity + EntityTrait>(self, spec: RecursiveCte<J>) -> Self;
+
+    /// Reference a registered CTE from the outer query. Without this the `WITH`
+    /// clause is valid SQL that computes nothing.
+    pub fn join_cte(self, name: &'static str, on: Condition) -> Self;
+
+    pub fn filter(self, filter: Condition) -> Self;
+    pub fn limit(self, limit: u64) -> Self;
+    /// `join_cte` is an inner join, so an outer row repeats per matching CTE row.
+    /// Needed whenever the CTE is a membership set rather than a 1:1 join —
+    /// e.g. expanding a breadth-first frontier where edges converge on a node.
+    pub fn distinct(self) -> Self;
+
+    /// Ordering is split by column provenance, because the two cases differ in
+    /// validity under `DISTINCT` and the type cannot otherwise tell them apart.
+    /// An entity column is always in the outer `SELECT` list; a CTE column is not,
+    /// and PostgreSQL/`MySQL` both reject `ORDER BY` on an expression missing from
+    /// a `SELECT DISTINCT` list (`SQLite` accepts it, so the mistake would only
+    /// surface in production). Combining `distinct()` with `order_by_cte()`
+    /// therefore fails with `ScopeError::Invalid` on every backend.
+    pub fn order_by(self, col: E::Column, order: Order) -> Self;
+    pub fn order_by_cte(self, cte: &'static str, col: &'static str, order: Order) -> Self;
+
+    /// The outer query inherits `Select<E>`'s projection — every column of `E` —
+    /// and `all_as::<T>()` narrows only deserialization, not the SQL. On Postgres
+    /// that is the difference between an index-only scan and a heap visit per row.
+    pub fn select_only(self) -> Self;
+    pub fn column(self, col: E::Column) -> Self;
+    pub fn column_from_cte(self, cte: &'static str, col: &'static str, alias: &'static str) -> Self;
+    pub fn expr_as(self, expr: Expr, alias: &'static str) -> Self;
+
+    // Execution: `FromQueryResult::find_by_statement`, not `Select<E>::all()`.
+    pub async fn all(self, runner: &impl DBRunner) -> Result<Vec<E::Model>, ScopeError>;
+    pub async fn one(self, runner: &impl DBRunner) -> Result<Option<E::Model>, ScopeError>;
+    /// CTEs usually compute something the entity model has no shape for
+    /// (aggregates, window functions), so a custom projection is the common case.
+    pub async fn all_as<T: FromQueryResult>(self, runner: &impl DBRunner) -> Result<Vec<T>, ScopeError>;
+
+    /// Render without executing. Exists because the crate has no mock database,
+    /// so this is the only way a test can assert on the emitted SQL.
+    #[doc(hidden)]
+    pub fn build_statement(&self, backend: DbBackend) -> Statement;
 }
 ```
 
 The invariant this yields:
 
-- A `SecureCte` **cannot** be constructed from an `Unscoped` select → the compiler
-  forbids unwrapped table access inside `WITH`.
+- A CTE query **cannot** be started from an `Unscoped` select → the compiler forbids
+  unwrapped table access inside `WITH`. Pinned by the compile-fail test
+  `tests/ui/fail/cte_from_unscoped.rs`.
 - The outer query is itself `Scoped` on its own root entity.
 - The `Scopable` requirement is not a separate check: `SecureSelect<E, Scoped>` is only
   reachable through `scope_with`/`scope_with_arc`, which are bounded `E: ScopableEntity`
   ([select.rs:151-155](../../../../libs/toolkit-db/src/secure/select.rs#L151-L155)). So
-  `into_cte`/`with_ctes` carry that bound (shown above) and a non-`Scopable` entity can
-  never reach a CTE.
+  `with_ctes` is reachable only from a `Scoped` select, and `cte`/`recursive_cte` carry
+  `J: ScopableEntity` for the body entity, so a non-`Scopable` entity can never reach a
+  CTE.
 - `with_ctes` returns `SecureCteSelect`, a type that does **not** reuse `Select<E>`'s
   execution path, so the API shape and the "Feasibility constraint" section below agree
   — there is no way to build a CTE query that then executes as a plain `Select<E>` and
@@ -157,15 +204,30 @@ detail, out of scope for this ADR.
 
 ### CTE name
 
-`into_cte` takes `&'static str`, not `&str` — an ergonomic nudge toward string literals,
-not a security control (a `&'static str` can still be produced at runtime by leaking).
-Injection safety does not depend on it: the name goes through sea_query's `Alias`/`Iden`,
-which renders it as a quoted, escaped identifier. In the pinned **sea_query 0.32.7** the
-quote char is `"` for Postgres and SQLite and `` ` `` for MySQL, and an embedded quote
-char is escaped by doubling it (`types.rs:31-39`). So a hostile name becomes an inert
-quoted identifier, never executable SQL — confirm with the hostile-name test (see
-Confirmation). A gear that needs a truly dynamic name is out of
-scope for Level A (escape-hatch, Level B); validate against an allowlist there.
+`cte`/`recursive_cte` take `&'static str`, not `&str` — an ergonomic nudge toward string
+literals, not a security control (a `&'static str` can still be produced at runtime by
+leaking). Injection safety does not depend on it: the name goes through sea_query's
+`Alias`, which renders it as a quoted, escaped identifier.
+
+The pinned version is **sea_query 1.0.2** (pulled by sea-orm 2.0.2 since commit
+`5446288b`), where the mechanism is a two-branch gate rather than unconditional
+escaping — worth stating precisely, because only one branch escapes:
+
+- `QuotedBuilder::prepare_iden` (`sea-query-1.0.2/src/backend/mod.rs:44-61`) doubles the
+  quote char **only for `Cow::Owned`**; a `Cow::Borrowed` is written verbatim.
+- `Alias::new(name)` always yields `Cow::Owned`, so it is always escaped. A `&'static str`
+  used directly as an `Iden` yields `Cow::Borrowed` **only if `is_static_iden()` passes**
+  (`src/types/iden/core.rs:228`, i.e. `[A-Za-z_][A-Za-z0-9_]*`), and otherwise falls back
+  to `Cow::Owned` — so hostile input is escaped on that path too.
+
+Quote chars: `"` for Postgres and SQLite, `` ` `` for MySQL. So a hostile name becomes an
+inert quoted identifier, never executable SQL — pinned by the hostile-name tests (see
+Confirmation), which assert the *structural* property that the name occupies exactly the
+identifier slot of one CTE definition, not merely that the payload appears somewhere.
+
+The implementation must therefore route names through `Alias::new(...)` and never
+`format!` them into SQL. A gear that needs a truly dynamic name is out of scope for
+Level A (escape-hatch, Level B); validate against an allowlist there.
 
 ### Same-scope constraint
 
@@ -173,18 +235,20 @@ The outer query and **every** supplied `SecureCte` must carry the **same**
 `AccessScope`. Combining CTEs built from different scopes (e.g. two tenants) in one query
 is disallowed: each CTE body is still individually safe (its own scope is embedded), but
 a single query mixing scopes is semantically incoherent and exactly the kind of ad-hoc
-pattern this ADR exists to prevent. Enforcement, in order of preference:
+pattern this ADR exists to prevent.
 
-1. **Structural (preferred).** Seed each CTE from the outer query's own
-   `Arc<AccessScope>` so a differently-scoped CTE is *unrepresentable* — no check needed,
-   matching the compile-time ethos of the rest of the Secure ORM.
-2. **Hard runtime check (fallback).** If the structural design proves too invasive for
-   the first cut, `with_ctes` compares the outer `AccessScope` against each CTE's by
-   value (`AccessScope: PartialEq`,
-   [access_scope.rs](../../../../libs/toolkit-security/src/access_scope.rs)) and returns
-   `Err` on mismatch — **in all build profiles**. Note: `debug_assert!` is **not**
-   acceptable here; it is compiled out in release builds and would leave a
-   tenant-isolation invariant unchecked in production.
+**Resolved: option 1, structurally.** `with_ctes()` captures the outer query's
+`Arc<AccessScope>` and every body registered on the builder is scoped from it. A
+differently-scoped CTE is unrepresentable, so there is nothing to compare, no runtime
+check, and no error case — `with_ctes` does not return `Result`. The options considered
+and *not* taken, recorded so they are not revisited:
+
+2. **Hard runtime check.** Comparing the outer `AccessScope` against each CTE's by value
+   (`AccessScope: PartialEq`,
+   [access_scope.rs](../../../../libs/toolkit-security/src/access_scope.rs)) and returning
+   `Err` on mismatch — **in all build profiles**. Unnecessary given option 1. Note:
+   `debug_assert!` would **not** have been acceptable; it is compiled out in release
+   builds and would leave a tenant-isolation invariant unchecked in production.
 3. **dylint (complementary, not a substitute).** A custom lint can enforce the *syntactic*
    Level-C prohibitions (no raw `WITH` string, no `into_inner`/`into_query` in
    handlers/services/repos), but it **cannot** verify that two runtime `AccessScope`
@@ -201,30 +265,41 @@ the only public unwrap is `into_inner() -> Select<E>`
 ([select.rs:415-418](../../../../libs/toolkit-db/src/secure/select.rs#L415-L418)) —
 there is no `into_query()`. Critically, **`sea_orm::Select<E>` has no `.with()`
 method**; `WithClause`/`CommonTableExpression` live on `sea_query`. Therefore
-`into_cte`/`with_ctes` cannot be a drop-in over `inner`:
+the CTE API cannot be a drop-in over `inner`. This still holds in sea-orm 2.0.2. How the
+implementation satisfies it:
 
-- `into_cte` must call `QueryTrait::into_query()` on the `Select<E>` to obtain a
+- `cte`/`recursive_cte` call `QueryTrait::into_query()` on the `Select<J>` to obtain a
   `sea_query::SelectStatement` (scope `WHERE` already embedded) and wrap it in a
   `sea_query::CommonTableExpression`.
-- `with_ctes` must build the outer query as a `sea_query` statement with
-  `.with(WithClause)` and execute it through a **separate path** —
-  `E::find_by_statement(backend.build(&stmt))` / `FromQueryResult` — **not** through
-  `Select<E>::all()`.
+- `SecureCteSelect` holds the outer query as a `sea_query::SelectStatement`, attaches
+  `.with(WithClause)` to get a `WithQuery`, and executes through a **separate path** —
+  **not** `Select<E>::all()`.
+- Two corrections to the original sketch. `find_by_statement` is a method on
+  **`FromQueryResult`**, not `EntityTrait` (`sea-orm-2.0.2/src/entity/model.rs:214`), so
+  the call is `E::Model::find_by_statement(stmt)`. And `StatementBuilder` *is* implemented
+  for `sea_query::WithQuery` (`sea-orm-2.0.2/src/database/statement.rs:134`) via
+  `from_string_values_tuple`, so the statement carries **bound parameters** and no manual
+  per-backend `match` is needed.
+- One gap this exposed: `DBRunner` is sealed and method-free, so there was no way to learn
+  the backend in order to render. Added `pub(crate) SeaOrmRunner::backend()`, mirroring
+  `outbox/core.rs:408-413`, which keeps the trait method-free and leaks no SeaORM type.
 
 This is a design requirement, not an optional detail: an implementer who assumes
 `inner.with(...)` exists will hit a type wall.
 
 ### Levels of strictness
 
-- **Level A (safe, this decision)** — `SecureCte` only from scoped selects over
-  `Scopable` entities. Covers the great majority of real needs (aggregations, dedup,
-  window functions over an intermediate scoped set).
+- **Level A (safe, this decision)** — `cte`/`recursive_cte`, reachable only from a scoped
+  select and only over `Scopable` entities. Covers the great majority of real needs
+  (aggregations, dedup, window functions over an intermediate scoped set, and hierarchy
+  traversal with a depth cap).
 - **Level B (future, controlled escape-hatch)** — CTE over a non-`Scopable` source but
   with a **mandatory** `.scope_via_exists::<J>()` predicate to a scoped entity.
   Out of scope here; recorded so it is not reinvented ad hoc.
-- **Level C (forbidden in user gears)** — raw `WITH` from a string. Not allowed in
-  standard user-gear code (handlers/services/repos). Migrations and the
-  system libraries that implement the Secure ORM (`toolkit-db` internals, e.g. the
+- **Level C (forbidden in user gears)** — raw `WITH` from a string, recursive or not. Not
+  allowed in standard user-gear code (handlers/services/repos): nothing then guarantees the
+  body is scoped, nor — for a recursive `WITH` — that the walk terminates. Migrations and
+  the system libraries that implement the Secure ORM (`toolkit-db` internals, e.g. the
   outbox writer) are a different layer and are not governed by this policy.
   This prohibition is *syntactic* and can therefore be enforced mechanically rather
   than by reviewer vigilance: a custom [dylint](https://github.com/trailofbits/dylint)
@@ -247,13 +322,20 @@ This is a design requirement, not an optional detail: an implementer who assumes
   `find_by_statement`/`FromQueryResult`), diverging from the existing `.all()` path.
 - The CTE body is scoped, but the outer query cannot post-filter the CTE's contents —
   the scope must be correct at body-build time.
+- Recursive traversal requires the caller to state a depth bound. There is no safe
+  default: `CYCLE` is not portable, so an unbounded walk over a cyclic graph would not
+  terminate.
+- Recursive results depend on the dedup mode: `Union` (default) discards rows
+  duplicating ones already produced at the same depth; `UnionAll` keeps every row
+  (see "Recursive CTE"). Neither is a visited set -- a node can still recur at a
+  greater depth.
 
 **Risks:**
 
 - The correlation between a CTE and the outer query (e.g. joining the CTE to the outer
   entity on the right tenant key) is **not** compiler-verified. This is a **correctness**
-  risk, not an isolation risk: because every `SecureCte` embeds its own scope in its own
-  body via `build_scope_condition`, a wrong join predicate can only under- or over-select
+  risk, not an isolation risk: because every CTE body embeds its own scope via
+  `build_scope_condition`, a wrong join predicate can only under- or over-select
   *rows* (missing/duplicate results) — it **cannot** leak another tenant's data, since the
   CTE body never contained that data to begin with. The isolation boundary is
   per-CTE-body and independent of outer-join correctness. Mitigate the correctness risk
@@ -266,32 +348,134 @@ This is a design requirement, not an optional detail: an implementer who assumes
 
 ### Confirmation
 
-- Tests modeled on the existing scope-condition tests
-  ([cond.rs:191+](../../../../libs/toolkit-db/src/secure/cond.rs#L191)) that assert the
-  scope condition is present in the body of **every** CTE (assert against the built
-  SQL, per backend).
-- Add an execution-path test on `SecureCteSelect::all`/`one`: capture the emitted
-  statement and assert it contains the `WITH` clause, so a regression that falls back to
-  the plain `Select<E>` path (silently dropping the CTE) is caught — not just that the
-  scope predicate is present inside the body.
-- Add a hostile-name test for `into_cte`: pass a name containing the backend quote char
-  and SQL metacharacters (e.g. `foo"; DROP TABLE x --`) and assert the built statement
-  renders it as a single quoted, escaped identifier (doubled quote char), not as
-  executable SQL — per backend.
+Done ([`cte_tests.rs`](../../../../libs/toolkit-db/src/secure/cte_tests.rs),
+[`tests/sqlite/secure_cte.rs`](../../../../libs/toolkit-db/tests/sqlite/secure_cte.rs),
+[`tests/ui/fail/cte_from_unscoped.rs`](../../../../libs/toolkit-db/tests/ui/fail/cte_from_unscoped.rs)):
+
+- Scope present in the body of **every** CTE, asserted against the built SQL per backend
+  (Postgres / MySQL / SQLite). Unlike the existing scope-condition tests
+  ([cond.rs:191+](../../../../libs/toolkit-db/src/secure/cond.rs#L191)), which match on the
+  `Debug` form of a `Condition`, these assert on the rendered statement — a `Condition`
+  that never reaches the SQL would satisfy a Debug check and still leak.
+- Execution-path test: the emitted statement starts with `WITH`, so a regression that fell
+  back to the plain `Select<E>` path (silently dropping the CTE) is caught.
+- Hostile-name test per backend: `foo"; DROP TABLE x --` must render as a single quoted,
+  escaped identifier. Asserted **structurally** — the name occupies exactly the identifier
+  slot of one CTE definition — rather than by searching for the payload, because a
+  correctly escaped name still *contains* the dangerous substring.
+- Compile-fail test: `with_ctes()` on an `Unscoped` select does not compile.
+- Recursive: `WITH RECURSIVE` emitted, scope predicate present in **both** members, depth
+  cap emitted and reflecting the caller's bound. Live SQLite tests cover tenant isolation,
+  subtree traversal, depth truncation, and termination on a cyclic graph.
+
+Two traps worth recording, because both produced tests that passed against deliberately
+broken code before being fixed:
+
+1. **Counting the column name is not counting the predicate.** `tenant_id` appears in every
+   member's `SELECT` list, so `contains("tenant_id")` passes even on a completely unscoped
+   member. Assert on the `tenant_id IN (` form.
+2. **The outer query masks a leaking CTE body.** Joining a CTE back on `id` re-filters
+   through the outer query's own scope predicate, which drops foreign rows before they are
+   observable — so that query shape cannot detect an unscoped body at all. To observe the
+   body, pin the outer query to one row and join the CTE on a tautology, making the CTE's
+   size visible in the row count.
+
+Remaining:
+
 - Codify the prohibition on raw and recursive CTEs in gear code in
   [11_database_patterns.md](../../../toolkit_unified_system/11_database_patterns.md),
-  alongside the existing "No plain SQL" rule.
+  alongside the existing "No plain SQL" rule. **Done.**
 - Back the Level-C prohibition with a custom `dylint` lint in CI (flag raw `WITH`
   strings and `into_inner()`/`into_query()` reaching a raw-SQL sink in gear crates), so
-  the guardrail is machine-checked rather than left to review. The same-scope invariant
-  is *not* covered by the lint and must be enforced structurally / at runtime instead.
+  the guardrail is machine-checked rather than left to review. **Not done** — the lint
+  crate lives in the separate `cargo-gears` repository
+  (`crates/cargo-gears-lints`, closest analog `de07_security/de0706_no_direct_sqlx.rs`),
+  so this is a cross-repo change. Note it already has a target: the only current
+  `into_inner()`→`into_query()` chain in gear code is
+  `account-management/.../repo_impl/reads.rs:512-518`. The same-scope invariant is *not*
+  covered by the lint and is enforced structurally instead.
 
 ## Recursive CTE (`WITH RECURSIVE`)
 
-**Rejected for hierarchy traversal.** A recursive member references the CTE itself, and
-scope cannot be embedded into the recursive step statically — a direct conflict with
-the guardrails. The platform already made the opposite architectural choice: it
-**materializes transitive closure on write** rather than computing it on read.
+**Accepted, with a mandatory depth cap.** This reverses the original rejection, whose
+stated reason does not hold.
+
+The rejection claimed "scope cannot be embedded into the recursive step statically". It
+can. A recursive member is not a query over the CTE alone — it reads the **real table**
+joined against the CTE self-reference, so `build_scope_condition::<J>()` applies to it
+exactly as it does to the seed. Both members can, and do, carry the same
+`Arc<AccessScope>`:
+
+```sql
+WITH RECURSIVE n AS (
+    SELECT j.link_col, j.anchor_col, 0 AS __cte_depth FROM j
+     WHERE <seed> AND <scope>
+    UNION                                            -- RecursiveDedup, UNION by default
+    SELECT j.link_col, j.anchor_col, n.__cte_depth + 1 FROM j
+      JOIN n ON j.link_col = n.anchor_col
+     WHERE <scope> AND n.__cte_depth < <max_depth>   -- library-emitted, not optional
+)
+```
+
+The body projects **three columns, not the whole row**. A walk needs only the two
+link columns and the depth; the outer query supplies full rows by joining back. That
+is not merely narrower — under `UNION` the dedup compares every selected column, and
+PostgreSQL's `json` type has no equality operator, so selecting a `ColumnType::Json`
+column here would fail with *"could not identify an equality operator for type json"*
+before the traversal ran. The same constraint applies to `distinct()` on the outer
+query, which is why the projection controls exist.
+
+The real hazard is different, and was not named in the original rejection: **cycles**.
+`sea_query` renders PostgreSQL's `CYCLE` clause but its MySQL and SQLite builders
+implement `prepare_with_clause_recursive_options` as **empty no-ops**
+(`sea-query-1.0.2/src/backend/mysql/query.rs:139-140`,
+`src/backend/sqlite/query.rs:65-66`), so `CYCLE` cannot be relied on portably — a cyclic
+graph would recurse until the server gave up. Hence `RecursiveCte::max_depth` has no
+default and no `Option`: the caller must state a bound, and the library emits it as a
+predicate on the recursive member. That is the termination guarantee.
+
+**Path explosion is a choice, not an inherent limit.** An earlier draft of this ADR
+stated that the walk necessarily enumerates paths and was therefore unsuited to
+general graphs. That was a consequence of emitting `UNION ALL`, not of recursion.
+Plain `UNION` in a recursive CTE discards rows duplicating ones already produced —
+standard SQL, available on PostgreSQL, MySQL 8+ and SQLite. Since the row carries its
+depth, dedup is per (row, depth), so re-expansion is bounded by *(rows × depth)*
+rather than by path count; measured on a hub-heavy 200k-node / 660k-edge profile at
+p95 4.06 ms by the Graph Storage team, and reproduced here on a converging-path
+fixture at 50 rows against 240 for `UNION ALL`.
+
+`RecursiveDedup::Union` is therefore the default, with `UnionAll` available for the
+sparse parent-pointer case where comparing rows is wasted work. Neither is a visited
+set: a node can still be revisited at a greater depth, only not re-emitted
+identically. `distinct()` deduplicates the final rows but does not prune the walk.
+
+**Shape limit: one self-referencing table.** The recursive member joins `J` to the CTE
+on `J.link_col = cte.anchor_col`, so both endpoints of a hop must be columns of the
+same entity — an edge table (`src`, `dst`) or a parent-pointer tree
+(`parent_id`, `id`). A hop *through* a separate table (`node -> edge -> node`) needs a
+three-way join in the recursive member and is not expressible; use one scoped query
+per hop instead. The column pair is named `link_col`/`anchor_col` rather than
+child/parent because the traversal is directed-edge, not necessarily hierarchical.
+
+Two further consequences worth stating plainly:
+
+- **Cost.** If the scope is `InTenantSubtree` (itself a subquery over `tenant_closure`),
+  embedding it per hop re-evaluates it at every recursion level. Closure tables remain the
+  better choice for *hot*, frequently-traversed hierarchies — see below — but they are no
+  longer a *precondition* for traversing one.
+- **Dedup is per depth, not per node.** `Union` (default) discards a row duplicating one
+  already produced at the same depth, so re-expansion is bounded by *(rows x depth)* rather
+  than by path count. It is not a visited set: a node reachable by two paths of different
+  length is still expanded at each depth it is reached. `UnionAll` keeps every row and
+  therefore enumerates full paths. Either way the depth cap guarantees termination, not
+  node-level uniqueness; callers wanting distinct nodes should dedup the final rows with
+  `distinct()` (after narrowing the projection with `select_only()` -- see
+  "API shape") or `GROUP BY`.
+
+### Closure tables: still preferred for hot hierarchies, no longer required
+
+The platform materializes transitive closure on write rather than computing it on read,
+and that remains the right default for hierarchies that are traversed often:
 
 - `tenant_closure` (`ancestor_id, descendant_id, barrier, descendant_status`) is
   maintained incrementally on tree changes
@@ -304,24 +488,23 @@ the guardrails. The platform already made the opposite architectural choice: it
   table (`col IN (SELECT descendant_id FROM ... WHERE ancestor_id = ?)`), not recursion
   ([cond.rs:121-185](../../../../libs/toolkit-db/src/secure/cond.rs#L121-L185)).
 
-The driver for this ADR is a **new domain hierarchy not yet in the closure model.**
-The recommendation is therefore **not** to introduce `WITH RECURSIVE`, but to extend
-the closure model:
+The driver for this ADR is a **new domain hierarchy not yet in the closure model.** For
+such a hierarchy there are now two legitimate routes, and the choice is a cost question
+rather than a safety one:
 
-1. Add a new closure table for the new hierarchy, maintained incrementally on write
-   (self-row + one strict-ancestor hop per edge), with the same self-row / status /
-   barrier-style invariants and a covering index.
-2. Add a new `ScopeFilter` variant and a branch in `build_scope_condition`, modeled on
-   `InTenantSubtree` / `InGroupSubtree`.
+- **Traversed often → extend the closure model.** Add a closure table maintained
+  incrementally on write (self-row + one strict-ancestor hop per edge) with the same
+  self-row / status / barrier-style invariants and a covering index, plus a new
+  `ScopeFilter` variant and a `build_scope_condition` branch modeled on
+  `InTenantSubtree` / `InGroupSubtree`. Traversal then becomes part of the scope
+  condition and inherits tenant isolation for free, and reads stay flat.
+- **Traversed rarely, or the tree changes constantly → `recursive_cte`.** No migration, no
+  write-path maintenance. Pay per-read recursion instead, and accept the per-hop cost of a
+  subquery-based scope filter.
 
-Then traversal of the new hierarchy becomes part of the scope condition and inherits
-tenant isolation "for free", exactly as the existing hierarchies do.
-
-A recursive CTE would be justified only for an **ad-hoc hierarchy not worth
-materializing** (rare traversal, frequently changing tree). Even then it must be a
-future Level B/C feature with an explicit constraint: the recursive seed is a
-scoped select, and the recursive member is physically confined to the same tenant
-column in its join predicate.
+Neither route requires the other. What is *not* acceptable is a hand-written recursive
+`WITH` in gear code (Level C), because nothing then guarantees the recursive member is
+scoped or that the walk terminates.
 
 ## Pros and Cons of the Options
 
@@ -354,12 +537,21 @@ column in its join predicate.
 
 ### Option D: `WITH RECURSIVE` for hierarchies
 
-- Good, because it materializes nothing (no closure table to maintain).
-- Bad, because scope cannot be embedded into the recursive member statically → tenant
-  isolation cannot be guaranteed.
-- Bad, because barriers/status would have to be threaded into the recursion by hand.
-- Bad, because it duplicates a problem already solved by closure tables.
-- Rejected; extend the closure model instead.
+**Accepted alongside Option A**, as `recursive_cte`. Originally rejected on a premise that
+turned out to be false; see "Recursive CTE" above.
+
+- Good, because it materializes nothing — no closure table, no write-path maintenance,
+  no migration.
+- Good, because scope *is* statically embeddable in the recursive member: that member reads
+  the real table joined to the CTE self-reference, so the same `build_scope_condition`
+  applies there as to the seed. (This is the corrected premise. The original "scope cannot
+  be embedded into the recursive member statically" was wrong.)
+- Bad, because `CYCLE` is not portable — `sea_query`'s MySQL and SQLite builders no-op it —
+  so termination depends on a library-emitted depth cap rather than the engine.
+- Bad, because a subquery-based scope filter (`InTenantSubtree`) is re-evaluated per hop.
+- Bad, because dedup is per depth, not per node: a node reachable via paths of
+  different lengths is still expanded once per depth even under the default `Union`.
+- Not a substitute for closure tables on hot paths; both are supported, chosen on cost.
 
 ## More Information
 

--- a/docs/toolkit_unified_system/11_database_patterns.md
+++ b/docs/toolkit_unified_system/11_database_patterns.md
@@ -10,6 +10,77 @@ For security-scoped database access (`SecureConn`, `AccessScope`, `PolicyEnforce
 - **Rule**: Repository methods accept `runner: &impl DBRunner`, not `&SecureConn`.
 - **Rule**: Use `in_transaction_mapped` for transactional work.
 - **Rule**: Each gear gets its own isolated migration history table.
+- **Rule**: CTEs go through `with_ctes()` / `cte()` / `recursive_cte()`. A raw `WITH`
+  string — recursive or not — is forbidden in gear code, as is reaching a raw-SQL sink
+  via `into_inner()` / `into_query()`.
+- **Rule**: Recursive traversal must state a depth bound. There is no safe default.
+
+## Common Table Expressions (`WITH`)
+
+The full rationale is [ADR-0001](../arch/secure-orm/ADR/0001-secure-cte-policy.md); the
+rules that matter day to day:
+
+A CTE body is an independent `SELECT`, so the outer query's scope `WHERE` does **not**
+reach inside it. The Secure ORM therefore embeds scope into *every* CTE body rather than
+relying on the outer query. `with_ctes()` is only reachable from a scoped select, and each
+body inherits that query's `AccessScope` — a differently-scoped CTE cannot be built, so
+there is no check to remember and no error to handle.
+
+```rust
+let rows = order::Entity::find()
+    .secure()
+    .scope_with(&scope)          // required before with_ctes()
+    .with_ctes()
+    .cte::<line_item::Entity>("scoped_items", |q| {
+        q.filter(line_item::Column::Quantity.gt(0))
+    })
+    .join_cte("scoped_items", on_condition)   // define != use
+    .all(runner)
+    .await?;
+```
+
+Things to keep in mind:
+
+- **Attaching a CTE is not using it.** `cte()` only defines; without `join_cte()` the
+  `WITH` clause is valid SQL that computes nothing.
+- **The join predicate is yours to get right.** It is not compiler-verified. Getting it
+  wrong changes which rows return, but cannot cross a tenant boundary — the body never
+  held another tenant's rows.
+- **`join_cte` is an inner join**, so an outer row repeats once per matching CTE row. Use
+  `.distinct()` when the CTE is a membership set rather than a 1:1 join — and narrow the
+  projection first with `.select_only()`, because `SELECT DISTINCT` compares every selected
+  column and PostgreSQL's `json` has no equality operator (`jsonb` does).
+- **Ordering is split by where the column comes from.** `.order_by(E::Column, ..)` for an
+  entity column, `.order_by_cte("cte", "col", ..)` for a CTE's own column (e.g. a recursive
+  walk's depth). Only the first is combinable with `.distinct()`: PostgreSQL and MySQL both
+  reject `ORDER BY` on an expression that is not in a `SELECT DISTINCT` list, so pairing
+  `.distinct()` with `.order_by_cte()` returns `ScopeError::Invalid` on every backend rather
+  than working on SQLite and failing in production. "Distinct rows, shallowest first" needs
+  `GROUP BY … ORDER BY MIN(depth)`, which this API cannot express yet — dedup in the caller.
+- **The outer query selects every column of `E` by default.** `all_as::<T>()` narrows
+  *deserialization*, not the SQL — a hop needing only ids still transfers the wide columns,
+  and on PostgreSQL that turns an index-only scan into a heap visit per row (measured 0.371
+  ms against 0.079 ms). Use `.select_only()` plus `.column()` / `.column_from_cte()` /
+  `.expr_as()` to narrow it, and pair that with `all_as::<T>()` rather than `all()`.
+- **Don't `OR` two columns in a `join_cte` predicate.** `node.id = cte.src OR node.id =
+  cte.dst` drops the index and sequentially scans (15.2 ms against 0.30 ms on 199k nodes).
+  Put the alternation inside the CTE body instead, projecting one column that already holds
+  both endpoints.
+- **Recursive walks need a depth cap**, passed to `RecursiveCte::new`. PostgreSQL's `CYCLE`
+  clause is not portable (sea_query no-ops it on MySQL and SQLite), so the cap is the only
+  termination guarantee. Separately, the dedup mode decides how much work happens inside
+  that bound: the default `RecursiveDedup::Union` discards rows duplicating ones already
+  produced, bounding re-expansion by *(rows × depth)*; `UnionAll` keeps everything and
+  enumerates *paths*, which multiplies on hub-shaped graphs. Neither is a visited set.
+- **A recursive walk spans one self-referencing table.** The recursive member joins `J` to
+  the CTE on `J.link_col = cte.anchor_col`, so both endpoints must be columns of the same
+  entity — an edge table (`src`, `dst`) or a parent-pointer tree (`parent_id`, `id`). A hop
+  *through* a separate table (`node -> edge -> node`) needs a three-way join and is not
+  expressible; use one scoped query per hop instead.
+
+For a hierarchy that is traversed often, prefer a closure table (as `tenant_closure` does)
+over recursing on every read — `recursive_cte` is the right tool for rarely-walked or
+frequently-changing trees, where materializing is not worth the write-path cost.
 
 ## Executors: `DBRunner` and `SecureTx`
 
@@ -164,7 +235,11 @@ Raw SQL is **allowed only in migration infrastructure** (migration runner + migr
 
 - [ ] Use `runner: &impl DBRunner` in repository method signatures.
 - [ ] Use `in_transaction_mapped` for multi-step mutations.
-- [ ] Use raw SQL only in `migrations/*.rs`.
+- [ ] Use raw SQL only in migration infrastructure (migration runner + migration
+      definitions) — including raw `WITH`.
+- [ ] Build CTEs with `with_ctes()`/`cte()`/`recursive_cte()`, and reference them with
+      `join_cte()`.
+- [ ] Give every `recursive_cte` an explicit `max_depth`.
 - [ ] Add indexes on security columns (`tenant_id`, `resource_id`).
 - [ ] Provide `DatabaseCapability::migrations()` returning SeaORM migrations.
 

--- a/libs/toolkit-db/src/secure/cte.rs
+++ b/libs/toolkit-db/src/secure/cte.rs
@@ -1,0 +1,668 @@
+//! Common Table Expression (`WITH`) support for the Secure ORM.
+//!
+//! Implements [ADR-0001](../../../../docs/arch/secure-orm/ADR/0001-secure-cte-policy.md).
+//!
+//! # Why this is a separate type
+//!
+//! A CTE body is an independent `SELECT` over arbitrary tables, so the outer
+//! query's scope `WHERE` does **not** reach inside it. Left unchecked that is a
+//! direct tenant-isolation hole. The rule this module enforces is therefore
+//! *not* "scope the outer query" but **"embed scope inside the body of every
+//! CTE"** — then any table a CTE touches is already filtered.
+//!
+//! Isolation is structural rather than checked at runtime: a [`SecureCteSelect`]
+//! is reachable only from [`SecureSelect<E, Scoped>::with_ctes`], and every CTE
+//! registered on it is scoped with *that query's* `Arc<AccessScope>`. There is no
+//! way to hand it a body carrying a different scope, so there is nothing to
+//! compare and no error case to return.
+//!
+//! # Why it cannot reuse `Select<E>`
+//!
+//! `SecureSelect` wraps a [`sea_orm::Select<E>`], which has no `.with()` —
+//! `WithClause`/`CommonTableExpression` live in `sea_query`. So a CTE query
+//! cannot be a `Select<E>` at all, and executing one has to go through
+//! `FromQueryResult::find_by_statement` instead of `Select<E>::all()`. Returning
+//! `Self` from `with_ctes` would let the `WITH` clause silently vanish at
+//! execution time; returning a distinct type makes that unrepresentable.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! // Rows of `order` that have at least one line item in the same scope.
+//! let rows = order::Entity::find()
+//!     .secure()
+//!     .scope_with(&scope)
+//!     .with_ctes()
+//!     .cte::<line_item::Entity>("scoped_items", |q| {
+//!         q.filter(line_item::Column::Quantity.gt(0))
+//!     })
+//!     .join_cte(
+//!         "scoped_items",
+//!         Condition::all().add(
+//!             Expr::col((Alias::new("scoped_items"), Alias::new("order_id")))
+//!                 .equals((order::Entity, order::Column::Id)),
+//!         ),
+//!     )
+//!     .all(&conn)
+//!     .await?;
+//! ```
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use sea_orm::sea_query::{
+    Alias, CommonTableExpression, Expr, IntoIden, JoinType, Order, SelectStatement, UnionType,
+    WithClause,
+};
+use sea_orm::{
+    ColumnTrait, Condition, EntityTrait, ExprTrait, FromQueryResult, QueryFilter, QueryTrait,
+    StatementBuilder,
+};
+
+use crate::secure::error::ScopeError;
+use crate::secure::select::{Scoped, SecureEntityExt, SecureSelect};
+use crate::secure::{AccessScope, DBRunner, DBRunnerInternal, ScopableEntity};
+
+/// Column a recursive CTE exposes its distance-from-seed on.
+///
+/// Emitted into every recursive CTE body, because the depth cap has to be
+/// expressible as a predicate on the recursive member. A CTE whose source entity
+/// already has a column of this name would collide, so the name is deliberately
+/// unlikely: double leading underscore, not a plausible domain column.
+const DEPTH_COLUMN: &str = "__cte_depth";
+
+/// A scoped query that carries `WITH` definitions.
+///
+/// Built by [`SecureSelect::with_ctes`]. Every CTE registered here is scoped
+/// with the originating query's `AccessScope`, so mixing scopes in one statement
+/// is unrepresentable rather than rejected.
+///
+/// Executes through `find_by_statement`, not `Select<E>` — see the module docs.
+#[must_use]
+pub struct SecureCteSelect<E: EntityTrait> {
+    /// Outer query, scope `WHERE` already embedded by `scope_with`.
+    outer: SelectStatement,
+    with: WithClause,
+    /// Seeds every CTE body. This is what makes same-scope structural.
+    scope: Arc<AccessScope>,
+    /// Mirrors [`Self::distinct`]. `sea_query` keeps `SelectStatement::distinct`
+    /// private, so the flag cannot be read back off the statement.
+    distinct: bool,
+    /// Set by [`Self::order_by_cte`]: the query orders by a column that is *not*
+    /// in the outer `SELECT` list. Harmless alone, invalid under `DISTINCT`.
+    orders_by_cte: bool,
+    _entity: PhantomData<E>,
+}
+
+/// A recursive CTE that walks a self-referencing hierarchy.
+///
+/// Both the seed and the recursive member carry the outer query's scope: the
+/// recursive member reads the *real table* joined against the CTE self-reference,
+/// so `build_scope_condition` applies to it exactly as it does to the seed. That
+/// is why recursion is admissible here at all.
+///
+/// The hazard recursion does introduce is **cycles**, and it is not optional to
+/// handle: `sea_query` renders `PostgreSQL`'s `CYCLE` clause but silently drops it
+/// on `MySQL` and `SQLite`, so a portable guard cannot rely on it. Hence `max_depth`
+/// has no default — a caller must state a bound, and it is emitted as a predicate
+/// on the recursive member.
+///
+/// # What bounds the walk
+///
+/// Two independent limits, and it is worth knowing which does what.
+///
+/// The **depth cap** guarantees termination. The **dedup mode** decides how much
+/// work happens inside that bound, and the default matters:
+///
+/// - [`RecursiveDedup::Union`] (default) discards rows duplicating ones already
+///   produced. Because the row carries its depth, a node reached at two depths is
+///   still expanded twice — so re-expansion is bounded by *(rows × depth)* rather
+///   than by path count. This is plain standard-SQL `UNION`, not a
+///   `PostgreSQL`-only trick, and it is what keeps a hub-heavy graph flat.
+/// - [`RecursiveDedup::UnionAll`] keeps everything and therefore enumerates
+///   **paths**: where several equal-length paths converge on a node, the row count
+///   multiplies with the branching factor. Faster per row on a sparse
+///   parent-pointer tree, a liability on anything hub-shaped.
+///
+/// Neither mode is a visited set: nothing prevents a node from being *revisited* at
+/// a greater depth, only from being *re-emitted* identically. If you need
+/// strictly-once semantics, dedup on the caller side, or expand one hop per query
+/// with [`SecureCteSelect::cte`] and keep the frontier yourself.
+/// [`SecureCteSelect::distinct`] deduplicates the final rows but does not prune the
+/// walk.
+///
+/// # Shape limit: one self-referencing table
+///
+/// The recursive member is `FROM J JOIN <cte> ON J.link_col = <cte>.anchor_col` —
+/// two tables, so both endpoints of the hop must be columns of the **same** entity
+/// `J`. A walk over an edge table works (`(src_node_id, dst_node_id)` on the edge
+/// entity), and so does a parent-pointer tree (`(parent_id, id)`).
+///
+/// What this cannot express is a hop *through* a separate table — `node -> edge ->
+/// node`, where the recursion carries nodes but the connection lives in an edge
+/// table. That needs a three-way join in the recursive member. Use one scoped query
+/// per hop instead: a query over the edge table for the frontier's endpoints, then
+/// a scoped query over the nodes it produced.
+/// How the recursive member is combined with the already-walked rows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RecursiveDedup {
+    /// `UNION` — discard rows duplicating ones already produced. The default.
+    ///
+    /// Dedup is on the whole projected row, and the row carries the depth, so a
+    /// node reached at two different depths is still expanded twice. Re-expansion
+    /// is therefore bounded by *(rows × depth)* rather than by path count — which
+    /// is what keeps a hub-heavy graph flat. Plain `UNION` in a recursive CTE is
+    /// standard SQL and works on `PostgreSQL`, `MySQL` 8+ and `SQLite`.
+    #[default]
+    Union,
+    /// `UNION ALL` — keep every row the walk produces.
+    ///
+    /// Cheaper per row, because nothing is compared, but it enumerates **paths**:
+    /// on a graph where several paths of equal length converge on a node, the row
+    /// count multiplies with the branching factor. Reasonable for a sparse tree
+    /// where every node has one parent; a liability on anything hub-shaped.
+    UnionAll,
+}
+
+#[must_use]
+pub struct RecursiveCte<J: EntityTrait> {
+    name: &'static str,
+    seed: Condition,
+    link_col: J::Column,
+    anchor_col: J::Column,
+    max_depth: u32,
+    dedup: RecursiveDedup,
+}
+
+impl<J: EntityTrait> RecursiveCte<J> {
+    /// Name of the column carrying distance-from-seed, for ordering or filtering
+    /// the CTE from the outer query.
+    ///
+    /// Exposed so callers do not hardcode the literal; see
+    /// [`SecureCteSelect::order_by_cte`] for the usual use.
+    pub const DEPTH_COLUMN: &'static str = DEPTH_COLUMN;
+
+    /// Describe a recursive walk over `J`.
+    ///
+    /// - `name` — the CTE's name, referenced later via
+    ///   [`SecureCteSelect::join_cte`].
+    /// - `seed` — which rows start the walk, e.g. `Column::Id.eq(root)`. Scope is
+    ///   applied on top of this; it is not a substitute for it.
+    /// - `link_col` — column on the *next* row that points back at a walked row.
+    /// - `anchor_col` — column on the *walked* row that `link_col` refers to.
+    /// - `max_depth` — how many hops past the seed to follow. `0` yields the seed
+    ///   rows only. Mandatory: see the type docs on cycles.
+    ///
+    /// The emitted join is `J.link_col = <cte>.anchor_col`. For a parent-pointer
+    /// tree that is `(parent_id, id)`; for a walk over an edge table it is
+    /// `(src_node_id, dst_node_id)`. The pair is deliberately *not* named
+    /// child/parent — the traversal is directed-edge, not necessarily hierarchical.
+    ///
+    /// Defaults to [`RecursiveDedup::Union`]; override with
+    /// [`dedup`](Self::dedup).
+    pub fn new(
+        name: &'static str,
+        seed: Condition,
+        link_col: J::Column,
+        anchor_col: J::Column,
+        max_depth: u32,
+    ) -> Self {
+        Self {
+            name,
+            seed,
+            link_col,
+            anchor_col,
+            max_depth,
+            dedup: RecursiveDedup::Union,
+        }
+    }
+
+    /// Choose `UNION` or `UNION ALL` for the recursive step.
+    pub fn dedup(mut self, dedup: RecursiveDedup) -> Self {
+        self.dedup = dedup;
+        self
+    }
+}
+
+// `with_ctes` lives on the scoped select: a CTE query is only reachable from an
+// already-scoped query, which is what carries the scope the bodies inherit.
+impl<E> SecureSelect<E, Scoped>
+where
+    E: EntityTrait,
+{
+    /// Begin a query that carries `WITH` definitions.
+    ///
+    /// Every CTE registered on the result is scoped with **this** query's
+    /// `AccessScope`, so a differently-scoped CTE cannot be constructed. The
+    /// returned type executes through its own path; see [`SecureCteSelect`].
+    pub fn with_ctes(self) -> SecureCteSelect<E> {
+        let scope = self.scope_arc();
+        SecureCteSelect {
+            outer: QueryTrait::into_query(self.into_inner()),
+            with: WithClause::new(),
+            scope,
+            distinct: false,
+            orders_by_cte: false,
+            _entity: PhantomData,
+        }
+    }
+}
+
+impl<E> SecureCteSelect<E>
+where
+    E: EntityTrait,
+{
+    /// Register a non-recursive CTE over `J`.
+    ///
+    /// `body` shapes the CTE's `SELECT` — filters, ordering, limits. Scope is
+    /// applied *after* it returns, so a body cannot filter the scope predicate
+    /// back off.
+    ///
+    /// Attaching a definition is not the same as using it: reference the CTE from
+    /// the outer query with [`join_cte`](Self::join_cte).
+    ///
+    /// # What the closure is and is not prevented from doing
+    ///
+    /// Scope for `J` is applied after `body` returns, so a body cannot filter the
+    /// scope predicate back off. It *can*, however, widen the body beyond `J`:
+    /// `sea_orm`'s `QueryTrait::query()` is public, so a caller may reach the
+    /// underlying `SelectStatement` and join a table that gets no scope predicate of
+    /// its own.
+    ///
+    /// That is the crate's existing boundary rather than a property of this method —
+    /// `filter`, [`join_cte`](Self::join_cte) and `SecureSelect::project_all` all
+    /// accept caller-built `sea_query` fragments, and `into_inner()` hands over the
+    /// whole builder. The guarantee is "the entity you queried is always scoped",
+    /// not "no other table can appear". Tables a gear brings in itself are the
+    /// gear's responsibility, and the Level-C lint in ADR-0001 is the intended
+    /// mechanical check.
+    pub fn cte<J>(
+        mut self,
+        name: &'static str,
+        body: impl FnOnce(sea_orm::Select<J>) -> sea_orm::Select<J>,
+    ) -> Self
+    where
+        J: ScopableEntity + EntityTrait,
+        J::Column: ColumnTrait + Copy,
+    {
+        // Routed through `scope_with_arc` rather than calling
+        // `build_scope_condition` directly, so there is exactly one definition of
+        // "apply scope to a select" in the crate.
+        let scoped = body(J::find())
+            .secure()
+            .scope_with_arc(Arc::clone(&self.scope));
+
+        let mut cte = CommonTableExpression::new();
+        cte.table_name(Alias::new(name))
+            .query(QueryTrait::into_query(scoped.into_inner()));
+        self.with.cte(cte);
+        self
+    }
+
+    /// Register a recursive CTE over a self-referencing `J`.
+    ///
+    /// Emits, with `<scope>` present in **both** members and the union operator
+    /// chosen by [`RecursiveDedup`] (`UNION` by default):
+    ///
+    /// ```sql
+    /// WITH RECURSIVE n AS (
+    ///     SELECT j.link_col, j.anchor_col, 0 AS __cte_depth FROM j
+    ///      WHERE <seed> AND <scope>
+    ///     UNION
+    ///     SELECT j.link_col, j.anchor_col, n.__cte_depth + 1 FROM j
+    ///       JOIN n ON j.link_col = n.anchor_col
+    ///      WHERE <scope> AND n.__cte_depth < <max_depth>
+    /// )
+    /// ```
+    ///
+    /// # The body projects three columns, not the whole row
+    ///
+    /// A walk only needs the two link columns and the depth. Selecting every
+    /// column of `J` would be wasted width, and under `UNION` it is worse than
+    /// wasteful: dedup has to compare every selected column, and `PostgreSQL`'s
+    /// `json` type has no equality operator, so a `J` carrying a
+    /// `ColumnType::Json` column would fail with *"could not identify an equality
+    /// operator for type json"* before the traversal ran. (`jsonb` is fine — it has
+    /// equality. Narrowing sidesteps the question entirely.)
+    ///
+    /// Consequences for the caller:
+    ///
+    /// - Reference the CTE on one of those two columns via
+    ///   [`join_cte`](Self::join_cte); the outer query supplies the full rows.
+    /// - [`column_from_cte`](Self::column_from_cte) can read `link_col`,
+    ///   `anchor_col` or [`RecursiveCte::DEPTH_COLUMN`] — no other column of `J` is
+    ///   in the CTE.
+    /// - Dedup under `UNION` is on `(link, anchor, depth)`, which prunes strictly
+    ///   more than dedup on the full row would.
+    pub fn recursive_cte<J>(mut self, spec: RecursiveCte<J>) -> Self
+    where
+        J: ScopableEntity + EntityTrait,
+        J::Column: ColumnTrait + Copy,
+    {
+        let cte_ref = Alias::new(spec.name);
+        let depth = Alias::new(DEPTH_COLUMN);
+
+        // Seed: the caller's starting predicate, AND the scope. Projection is
+        // narrowed to the traversal columns -- see the method docs on why the full
+        // row must not be selected here.
+        let mut seed = QueryTrait::into_query(
+            J::find()
+                .filter(spec.seed)
+                .secure()
+                .scope_with_arc(Arc::clone(&self.scope))
+                .into_inner(),
+        );
+        seed.clear_selects();
+        seed.column((J::default(), spec.link_col))
+            .column((J::default(), spec.anchor_col))
+            .expr_as(Expr::val(0), depth.clone());
+
+        // Recursive member: reads the real table `J` joined to the CTE, so the
+        // same scope condition applies here as to the seed. The depth predicate
+        // is emitted by us, not the caller -- it is the termination guarantee.
+        let mut step = QueryTrait::into_query(
+            J::find()
+                .secure()
+                .scope_with_arc(Arc::clone(&self.scope))
+                .into_inner(),
+        );
+        step.clear_selects();
+        step.column((J::default(), spec.link_col))
+            .column((J::default(), spec.anchor_col))
+            .expr_as(
+                Expr::col((cte_ref.clone(), depth.clone())).add(Expr::val(1)),
+                depth.clone(),
+            )
+            .join(
+                JoinType::InnerJoin,
+                cte_ref.clone(),
+                Expr::col((J::default(), spec.link_col))
+                    .equals((cte_ref.clone(), spec.anchor_col.into_iden())),
+            )
+            .and_where(Expr::col((cte_ref, depth)).lt(spec.max_depth));
+
+        let union = match spec.dedup {
+            RecursiveDedup::Union => UnionType::Distinct,
+            RecursiveDedup::UnionAll => UnionType::All,
+        };
+        seed.union(union, step);
+
+        let mut cte = CommonTableExpression::new();
+        cte.table_name(Alias::new(spec.name)).query(seed);
+        self.with.recursive(true).cte(cte);
+        self
+    }
+
+    /// Join a registered CTE into the outer query.
+    ///
+    /// `with_ctes`/`cte` only *define*; without a reference the `WITH` clause is
+    /// valid SQL that computes nothing. `on` ties the CTE to the outer entity and
+    /// is the caller's responsibility — getting it wrong changes which rows come
+    /// back, but cannot cross a tenant boundary, because the CTE body never held
+    /// another tenant's rows to begin with.
+    ///
+    /// # Avoid `OR` across two columns in `on`
+    ///
+    /// "either endpoint of an edge" is the natural predicate for a graph hop, but
+    /// `node.id = cte.src OR node.id = cte.dst` makes `PostgreSQL` abandon the index
+    /// and sequentially scan the outer table — measured at 15.2 ms against 0.30 ms
+    /// for the equivalent single-column form, same rows, on 199k nodes / 600k edges.
+    ///
+    /// Put the alternation inside the CTE instead, so the outer predicate stays a
+    /// single indexed comparison: have the CTE body project one column that already
+    /// contains both endpoints (a `UNION` of the two projections), then join on
+    /// that.
+    pub fn join_cte(mut self, name: &'static str, on: Condition) -> Self {
+        self.outer.join(JoinType::InnerJoin, Alias::new(name), on);
+        self
+    }
+
+    /// Add a filter to the outer query, on top of its scope.
+    pub fn filter(mut self, filter: Condition) -> Self {
+        self.outer.cond_where(filter);
+        self
+    }
+
+    /// Limit the outer query.
+    pub fn limit(mut self, limit: u64) -> Self {
+        self.outer.limit(limit);
+        self
+    }
+
+    /// `SELECT DISTINCT` on the outer query.
+    ///
+    /// [`join_cte`](Self::join_cte) emits an inner join, so an outer row is
+    /// repeated once per matching CTE row. That is usually not what you want when
+    /// the CTE is a set you are testing membership against — e.g. expanding a
+    /// breadth-first frontier, where several edges converge on the same node.
+    ///
+    /// Cannot be combined with [`order_by_cte`](Self::order_by_cte); see that
+    /// method.
+    ///
+    /// # Requires every selected column to be comparable
+    ///
+    /// `SELECT DISTINCT` compares all selected columns, and by default the outer
+    /// query selects every column of `E`. `PostgreSQL`'s `json` has no equality
+    /// operator, so an entity carrying a `ColumnType::Json` column fails with
+    /// *"could not identify an equality operator for type json"*. (`jsonb` is fine.)
+    /// Narrow the projection with [`select_only`](Self::select_only) first — which
+    /// you want anyway, since dedup over a wide row is wasted work.
+    pub fn distinct(mut self) -> Self {
+        self.outer.distinct();
+        self.distinct = true;
+        self
+    }
+
+    /// Order by a column of the outer entity `E`.
+    ///
+    /// The column is qualified with `E`'s table, so it stays unambiguous after a
+    /// [`join_cte`](Self::join_cte) whose CTE happens to expose a column of the
+    /// same name. Entity columns are always in the outer `SELECT` list, so this is
+    /// safe to combine with [`distinct`](Self::distinct).
+    pub fn order_by(mut self, col: E::Column, order: Order) -> Self {
+        self.outer.order_by((E::default(), col), order);
+        self
+    }
+
+    /// Order by a column of a registered CTE — e.g. a recursive walk's depth.
+    ///
+    /// ```rust,ignore
+    /// // Shallowest hop first.
+    /// .order_by_cte("subtree", RecursiveCte::<E>::DEPTH_COLUMN, Order::Asc)
+    /// ```
+    ///
+    /// # Not combinable with `distinct()`
+    ///
+    /// A CTE column is not in the outer `SELECT` list, and both `PostgreSQL` and
+    /// `MySQL` reject `ORDER BY` on an expression missing from a `SELECT DISTINCT`
+    /// list (`SQLite` accepts it, which is worse — it means the mistake only
+    /// surfaces in production). Combining the two therefore returns
+    /// [`ScopeError::Invalid`] from `all`/`one`/`all_as` on **every** backend
+    /// rather than emitting SQL that some engines refuse.
+    ///
+    /// "Distinct rows, shallowest first" needs
+    /// `GROUP BY <entity cols> ORDER BY MIN(depth)`, which this API cannot express
+    /// yet — dedup on the caller side for now.
+    pub fn order_by_cte(mut self, cte: &'static str, col: &'static str, order: Order) -> Self {
+        self.outer
+            .order_by((Alias::new(cte), Alias::new(col)), order);
+        self.orders_by_cte = true;
+        self
+    }
+
+    /// Drop the default `SELECT` list, so only columns added afterwards are
+    /// selected.
+    ///
+    /// `with_ctes()` inherits `Select<E>`'s projection, which is *every* column of
+    /// `E`. For a query that only needs a key — a breadth-first hop returning ids,
+    /// say — that means transferring every wide column too, and on `PostgreSQL` it
+    /// turns an index-only scan into a heap visit per row.
+    ///
+    /// [`all_as`](Self::all_as) alone does **not** narrow this: it changes how rows
+    /// are *deserialized*, not what the server is asked for.
+    ///
+    /// # Pairs with `all_as`, not `all`
+    ///
+    /// [`all`](Self::all) and [`one`](Self::one) deserialize into `E::Model`, which
+    /// needs every column of `E` present. Narrow the list and they will fail at
+    /// deserialization — use `all_as::<T>()` with a `T` matching the columns you
+    /// selected.
+    ///
+    /// ```rust,ignore
+    /// #[derive(FromQueryResult)]
+    /// struct Hop { id: Uuid }
+    ///
+    /// let ids = node::Entity::find().secure().scope_with(&scope)
+    ///     .with_ctes()
+    ///     .cte::<edge::Entity>("hop", |q| q)
+    ///     .join_cte("hop", on)
+    ///     .select_only()
+    ///     .column(node::Column::Id)
+    ///     .all_as::<Hop>(runner)
+    ///     .await?;
+    /// ```
+    pub fn select_only(mut self) -> Self {
+        self.outer.clear_selects();
+        self
+    }
+
+    /// Add a column of the outer entity `E` to the `SELECT` list, qualified with
+    /// `E`'s table so it stays unambiguous after a [`join_cte`](Self::join_cte).
+    pub fn column(mut self, col: E::Column) -> Self {
+        self.outer.column((E::default(), col));
+        self
+    }
+
+    /// Add a column of a registered CTE to the `SELECT` list, under `alias`.
+    ///
+    /// Aliasing is required rather than optional: a CTE built from an entity
+    /// exposes that entity's column names, so an unaliased CTE column would
+    /// collide with the outer entity's own column of the same name.
+    pub fn column_from_cte(
+        mut self,
+        cte: &'static str,
+        col: &'static str,
+        alias: &'static str,
+    ) -> Self {
+        self.outer.expr_as(
+            Expr::col((Alias::new(cte), Alias::new(col))),
+            Alias::new(alias),
+        );
+        self
+    }
+
+    /// Add an arbitrary expression to the `SELECT` list under `alias` — an
+    /// aggregate, a window function, a computed value.
+    ///
+    /// Scope is unaffected: the `WHERE` built by `scope_with` is independent of the
+    /// projection, so narrowing or extending the select list cannot widen access.
+    pub fn expr_as(mut self, expr: Expr, alias: &'static str) -> Self {
+        self.outer.expr_as(expr, Alias::new(alias));
+        self
+    }
+
+    /// Reject query shapes that are not portable across backends.
+    ///
+    /// Checked at execution rather than in the builder because the builder methods
+    /// return `Self`, and the conflict only exists once both halves are present.
+    ///
+    /// Reuses `ScopeError::Invalid` — whose `Display` prefix reads "invalid scope",
+    /// slightly off for a query-shape error — because `ScopeError` is a public enum
+    /// without `#[non_exhaustive]`, so adding a variant would break downstream
+    /// exhaustive matches.
+    pub(crate) fn validate(&self) -> Result<(), ScopeError> {
+        if self.distinct && self.orders_by_cte {
+            return Err(ScopeError::Invalid(
+                "SELECT DISTINCT cannot ORDER BY a CTE column that is not in the \
+                 select list; drop distinct() or order by an entity column",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Render the statement for `backend` without executing it.
+    ///
+    /// Exists because this crate has no mock database: it is the only way for a
+    /// test to assert on the emitted SQL, including that the `WITH` clause is
+    /// present at all. Crate-private — `sea_orm::Statement` and `DbBackend` must
+    /// not appear in this crate's public surface (see the [`runner`] module docs).
+    ///
+    /// Clones, so it is not on the execution path; that uses
+    /// [`into_statement`](Self::into_statement).
+    ///
+    /// [`runner`]: crate::secure
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn build_statement(&self, backend: sea_orm::DbBackend) -> sea_orm::Statement {
+        let query = self.outer.clone().with(self.with.clone());
+        StatementBuilder::build(&query, &backend)
+    }
+
+    /// Same as [`build_statement`](Self::build_statement) but consumes `self`,
+    /// avoiding a clone of the outer statement and the whole `WithClause` on every
+    /// executed query.
+    fn into_statement(self, backend: sea_orm::DbBackend) -> sea_orm::Statement {
+        let query = self.outer.with(self.with);
+        StatementBuilder::build(&query, &backend)
+    }
+
+    /// Execute and return all matching rows of `E`.
+    ///
+    /// # Errors
+    /// Returns `ScopeError::Db` if the query fails, or `ScopeError::Invalid` if
+    /// `distinct()` was combined with `order_by_cte()`.
+    pub async fn all(self, runner: &impl DBRunner) -> Result<Vec<E::Model>, ScopeError>
+    where
+        E::Model: Send + Sync,
+    {
+        self.all_as::<E::Model>(runner).await
+    }
+
+    /// Execute and return at most one row of `E`.
+    ///
+    /// # Errors
+    /// Returns `ScopeError::Db` if the query fails, or `ScopeError::Invalid` if
+    /// `distinct()` was combined with `order_by_cte()`.
+    pub async fn one(self, runner: &impl DBRunner) -> Result<Option<E::Model>, ScopeError> {
+        self.validate()?;
+        let exec = DBRunnerInternal::as_seaorm(runner);
+        let stmt = self.into_statement(exec.backend());
+        Ok(match exec {
+            crate::secure::SeaOrmRunner::Conn(db) => {
+                E::Model::find_by_statement(stmt).one(db).await?
+            }
+            crate::secure::SeaOrmRunner::Tx(tx) => {
+                E::Model::find_by_statement(stmt).one(tx).await?
+            }
+        })
+    }
+
+    /// Execute and deserialize into a custom row type `T`.
+    ///
+    /// This controls **deserialization only** — it does not narrow the SQL. By
+    /// default the outer query still selects every column of `E`, so a `T` with two
+    /// fields still transfers the whole row. To narrow what the server is asked
+    /// for, combine with [`select_only`](Self::select_only) and
+    /// [`column`](Self::column) / [`expr_as`](Self::expr_as).
+    ///
+    /// # Errors
+    /// Returns `ScopeError::Db` if the query fails, or `ScopeError::Invalid` if
+    /// `distinct()` was combined with `order_by_cte()`.
+    pub async fn all_as<T>(self, runner: &impl DBRunner) -> Result<Vec<T>, ScopeError>
+    where
+        T: FromQueryResult + Send + Sync,
+    {
+        self.validate()?;
+        let exec = DBRunnerInternal::as_seaorm(runner);
+        let stmt = self.into_statement(exec.backend());
+        Ok(match exec {
+            crate::secure::SeaOrmRunner::Conn(db) => T::find_by_statement(stmt).all(db).await?,
+            crate::secure::SeaOrmRunner::Tx(tx) => T::find_by_statement(stmt).all(tx).await?,
+        })
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "cte_tests.rs"]
+mod tests;

--- a/libs/toolkit-db/src/secure/cte_tests.rs
+++ b/libs/toolkit-db/src/secure/cte_tests.rs
@@ -1,0 +1,958 @@
+//! Tests for CTE support in the Secure ORM.
+//!
+//! These assert on the **rendered SQL, per backend**, rather than on the `Debug`
+//! form of a `sea_orm::Condition` (the style used in `cond.rs`). The isolation
+//! claim in ADR-0001 is about what reaches the database, so that is what gets
+//! asserted; a `Condition` that never makes it into the emitted statement would
+//! satisfy a Debug-string check and still leak.
+
+use super::*;
+use sea_orm::DbBackend;
+
+/// Every backend the Secure ORM renders for.
+const BACKENDS: [DbBackend; 3] = [DbBackend::Postgres, DbBackend::MySql, DbBackend::Sqlite];
+
+/// A tenant-scoped entity with a self-referencing `parent_id`, so the same
+/// fixture serves both the flat and the recursive tests.
+mod node {
+    use sea_orm::entity::prelude::*;
+    use toolkit_security::access_scope::pep_properties;
+
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "cte_node")]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: Uuid,
+        pub tenant_id: Uuid,
+        pub parent_id: Option<Uuid>,
+        pub name: String,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+
+    impl crate::secure::ScopableEntity for Entity {
+        fn tenant_col() -> Option<Column> {
+            Some(Column::TenantId)
+        }
+        fn resource_col() -> Option<Column> {
+            Some(Column::Id)
+        }
+        fn owner_col() -> Option<Column> {
+            None
+        }
+        fn type_col() -> Option<Column> {
+            None
+        }
+        fn resolve_property(property: &str) -> Option<Column> {
+            match property {
+                p if p == pep_properties::OWNER_TENANT_ID => Some(Column::TenantId),
+                p if p == pep_properties::RESOURCE_ID => Some(Column::Id),
+                _ => None,
+            }
+        }
+    }
+}
+
+/// A second scoped entity, for asserting that *every* CTE body is scoped rather
+/// than just the first.
+mod item {
+    use sea_orm::entity::prelude::*;
+    use toolkit_security::access_scope::pep_properties;
+
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "cte_item")]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: Uuid,
+        pub tenant_id: Uuid,
+        pub node_id: Uuid,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+
+    impl crate::secure::ScopableEntity for Entity {
+        fn tenant_col() -> Option<Column> {
+            Some(Column::TenantId)
+        }
+        fn resource_col() -> Option<Column> {
+            Some(Column::Id)
+        }
+        fn owner_col() -> Option<Column> {
+            None
+        }
+        fn type_col() -> Option<Column> {
+            None
+        }
+        fn resolve_property(property: &str) -> Option<Column> {
+            match property {
+                p if p == pep_properties::OWNER_TENANT_ID => Some(Column::TenantId),
+                p if p == pep_properties::RESOURCE_ID => Some(Column::Id),
+                _ => None,
+            }
+        }
+    }
+}
+
+fn tenant_scope(tenant: uuid::Uuid) -> AccessScope {
+    AccessScope::for_tenants(vec![tenant])
+}
+
+/// A scoped select over `node`, the starting point for every test below.
+fn scoped_nodes(scope: &AccessScope) -> SecureSelect<node::Entity, Scoped> {
+    node::Entity::find().secure().scope_with(scope)
+}
+
+/// The text between `AS (` and its *matching* `)`, i.e. one CTE body alone.
+///
+/// Naive `split_once("AS (")` keeps the trailing outer query in the tail, so any
+/// assertion about "the body" would silently also see the outer query's
+/// predicates -- which makes a missing predicate inside the CTE invisible.
+fn cte_body(sql: &str) -> &str {
+    let open = sql.find("AS (").expect("no CTE in statement") + "AS (".len();
+    let mut depth = 1usize;
+    for (offset, ch) in sql[open..].char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &sql[open..open + offset];
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("unbalanced parentheses in {sql}")
+}
+
+/// Occurrences of a scope predicate. Deliberately matches `tenant_id IN (` and
+/// not bare `tenant_id`: the column also appears in every SELECT list, so a
+/// substring check on the name alone passes even against an unscoped query.
+fn scope_predicates(fragment: &str) -> usize {
+    fragment.matches("tenant_id\" IN (").count() + fragment.matches("tenant_id` IN (").count()
+}
+
+#[test]
+fn cte_body_embeds_scope_condition_on_every_backend() {
+    // The load-bearing invariant of ADR-0001: the CTE body carries its own scope
+    // predicate, because the outer WHERE cannot reach inside WITH.
+    let tenant = uuid::Uuid::new_v4();
+    let scope = tenant_scope(tenant);
+
+    for backend in BACKENDS {
+        let stmt = scoped_nodes(&scope)
+            .with_ctes()
+            .cte::<item::Entity>("scoped_items", |q| q)
+            .build_statement(backend);
+        let sql = stmt.to_string();
+
+        assert_eq!(
+            scope_predicates(cte_body(&sql)),
+            1,
+            "{backend:?} CTE body has no tenant predicate: {sql}"
+        );
+        assert!(
+            sql.contains(&tenant.to_string()),
+            "{backend:?} did not bind the tenant id: {sql}"
+        );
+    }
+}
+
+#[test]
+fn with_ctes_emits_with_clause_on_every_backend() {
+    // Regression guard named in the ADR: if this type ever fell back to the plain
+    // `Select<E>` path, the WITH clause would silently disappear and the query
+    // would still run -- just against unfiltered tables.
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+
+    for backend in BACKENDS {
+        let sql = scoped_nodes(&scope)
+            .with_ctes()
+            .cte::<item::Entity>("scoped_items", |q| q)
+            .build_statement(backend)
+            .to_string();
+        assert!(
+            sql.trim_start().starts_with("WITH "),
+            "{backend:?} dropped the WITH clause: {sql}"
+        );
+    }
+}
+
+#[test]
+fn every_cte_body_is_scoped_not_just_the_first() {
+    let tenant = uuid::Uuid::new_v4();
+    let scope = tenant_scope(tenant);
+
+    for backend in BACKENDS {
+        let sql = scoped_nodes(&scope)
+            .with_ctes()
+            .cte::<item::Entity>("a", |q| q)
+            .cte::<node::Entity>("b", |q| q)
+            .build_statement(backend)
+            .to_string();
+
+        assert!(sql.contains("cte_item"), "{backend:?}: {sql}");
+        assert!(sql.contains("cte_node"), "{backend:?}: {sql}");
+        // Exactly three scope predicates: one per CTE body, one for the outer
+        // query. Counted on the `IN (` form, so SELECT-list mentions of the
+        // column do not inflate it -- otherwise dropping a body's scope entirely
+        // would still leave the count above any `>=` threshold.
+        assert_eq!(
+            scope_predicates(&sql),
+            3,
+            "{backend:?} expected a tenant predicate per body plus the outer query: {sql}"
+        );
+    }
+}
+
+#[test]
+fn cte_body_with_deny_all_scope_denies() {
+    // Error path: a deny-all scope must produce a body that selects nothing,
+    // rather than an unfiltered body.
+    let scope = AccessScope::default();
+    assert!(scope.is_deny_all(), "precondition");
+
+    for backend in BACKENDS {
+        let sql = scoped_nodes(&scope)
+            .with_ctes()
+            .cte::<item::Entity>("scoped_items", |q| q)
+            .build_statement(backend)
+            .to_string();
+        let body = cte_body(&sql);
+        assert!(
+            body.contains("FALSE") || body.contains("0 = 1") || body.contains("false"),
+            "{backend:?} deny-all body is not a deny: {sql}"
+        );
+    }
+}
+
+#[test]
+fn cte_body_with_unconstrained_scope_carries_no_tenant_predicate() {
+    // Negative space, and it pins allow-all semantics. `build_scope_condition`
+    // returns an empty `Condition::all()` for an unconstrained scope, which
+    // sea_query renders as a literal `WHERE TRUE` -- not as an absent WHERE. So
+    // the assertion is about the *predicate*, not the keyword: allow-all must
+    // not filter, and must not accidentally deny either.
+    let scope = AccessScope::allow_all();
+
+    for backend in BACKENDS {
+        let sql = scoped_nodes(&scope)
+            .with_ctes()
+            .cte::<item::Entity>("scoped_items", |q| q)
+            .build_statement(backend)
+            .to_string();
+        let body = cte_body(&sql);
+
+        assert_eq!(
+            scope_predicates(body),
+            0,
+            "{backend:?} allow-all body should not filter by tenant: {sql}"
+        );
+        assert!(
+            !body.contains("FALSE"),
+            "{backend:?} allow-all must not deny: {sql}"
+        );
+    }
+}
+
+#[test]
+fn cte_name_with_sql_metacharacters_renders_as_one_quoted_identifier() {
+    // The ADR claims a hostile CTE name cannot inject SQL because sea_query
+    // renders it as a quoted, escaped identifier. In sea-query 1.0.2 that holds
+    // via `is_static_iden`: anything outside [A-Za-z_][A-Za-z0-9_]* falls to the
+    // owned branch of `prepare_iden`, which doubles the quote char.
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+    let hostile = r#"foo"; DROP TABLE x --"#;
+
+    for backend in BACKENDS {
+        let sql = scoped_nodes(&scope)
+            .with_ctes()
+            .cte::<item::Entity>(hostile, |q| q)
+            .build_statement(backend)
+            .to_string();
+
+        let expected = match backend {
+            // `"` doubled, so the embedded quote cannot terminate the identifier.
+            DbBackend::Postgres | DbBackend::Sqlite => r#""foo""; DROP TABLE x --""#,
+            // MySQL quotes with backticks, so a `"` in the payload is ordinary.
+            DbBackend::MySql => "`foo\"; DROP TABLE x --`",
+            // `DbBackend` is #[non_exhaustive]; BACKENDS holds only the three above.
+            _ => unreachable!("unexpected backend {backend:?}"),
+        };
+
+        // Structural, not just "contains": the name must occupy exactly the
+        // identifier slot of a single CTE definition. If the payload had broken
+        // out of its quoting, the prefix would not line up and `AS (` would land
+        // somewhere else.
+        assert_eq!(
+            sql.matches(" AS (").count(),
+            1,
+            "{backend:?} name escaped its identifier slot: {sql}"
+        );
+        assert!(
+            sql.starts_with(&format!("WITH {expected} AS (")),
+            "{backend:?} expected the name as one quoted identifier {expected}, got: {sql}"
+        );
+    }
+}
+
+#[test]
+fn cte_name_with_backtick_is_escaped_for_mysql() {
+    // Companion to the test above: the doubling rule is per-backend, so the
+    // MySQL quote char needs its own payload to be meaningful.
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+    let sql = scoped_nodes(&scope)
+        .with_ctes()
+        .cte::<item::Entity>("ev`il", |q| q)
+        .build_statement(DbBackend::MySql)
+        .to_string();
+
+    assert!(sql.contains("`ev``il`"), "backtick not doubled: {sql}");
+}
+
+#[test]
+fn join_cte_references_the_cte_by_quoted_name() {
+    // `with_ctes` only defines; without this the WITH clause computes nothing.
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+
+    for backend in BACKENDS {
+        let sql = scoped_nodes(&scope)
+            .with_ctes()
+            .cte::<item::Entity>("scoped_items", |q| q)
+            .join_cte(
+                "scoped_items",
+                Condition::all().add(
+                    Expr::col((Alias::new("scoped_items"), Alias::new("node_id")))
+                        .equals((node::Entity, node::Column::Id)),
+                ),
+            )
+            .build_statement(backend)
+            .to_string();
+
+        assert!(
+            sql.contains("JOIN"),
+            "{backend:?} did not reference the CTE: {sql}"
+        );
+        assert!(
+            sql.matches("scoped_items").count() >= 2,
+            "{backend:?} CTE should appear as definition and as source: {sql}"
+        );
+    }
+}
+
+#[test]
+fn build_statement_binds_scope_values_instead_of_interpolating_them() {
+    // Guards against a regression to string interpolation. The tenant UUID must
+    // travel as a bound parameter, not spliced into the SQL text.
+    let tenant = uuid::Uuid::new_v4();
+    let scope = tenant_scope(tenant);
+
+    for backend in BACKENDS {
+        let stmt = scoped_nodes(&scope)
+            .with_ctes()
+            .cte::<item::Entity>("scoped_items", |q| q)
+            .build_statement(backend);
+
+        let values = stmt.values.as_ref().expect("bound values");
+        assert!(!values.0.is_empty(), "{backend:?} bound nothing");
+        assert!(
+            !stmt.sql.contains(&tenant.to_string()),
+            "{backend:?} interpolated the tenant id into SQL: {}",
+            stmt.sql
+        );
+    }
+}
+
+#[test]
+fn cte_body_filter_is_anded_with_scope_not_replacing_it() {
+    // A caller-supplied body filter must not be able to displace the scope
+    // predicate; both have to survive.
+    let tenant = uuid::Uuid::new_v4();
+    let scope = tenant_scope(tenant);
+
+    for backend in BACKENDS {
+        let sql = scoped_nodes(&scope)
+            .with_ctes()
+            .cte::<node::Entity>("named", |q| {
+                q.filter(node::Column::Name.eq("keep-me".to_owned()))
+            })
+            .build_statement(backend)
+            .to_string();
+
+        let body = cte_body(&sql);
+        assert!(body.contains("name"), "{backend:?} lost body filter: {sql}");
+        assert_eq!(
+            scope_predicates(body),
+            1,
+            "{backend:?} body filter displaced the scope: {sql}"
+        );
+    }
+}
+
+#[test]
+fn outer_filter_is_anded_with_the_outer_scope_not_replacing_it() {
+    // `SecureCteSelect::filter` writes to a `sea_query::SelectStatement` that
+    // already carries the scope `WHERE` from `scope_with`. sea_query's
+    // `cond_where` merges into the existing `Condition::all()` rather than
+    // overwriting it, but that is a property of a dependency, so pin it: a
+    // regression here would silently drop the outer query's scope.
+    let tenant = uuid::Uuid::new_v4();
+    let scope = tenant_scope(tenant);
+    let target = uuid::Uuid::new_v4();
+
+    for backend in BACKENDS {
+        let stmt = scoped_nodes(&scope)
+            .with_ctes()
+            .cte::<item::Entity>("scoped_items", |q| q)
+            .filter(Condition::all().add(node::Column::Id.eq(target)))
+            .build_statement(backend);
+        let sql = stmt.to_string();
+
+        // One predicate in the CTE body, one in the outer query -- the caller's
+        // filter must not have displaced either.
+        assert_eq!(
+            scope_predicates(&sql),
+            2,
+            "{backend:?} outer filter displaced a scope predicate: {sql}"
+        );
+        assert!(
+            sql.contains(&target.to_string()),
+            "{backend:?} lost the caller's outer filter: {sql}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Recursive CTEs
+// ---------------------------------------------------------------------------
+
+fn recursive_sql(backend: DbBackend, max_depth: u32) -> String {
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+    let root = uuid::Uuid::new_v4();
+    scoped_nodes(&scope)
+        .with_ctes()
+        .recursive_cte(RecursiveCte::<node::Entity>::new(
+            "subtree",
+            Condition::all().add(node::Column::Id.eq(root)),
+            node::Column::ParentId,
+            node::Column::Id,
+            max_depth,
+        ))
+        .build_statement(backend)
+        .to_string()
+}
+
+#[test]
+fn recursive_cte_emits_with_recursive_on_every_backend() {
+    for backend in BACKENDS {
+        let sql = recursive_sql(backend, 10);
+        assert!(
+            sql.trim_start().starts_with("WITH RECURSIVE "),
+            "{backend:?}: {sql}"
+        );
+    }
+}
+
+#[test]
+fn recursive_cte_scopes_both_seed_and_recursive_member() {
+    // The whole reason recursion is admissible under ADR-0001: the recursive
+    // member reads the real table, so the scope predicate applies there too. A
+    // scope on the seed alone would let the walk escape the tenant after one hop.
+    //
+    for backend in BACKENDS {
+        let sql = recursive_sql(backend, 10);
+        let body = cte_body(&sql);
+        let (seed, step) = body
+            .split_once("UNION")
+            .unwrap_or_else(|| panic!("{backend:?} has no recursive member: {sql}"));
+
+        assert_eq!(
+            scope_predicates(seed),
+            1,
+            "{backend:?} seed should carry exactly one tenant predicate: {sql}"
+        );
+        assert_eq!(
+            scope_predicates(step),
+            1,
+            "{backend:?} recursive member is unscoped -- the walk can leave the tenant: {sql}"
+        );
+    }
+}
+
+#[test]
+fn recursive_cte_emits_the_mandatory_depth_cap() {
+    // sea_query renders PostgreSQL's CYCLE clause but drops it on MySQL/SQLite,
+    // so the depth predicate is the only portable termination guarantee. It is
+    // emitted by the library, never optional.
+    for backend in BACKENDS {
+        let sql = recursive_sql(backend, 7);
+        let (_, step) = cte_body(&sql)
+            .split_once("UNION")
+            .expect("recursive member");
+        assert!(
+            step.contains("__cte_depth"),
+            "{backend:?} recursive member has no depth guard: {sql}"
+        );
+    }
+}
+
+#[test]
+fn recursive_cte_depth_cap_reflects_the_requested_bound() {
+    // Distinguishes "a cap is emitted" from "the caller's cap is emitted".
+    //
+    // Comparing two rendered statements would NOT do this: `recursive_sql` mints a
+    // fresh tenant and root UUID per call and `to_string()` inlines them, so the
+    // strings differ no matter what `max_depth` does. Assert the bound itself.
+    for backend in BACKENDS {
+        for cap in [0_u32, 3, 90] {
+            let sql = recursive_sql(backend, cap);
+            let (_, step) = cte_body(&sql)
+                .split_once("UNION")
+                .expect("recursive member");
+            let predicate = format!("__cte_depth\" < {cap}");
+            let predicate_mysql = format!("__cte_depth` < {cap}");
+            assert!(
+                step.contains(&predicate) || step.contains(&predicate_mysql),
+                "{backend:?} did not emit the requested bound {cap}: {step}"
+            );
+        }
+    }
+}
+
+#[test]
+fn recursive_cte_seed_starts_at_depth_zero() {
+    for backend in BACKENDS {
+        let sql = recursive_sql(backend, 10);
+        let (seed, _) = cte_body(&sql)
+            .split_once("UNION")
+            .expect("recursive member");
+        assert!(
+            seed.contains("__cte_depth"),
+            "{backend:?} seed does not establish the depth column: {sql}"
+        );
+    }
+}
+
+#[test]
+fn filter_and_limit_applied_before_with_ctes_survive_into_the_statement() {
+    // `with_ctes()` converts the `Select<E>` into a `sea_query::SelectStatement`
+    // via `into_query()`. Anything accumulated on the select beforehand -- extra
+    // filters, limits -- has to come through that conversion; silently dropping a
+    // caller's LIMIT would widen the result set.
+    let tenant = uuid::Uuid::new_v4();
+    let scope = tenant_scope(tenant);
+
+    for backend in BACKENDS {
+        let sql = node::Entity::find()
+            .secure()
+            .scope_with(&scope)
+            .filter(Condition::all().add(node::Column::Name.eq("pre".to_owned())))
+            .limit(7)
+            .with_ctes()
+            .cte::<item::Entity>("scoped_items", |q| q)
+            .build_statement(backend)
+            .to_string();
+
+        assert!(
+            sql.contains("'pre'"),
+            "{backend:?} dropped a filter applied before with_ctes(): {sql}"
+        );
+        assert!(
+            sql.contains("LIMIT 7"),
+            "{backend:?} dropped a limit applied before with_ctes(): {sql}"
+        );
+        // And the scope predicate is still there alongside it.
+        assert_eq!(
+            scope_predicates(&sql),
+            2,
+            "{backend:?} pre-conversion state displaced a scope predicate: {sql}"
+        );
+    }
+}
+
+#[test]
+fn join_cte_accepts_a_compound_on_condition() {
+    // A CTE reference often needs more than an equality on the key -- e.g. a BFS
+    // hop also constrains the CTE's source column to the current frontier. Pins
+    // that `join_cte` takes a full `Condition`, not just a key match.
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+    let frontier = uuid::Uuid::new_v4();
+
+    let sql = scoped_nodes(&scope)
+        .with_ctes()
+        .cte::<item::Entity>("scoped_items", |q| q)
+        .join_cte(
+            "scoped_items",
+            Condition::all()
+                .add(
+                    Expr::col((Alias::new("scoped_items"), Alias::new("node_id")))
+                        .equals((node::Entity, node::Column::Id)),
+                )
+                .add(Expr::col((Alias::new("scoped_items"), Alias::new("id"))).eq(frontier)),
+        )
+        .build_statement(DbBackend::Postgres)
+        .to_string();
+
+    assert!(sql.contains("INNER JOIN \"scoped_items\" ON"), "{sql}");
+    assert!(
+        sql.contains(&frontier.to_string()),
+        "second ON predicate lost: {sql}"
+    );
+}
+
+#[test]
+fn distinct_is_emitted_on_the_outer_query() {
+    // `join_cte` is an inner join, so an outer row repeats per matching CTE row.
+    // `distinct()` is how a caller collapses that -- e.g. a BFS frontier where
+    // several edges land on the same node.
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+
+    for backend in BACKENDS {
+        let sql = scoped_nodes(&scope)
+            .with_ctes()
+            .cte::<item::Entity>("scoped_items", |q| q)
+            .join_cte("scoped_items", join_on_node_id())
+            .distinct()
+            .build_statement(backend)
+            .to_string();
+
+        assert!(
+            sql.contains("SELECT DISTINCT"),
+            "{backend:?} did not emit DISTINCT: {sql}"
+        );
+        // Only the outer query is affected; the CTE body keeps its own shape.
+        assert_eq!(
+            sql.matches("SELECT DISTINCT").count(),
+            1,
+            "{backend:?} DISTINCT leaked into the CTE body: {sql}"
+        );
+    }
+}
+
+fn subtree_cte(root: uuid::Uuid) -> RecursiveCte<node::Entity> {
+    RecursiveCte::new(
+        "subtree",
+        Condition::all().add(node::Column::Id.eq(root)),
+        node::Column::ParentId,
+        node::Column::Id,
+        5,
+    )
+}
+
+#[test]
+fn order_by_cte_targets_the_cte_depth_column() {
+    // Ordering a recursive walk shallowest-first needs the CTE's own depth
+    // column, which is why `DEPTH_COLUMN` is public.
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+    let root = uuid::Uuid::new_v4();
+
+    for backend in BACKENDS {
+        let sql = scoped_nodes(&scope)
+            .with_ctes()
+            .recursive_cte(subtree_cte(root))
+            .join_cte("subtree", join_on_subtree_id())
+            .order_by_cte(
+                "subtree",
+                RecursiveCte::<node::Entity>::DEPTH_COLUMN,
+                Order::Asc,
+            )
+            .build_statement(backend)
+            .to_string();
+
+        let (_, tail) = sql.split_once("ORDER BY").unwrap_or_else(|| {
+            panic!("{backend:?} did not emit ORDER BY: {sql}");
+        });
+        assert!(
+            tail.contains("__cte_depth"),
+            "{backend:?} ordered by the wrong column: {sql}"
+        );
+    }
+}
+
+#[test]
+fn order_by_qualifies_the_entity_column_with_its_table() {
+    // Unqualified `ORDER BY "id"` would be ambiguous after joining a CTE that
+    // also exposes `id` -- which the recursive CTE does, since it selects all of
+    // the entity's columns.
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+    let root = uuid::Uuid::new_v4();
+
+    for backend in BACKENDS {
+        let sql = scoped_nodes(&scope)
+            .with_ctes()
+            .recursive_cte(subtree_cte(root))
+            .join_cte("subtree", join_on_subtree_id())
+            .order_by(node::Column::Id, Order::Desc)
+            .build_statement(backend)
+            .to_string();
+
+        let (_, tail) = sql.split_once("ORDER BY").expect("ORDER BY");
+        let qualified = tail.contains("\"cte_node\".\"id\"") || tail.contains("`cte_node`.`id`");
+        assert!(
+            qualified,
+            "{backend:?} emitted an unqualified ORDER BY column: {sql}"
+        );
+    }
+}
+
+#[test]
+fn distinct_with_order_by_entity_column_is_allowed() {
+    // The valid half of the pairing: an entity column IS in the outer SELECT
+    // list, so DISTINCT + ORDER BY on it is portable. A blanket rejection of
+    // distinct-plus-any-order-by would have wrongly blocked this.
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+
+    let query = scoped_nodes(&scope)
+        .with_ctes()
+        .cte::<item::Entity>("scoped_items", |q| q)
+        .join_cte("scoped_items", join_on_node_id())
+        .distinct()
+        .order_by(node::Column::Id, Order::Asc);
+
+    assert!(
+        query.validate().is_ok(),
+        "distinct + entity-column ordering must be permitted"
+    );
+}
+
+#[test]
+fn distinct_with_order_by_cte_is_rejected() {
+    // PostgreSQL and MySQL both refuse ORDER BY on an expression absent from a
+    // SELECT DISTINCT list; SQLite accepts it. Rejecting in the library makes the
+    // failure identical everywhere instead of surfacing only in production.
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+    let root = uuid::Uuid::new_v4();
+
+    let query = scoped_nodes(&scope)
+        .with_ctes()
+        .recursive_cte(subtree_cte(root))
+        .join_cte("subtree", join_on_subtree_id())
+        .distinct()
+        .order_by_cte(
+            "subtree",
+            RecursiveCte::<node::Entity>::DEPTH_COLUMN,
+            Order::Asc,
+        );
+
+    let Err(err) = query.validate() else {
+        panic!("distinct + order_by_cte must be rejected")
+    };
+    assert!(
+        matches!(err, ScopeError::Invalid(msg) if msg.contains("DISTINCT")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[test]
+fn order_by_cte_alone_is_allowed() {
+    // Ordering by a CTE column is only a problem under DISTINCT. On its own it is
+    // valid on all three backends, so it must not be rejected.
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+    let root = uuid::Uuid::new_v4();
+
+    let query = scoped_nodes(&scope)
+        .with_ctes()
+        .recursive_cte(subtree_cte(root))
+        .join_cte("subtree", join_on_subtree_id())
+        .order_by_cte(
+            "subtree",
+            RecursiveCte::<node::Entity>::DEPTH_COLUMN,
+            Order::Asc,
+        );
+
+    assert!(query.validate().is_ok(), "ordering alone must be permitted");
+}
+
+/// `ON scoped_items.node_id = cte_node.id`
+fn join_on_node_id() -> Condition {
+    Condition::all().add(
+        Expr::col((Alias::new("scoped_items"), Alias::new("node_id")))
+            .equals((node::Entity, node::Column::Id)),
+    )
+}
+
+/// `ON subtree.id = cte_node.id`
+fn join_on_subtree_id() -> Condition {
+    Condition::all().add(
+        Expr::col((Alias::new("subtree"), Alias::new("id")))
+            .equals((node::Entity, node::Column::Id)),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Projection on the outer query
+// ---------------------------------------------------------------------------
+
+#[test]
+fn select_only_narrows_the_outer_select_list() {
+    // Raised in review: the outer query inherits `Select<E>`'s projection, which is
+    // every column of E, so a hop needing only ids still transferred the wide
+    // columns -- an index-only scan degraded into a heap visit per row.
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+
+    for backend in BACKENDS {
+        let sql = scoped_nodes(&scope)
+            .with_ctes()
+            .cte::<item::Entity>("x", |q| q)
+            .join_cte("x", join_on_node_id())
+            .select_only()
+            .column(node::Column::Id)
+            .build_statement(backend)
+            .to_string();
+
+        // Mandatory, not a fallback: defaulting to the whole statement would make
+        // the assertion below inspect the CTE body too, degrading the test into a
+        // pass instead of failing when the rendering changes.
+        let (head, _) = sql
+            .split_once(" FROM \"cte_node\"")
+            .or_else(|| sql.split_once(" FROM `cte_node`"))
+            .unwrap_or_else(|| panic!("{backend:?} no outer FROM clause: {sql}"));
+        // The outer SELECT must carry exactly the one requested column. `name` is
+        // the marker: it is in E but must not survive select_only().
+        assert!(
+            !head.contains("\"name\"") && !head.contains("`name`"),
+            "{backend:?} outer SELECT still carries every column: {sql}"
+        );
+        assert!(
+            head.contains("\"id\"") || head.contains("`id`"),
+            "{backend:?} requested column missing: {sql}"
+        );
+    }
+}
+
+#[test]
+fn select_only_does_not_disturb_the_scope_predicate() {
+    // Projection and scope are independent; narrowing the select list must not
+    // drop the tenant filter from either the body or the outer query.
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+
+    for backend in BACKENDS {
+        let sql = scoped_nodes(&scope)
+            .with_ctes()
+            .cte::<item::Entity>("x", |q| q)
+            .join_cte("x", join_on_node_id())
+            .select_only()
+            .column(node::Column::Id)
+            .build_statement(backend)
+            .to_string();
+        assert_eq!(
+            scope_predicates(&sql),
+            2,
+            "{backend:?} select_only() disturbed a scope predicate: {sql}"
+        );
+    }
+}
+
+#[test]
+fn column_from_cte_and_expr_as_extend_the_outer_select_list() {
+    // A CTE column needs an alias to avoid colliding with the entity's own column
+    // of the same name; an expression covers aggregates and computed values.
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+    let root = uuid::Uuid::new_v4();
+
+    let sql = scoped_nodes(&scope)
+        .with_ctes()
+        .recursive_cte(subtree_cte(root))
+        .join_cte("subtree", join_on_subtree_id())
+        .select_only()
+        .column(node::Column::Id)
+        .column_from_cte("subtree", RecursiveCte::<node::Entity>::DEPTH_COLUMN, "hop")
+        .expr_as(Expr::val(1).add(Expr::val(1)), "two")
+        .build_statement(DbBackend::Postgres)
+        .to_string();
+
+    assert!(sql.contains(r#"AS "hop""#), "CTE column not aliased: {sql}");
+    assert!(sql.contains(r#"AS "two""#), "expression not aliased: {sql}");
+}
+
+// ---------------------------------------------------------------------------
+// Recursive dedup mode
+// ---------------------------------------------------------------------------
+
+#[test]
+fn recursive_cte_defaults_to_union_not_union_all() {
+    // Raised in review with measurements: UNION ALL enumerates paths, so on a graph
+    // where equal-length paths converge the row count multiplies with the branching
+    // factor. Plain UNION prunes that and is standard SQL on all three backends, so
+    // it is the safer default.
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+    let root = uuid::Uuid::new_v4();
+
+    for backend in BACKENDS {
+        let sql = scoped_nodes(&scope)
+            .with_ctes()
+            .recursive_cte(subtree_cte(root))
+            .build_statement(backend)
+            .to_string();
+        let body = cte_body(&sql);
+        assert!(
+            body.contains("UNION"),
+            "{backend:?} no UNION in the recursive body: {sql}"
+        );
+        assert!(
+            !body.contains("UNION ALL"),
+            "{backend:?} defaulted to UNION ALL, which enumerates paths: {sql}"
+        );
+    }
+}
+
+#[test]
+fn recursive_cte_dedup_union_all_is_opt_in() {
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+    let root = uuid::Uuid::new_v4();
+
+    for backend in BACKENDS {
+        let sql = scoped_nodes(&scope)
+            .with_ctes()
+            .recursive_cte(subtree_cte(root).dedup(RecursiveDedup::UnionAll))
+            .build_statement(backend)
+            .to_string();
+        assert!(
+            cte_body(&sql).contains("UNION ALL"),
+            "{backend:?} opt-in UNION ALL not emitted: {sql}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation inside the CTE body
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cte_body_supports_aggregation_with_scope_intact() {
+    // Answers a design question raised on the tracking issue: degree-ordered
+    // truncation needs an aggregate computed *inside* the scoped CTE body. The
+    // closure receives a `Select<J>`, so the whole `QuerySelect` surface is
+    // available -- and, critically, the scope predicate survives `select_only()`,
+    // which is what makes the aggregate safe to compute server-side.
+    use sea_orm::QuerySelect;
+    let scope = tenant_scope(uuid::Uuid::new_v4());
+
+    for backend in BACKENDS {
+        let sql = scoped_nodes(&scope)
+            .with_ctes()
+            .cte::<item::Entity>("degree", |q| {
+                q.select_only()
+                    .column(item::Column::NodeId)
+                    .column_as(Expr::col(item::Column::Id).count(), "degree")
+                    .group_by(item::Column::NodeId)
+            })
+            .build_statement(backend)
+            .to_string();
+
+        let body = cte_body(&sql);
+        assert!(body.contains("COUNT"), "{backend:?} no aggregate: {sql}");
+        assert!(body.contains("GROUP BY"), "{backend:?} no GROUP BY: {sql}");
+        assert_eq!(
+            scope_predicates(body),
+            1,
+            "{backend:?} select_only() in the body dropped its scope: {sql}"
+        );
+    }
+}

--- a/libs/toolkit-db/src/secure/mod.rs
+++ b/libs/toolkit-db/src/secure/mod.rs
@@ -104,6 +104,7 @@
 
 // Gear declarations
 mod cond;
+mod cte;
 mod db;
 mod db_ops;
 pub mod docs;
@@ -153,6 +154,9 @@ pub use select::{
     Scoped, SecureEntityExt, SecureFindRelatedExt, SecureSelect, SecureSelectTwo,
     SecureSelectTwoMany, Unscoped,
 };
+
+// CTE (`WITH`) operations -- see docs/arch/secure-orm/ADR/0001-secure-cte-policy.md
+pub use cte::{RecursiveCte, RecursiveDedup, SecureCteSelect};
 
 // Update/Delete/Insert operations
 pub use db_ops::{

--- a/libs/toolkit-db/src/secure/runner.rs
+++ b/libs/toolkit-db/src/secure/runner.rs
@@ -41,6 +41,19 @@ impl<'a> SeaOrmRunner<'a> {
             Self::Tx(t) => sea_orm::DatabaseExecutor::Transaction(t),
         }
     }
+
+    /// Which SQL dialect to render for.
+    ///
+    /// `DBRunner` is deliberately method-free, so callers that must build a
+    /// statement themselves (rather than letting `SeaORM` do it) have no other
+    /// way to learn the backend. Kept `pub(crate)` so no `SeaORM` type leaks.
+    pub(crate) fn backend(&self) -> sea_orm::DbBackend {
+        use sea_orm::ConnectionTrait;
+        match *self {
+            Self::Conn(c) => c.get_database_backend(),
+            Self::Tx(t) => t.get_database_backend(),
+        }
+    }
 }
 
 /// Internal-only bridge to `SeaORM`'s executor types.

--- a/libs/toolkit-db/tests/db_generic.rs
+++ b/libs/toolkit-db/tests/db_generic.rs
@@ -142,6 +142,27 @@ async fn outbox_schema_reapplies_cleanly_mysql() -> Result<()> {
     run_outbox_reapply_suite(&dut.url).await
 }
 
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn cte_shapes_are_valid_sql_sqlite() -> Result<()> {
+    let dut = common::bring_up_sqlite();
+    run_cte_suite(&dut.url).await
+}
+
+#[cfg(feature = "pg")]
+#[tokio::test]
+async fn cte_shapes_are_valid_sql_postgres() -> Result<()> {
+    let dut = common::bring_up_postgres().await?;
+    run_cte_suite(&dut.url).await
+}
+
+#[cfg(feature = "mysql")]
+#[tokio::test]
+async fn cte_shapes_are_valid_sql_mysql() -> Result<()> {
+    let dut = common::bring_up_mysql().await?;
+    run_cte_suite(&dut.url).await
+}
+
 /// Applies the identical outbox DDL twice over the same database.
 ///
 /// This is the crash-before-recording-then-retry path: every `CREATE TABLE` and
@@ -233,6 +254,304 @@ async fn run_common_suite(database_url: &str) -> Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!(e.to_string()))?;
     assert_eq!(count, 1);
+
+    Ok(())
+}
+
+// ════════════════════════════════════════════════════════════════════
+// CTE suite -- runs on every backend
+// ════════════════════════════════════════════════════════════════════
+//
+// The unit tests in `src/secure/cte_tests.rs` assert on rendered SQL *text*, so
+// they cannot tell whether a backend actually accepts the statement. That gap let
+// a real defect through: `distinct()` combined with ordering by a CTE column is
+// rejected by PostgreSQL and MySQL but accepted by SQLite, so a SQLite-only
+// integration suite reported success on SQL that fails in production.
+//
+// This suite therefore executes every query *shape* the CTE builder can emit,
+// once per backend. Assertions stay shallow on purpose -- the claim under test is
+// "the server accepts this", not "the rows are right". Row-level semantics
+// (tenant isolation, subtree membership, depth truncation, cycle termination) live
+// in `tests/sqlite/secure_cte.rs`, where in-memory SQLite makes them cheap.
+
+/// Separate table from `test_generic`: `recursive_cte` needs a self-referencing
+/// column, and `ent` is shared with the suites above.
+#[derive(Iden)]
+enum CteTbl {
+    #[iden = "test_cte_node"]
+    Table,
+    Id,
+    TenantId,
+    ParentId,
+    Name,
+    Payload,
+}
+
+struct CreateCteNode;
+impl mig::MigrationName for CreateCteNode {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "m001_create_test_cte_node"
+    }
+}
+
+#[async_trait::async_trait]
+impl mig::MigrationTrait for CreateCteNode {
+    async fn up(&self, manager: &mig::SchemaManager) -> Result<(), mig::DbErr> {
+        manager
+            .create_table(
+                sea_query::Table::create()
+                    .table(CteTbl::Table)
+                    .if_not_exists()
+                    .col(
+                        mig::ColumnDef::new(CteTbl::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(mig::ColumnDef::new(CteTbl::TenantId).uuid().not_null())
+                    .col(mig::ColumnDef::new(CteTbl::ParentId).uuid())
+                    .col(mig::ColumnDef::new(CteTbl::Name).string().not_null())
+                    // Deliberately `json`, not `jsonb`: on PostgreSQL `json` has no
+                    // equality operator, so selecting it inside a UNION-deduplicated
+                    // recursive CTE fails with "could not identify an equality
+                    // operator for type json". The recursive body must therefore
+                    // project only the traversal columns. This column exists to keep
+                    // that regression caught.
+                    .col(mig::ColumnDef::new(CteTbl::Payload).json())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &mig::SchemaManager) -> Result<(), mig::DbErr> {
+        manager
+            .drop_table(sea_query::Table::drop().table(CteTbl::Table).to_owned())
+            .await
+    }
+}
+
+mod cte_ent {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "test_cte_node")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub tenant_id: Uuid,
+        pub parent_id: Option<Uuid>,
+        pub name: String,
+        #[sea_orm(column_type = "Json", nullable)]
+        pub payload: Option<serde_json::Value>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+impl toolkit_db::secure::ScopableEntity for cte_ent::Entity {
+    fn tenant_col() -> Option<<Self as EntityTrait>::Column> {
+        Some(cte_ent::Column::TenantId)
+    }
+    fn resource_col() -> Option<<Self as EntityTrait>::Column> {
+        Some(cte_ent::Column::Id)
+    }
+    fn owner_col() -> Option<<Self as EntityTrait>::Column> {
+        None
+    }
+    fn type_col() -> Option<<Self as EntityTrait>::Column> {
+        None
+    }
+    fn resolve_property(property: &str) -> Option<<Self as EntityTrait>::Column> {
+        match property {
+            p if p == pep_properties::OWNER_TENANT_ID => Self::tenant_col(),
+            p if p == pep_properties::RESOURCE_ID => Self::resource_col(),
+            _ => None,
+        }
+    }
+}
+
+/// Narrow projection: the point of `all_as` is to avoid materialising the full
+/// model, so the cross-backend check uses a type that is not `E::Model`.
+#[derive(Debug, sea_orm::FromQueryResult)]
+struct NodeName {
+    name: String,
+}
+
+/// Row type for the `DISTINCT` shapes. They must not select the `json` column:
+/// `SELECT DISTINCT` compares every selected column and `PostgreSQL`'s `json` has no
+/// equality operator, so distinct-over-the-whole-entity is not portable. Narrowing
+/// the projection is the fix, which is what these shapes demonstrate.
+#[derive(Debug, sea_orm::FromQueryResult)]
+struct NodeIdName {
+    name: String,
+}
+
+async fn run_cte_suite(database_url: &str) -> Result<()> {
+    use sea_orm::sea_query::{Alias, Expr, Order};
+    use sea_orm::{ColumnTrait, Condition, ExprTrait, Set};
+    use toolkit_db::secure::RecursiveCte;
+
+    let db = toolkit_db::connect_db(database_url, toolkit_db::ConnectOpts::default()).await?;
+    toolkit_db::migration_runner::run_migrations_for_testing(&db, vec![Box::new(CreateCteNode)])
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+
+    let tenant_id = uuid::Uuid::new_v4();
+    let scope = toolkit_security::AccessScope::for_tenants(vec![tenant_id]);
+    let conn = db.conn().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+
+    // root -> child, so the recursive walk has at least one real hop to take.
+    let root = uuid::Uuid::new_v4();
+    let child = uuid::Uuid::new_v4();
+    for (id, parent, name) in [(root, None, "root"), (child, Some(root), "child")] {
+        let am = cte_ent::ActiveModel {
+            id: Set(id),
+            tenant_id: Set(tenant_id),
+            parent_id: Set(parent),
+            name: Set(name.to_owned()),
+            payload: Set(Some(serde_json::json!({ "n": name }))),
+        };
+        toolkit_db::secure::secure_insert::<cte_ent::Entity>(am, &scope, &conn)
+            .await
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    }
+
+    let scoped = || cte_ent::Entity::find().secure().scope_with(&scope);
+    let join_on_id = |cte: &'static str| {
+        Condition::all().add(
+            Expr::col((Alias::new(cte), Alias::new("id")))
+                .equals((cte_ent::Entity, cte_ent::Column::Id)),
+        )
+    };
+    let subtree = || {
+        RecursiveCte::<cte_ent::Entity>::new(
+            "subtree",
+            Condition::all().add(cte_ent::Column::Id.eq(root)),
+            cte_ent::Column::ParentId,
+            cte_ent::Column::Id,
+            5,
+        )
+    };
+
+    // Shape 1: flat CTE, joined back to the outer entity.
+    let flat = scoped()
+        .with_ctes()
+        .cte::<cte_ent::Entity>("all_nodes", |q| q)
+        .join_cte("all_nodes", join_on_id("all_nodes"))
+        .all(&conn)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    assert_eq!(flat.len(), 2, "flat CTE should return both seeded rows");
+
+    // Shape 2: recursive CTE. Two rows means the recursive member ran -- a seed
+    // that never recursed would return only the root.
+    let walked = scoped()
+        .with_ctes()
+        .recursive_cte(subtree())
+        .join_cte("subtree", join_on_id("subtree"))
+        .all(&conn)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    assert_eq!(walked.len(), 2, "recursive walk should reach the child");
+
+    // Shape 3: DISTINCT over a narrowed projection.
+    //
+    // The narrowing is not incidental. This entity carries a `json` column, and
+    // `SELECT DISTINCT` compares every selected column -- PostgreSQL's `json` has
+    // no equality operator, so distinct over the full entity is not portable.
+    // `select_only()` is what makes DISTINCT usable on such an entity.
+    let deduped = scoped()
+        .with_ctes()
+        .cte::<cte_ent::Entity>("all_nodes", |q| q)
+        .join_cte("all_nodes", join_on_id("all_nodes"))
+        .select_only()
+        .column(cte_ent::Column::Name)
+        .distinct()
+        .all_as::<NodeIdName>(&conn)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    assert_eq!(deduped.len(), 2);
+
+    // Shape 4: DISTINCT + ORDER BY an entity column. Valid everywhere, because an
+    // entity column is in the outer SELECT list.
+    let ordered = scoped()
+        .with_ctes()
+        .cte::<cte_ent::Entity>("all_nodes", |q| q)
+        .join_cte("all_nodes", join_on_id("all_nodes"))
+        .select_only()
+        .column(cte_ent::Column::Name)
+        .distinct()
+        .order_by(cte_ent::Column::Name, Order::Asc)
+        .all_as::<NodeIdName>(&conn)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    assert_eq!(
+        ordered.iter().map(|r| r.name.as_str()).collect::<Vec<_>>(),
+        vec!["child", "root"],
+        "ORDER BY on an entity column should sort"
+    );
+
+    // Shape 5: ORDER BY a CTE column, without DISTINCT. Valid on all three.
+    let by_depth = scoped()
+        .with_ctes()
+        .recursive_cte(subtree())
+        .join_cte("subtree", join_on_id("subtree"))
+        .order_by_cte(
+            "subtree",
+            RecursiveCte::<cte_ent::Entity>::DEPTH_COLUMN,
+            Order::Asc,
+        )
+        .all(&conn)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    assert_eq!(
+        by_depth.iter().map(|r| r.name.as_str()).collect::<Vec<_>>(),
+        vec!["root", "child"],
+        "ordering by depth should put the seed first"
+    );
+
+    // Shape 6: narrow projection through all_as.
+    let mut names = scoped()
+        .with_ctes()
+        .cte::<cte_ent::Entity>("all_nodes", |q| q)
+        .join_cte("all_nodes", join_on_id("all_nodes"))
+        .all_as::<NodeName>(&conn)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?
+        .into_iter()
+        .map(|n| n.name)
+        .collect::<Vec<_>>();
+    names.sort();
+    assert_eq!(names, vec!["child", "root"]);
+
+    // Shape 7: the rejected pairing. This is the regression guard -- PostgreSQL
+    // and MySQL reject this SQL outright, SQLite accepts it, so the library must
+    // refuse it identically on every backend BEFORE reaching the server.
+    let conflict = scoped()
+        .with_ctes()
+        .recursive_cte(subtree())
+        .join_cte("subtree", join_on_id("subtree"))
+        .select_only()
+        .column(cte_ent::Column::Name)
+        .distinct()
+        .order_by_cte(
+            "subtree",
+            RecursiveCte::<cte_ent::Entity>::DEPTH_COLUMN,
+            Order::Asc,
+        )
+        .all(&conn)
+        .await;
+    let Err(err) = conflict else {
+        anyhow::bail!("distinct() + order_by_cte() must be rejected, not executed");
+    };
+    assert!(
+        matches!(err, toolkit_db::secure::ScopeError::Invalid(msg) if msg.contains("DISTINCT")),
+        "expected a typed rejection, got: {err:?}"
+    );
 
     Ok(())
 }

--- a/libs/toolkit-db/tests/sqlite/mod.rs
+++ b/libs/toolkit-db/tests/sqlite/mod.rs
@@ -9,6 +9,7 @@ mod concurrency_tests;
 mod manager;
 mod options;
 mod pooling_tests;
+mod secure_cte;
 mod secure_insert_tenant_validation;
 mod secure_select_project_all;
 mod secure_update_tenant_safety;

--- a/libs/toolkit-db/tests/sqlite/secure_cte.rs
+++ b/libs/toolkit-db/tests/sqlite/secure_cte.rs
@@ -1,0 +1,600 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Integration tests for CTE support in the Secure ORM (ADR-0001).
+//!
+//! The unit tests in `src/secure/cte_tests.rs` assert what SQL is *built*. These
+//! assert what it *returns*, which is the only way to show the isolation claim
+//! actually holds and that a recursive walk terminates.
+//!
+//! Security contract:
+//! - No raw SQL in tests.
+//! - Schema is created via `sea-orm-migration` definitions run by the migration runner.
+
+use sea_orm::entity::prelude::*;
+use sea_orm::sea_query::{Alias, Expr};
+use sea_orm::{Condition, ExprTrait, Set};
+use sea_orm_migration::prelude as mig;
+use toolkit_db::migration_runner::run_migrations_for_testing;
+use toolkit_db::secure::{
+    Db, DbConn, RecursiveCte, ScopableEntity, SecureEntityExt, SecureUpdateExt, secure_insert,
+};
+use toolkit_db::{ConnectOpts, connect_db};
+use toolkit_security::{AccessScope, pep_properties};
+use uuid::Uuid;
+
+// ════════════════════════════════════════════════════════════════════
+// Test entity: a tenant-scoped tree
+// ════════════════════════════════════════════════════════════════════
+
+mod node {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "cte_nodes")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub tenant_id: Uuid,
+        pub parent_id: Option<Uuid>,
+        pub name: String,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+impl ScopableEntity for node::Entity {
+    fn tenant_col() -> Option<<Self as EntityTrait>::Column> {
+        Some(node::Column::TenantId)
+    }
+    fn resource_col() -> Option<<Self as EntityTrait>::Column> {
+        Some(node::Column::Id)
+    }
+    fn owner_col() -> Option<<Self as EntityTrait>::Column> {
+        None
+    }
+    fn type_col() -> Option<<Self as EntityTrait>::Column> {
+        None
+    }
+    fn resolve_property(property: &str) -> Option<<Self as EntityTrait>::Column> {
+        match property {
+            p if p == pep_properties::OWNER_TENANT_ID => Self::tenant_col(),
+            p if p == pep_properties::RESOURCE_ID => Self::resource_col(),
+            _ => None,
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Migration
+// ════════════════════════════════════════════════════════════════════
+
+struct CreateCteTables;
+
+impl mig::MigrationName for CreateCteTables {
+    fn name(&self) -> &'static str {
+        "m001_create_cte_tables"
+    }
+}
+
+#[async_trait::async_trait]
+impl mig::MigrationTrait for CreateCteTables {
+    async fn up(&self, manager: &mig::SchemaManager) -> Result<(), mig::DbErr> {
+        manager
+            .create_table(
+                mig::Table::create()
+                    .table(mig::Alias::new("cte_nodes"))
+                    .if_not_exists()
+                    .col(
+                        mig::ColumnDef::new(mig::Alias::new("id"))
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        mig::ColumnDef::new(mig::Alias::new("tenant_id"))
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(mig::ColumnDef::new(mig::Alias::new("parent_id")).uuid())
+                    .col(
+                        mig::ColumnDef::new(mig::Alias::new("name"))
+                            .string()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &mig::SchemaManager) -> Result<(), mig::DbErr> {
+        manager
+            .drop_table(
+                mig::Table::drop()
+                    .table(mig::Alias::new("cte_nodes"))
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Harness
+// ════════════════════════════════════════════════════════════════════
+
+struct TestDb {
+    db: Db,
+}
+
+impl TestDb {
+    async fn new(name: &str) -> Self {
+        let test_id = Uuid::new_v4();
+        let dsn = format!("sqlite:file:memdb_cte_{name}_{test_id}?mode=memory&cache=shared");
+        let opts = ConnectOpts {
+            max_conns: Some(1),
+            min_conns: Some(1),
+            ..Default::default()
+        };
+        let db = connect_db(&dsn, opts).await.expect("db connect");
+        run_migrations_for_testing(&db, vec![Box::new(CreateCteTables)])
+            .await
+            .expect("migrate");
+        Self { db }
+    }
+
+    fn conn(&self) -> DbConn<'_> {
+        self.db.conn().expect("conn")
+    }
+}
+
+/// Insert one node. Uses `secure_insert` so the row is written through the same
+/// scope machinery the reads go through.
+async fn insert_node(
+    conn: &DbConn<'_>,
+    scope: &AccessScope,
+    id: Uuid,
+    tenant: Uuid,
+    parent: Option<Uuid>,
+    name: &str,
+) {
+    let am = node::ActiveModel {
+        id: Set(id),
+        tenant_id: Set(tenant),
+        parent_id: Set(parent),
+        name: Set(name.to_owned()),
+    };
+    secure_insert::<node::Entity>(am, scope, conn)
+        .await
+        .expect("insert node");
+}
+
+/// `root -> child -> grandchild` plus a detached sibling, all in one tenant.
+struct Tree {
+    root: Uuid,
+    child: Uuid,
+    grandchild: Uuid,
+    detached: Uuid,
+}
+
+async fn seed_tree(conn: &DbConn<'_>, scope: &AccessScope, tenant: Uuid, prefix: &str) -> Tree {
+    let root = Uuid::new_v4();
+    let child = Uuid::new_v4();
+    let grandchild = Uuid::new_v4();
+    let detached = Uuid::new_v4();
+
+    insert_node(conn, scope, root, tenant, None, &format!("{prefix}-root")).await;
+    insert_node(
+        conn,
+        scope,
+        child,
+        tenant,
+        Some(root),
+        &format!("{prefix}-child"),
+    )
+    .await;
+    insert_node(
+        conn,
+        scope,
+        grandchild,
+        tenant,
+        Some(child),
+        &format!("{prefix}-grandchild"),
+    )
+    .await;
+    insert_node(
+        conn,
+        scope,
+        detached,
+        tenant,
+        None,
+        &format!("{prefix}-detached"),
+    )
+    .await;
+
+    Tree {
+        root,
+        child,
+        grandchild,
+        detached,
+    }
+}
+
+/// `ON cte.id = cte_nodes.id`, i.e. narrow the outer entity to the CTE's rows.
+fn join_on_id(cte: &'static str) -> Condition {
+    Condition::all().add(
+        Expr::col((Alias::new(cte), Alias::new("id"))).equals((node::Entity, node::Column::Id)),
+    )
+}
+
+fn subtree_of(root: Uuid, max_depth: u32) -> RecursiveCte<node::Entity> {
+    RecursiveCte::new(
+        "subtree",
+        Condition::all().add(node::Column::Id.eq(root)),
+        node::Column::ParentId,
+        node::Column::Id,
+        max_depth,
+    )
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Tests
+// ════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn cte_query_returns_only_rows_of_the_scoped_tenant() {
+    let tdb = TestDb::new("isolation").await;
+    let conn = tdb.conn();
+
+    let tenant_a = Uuid::new_v4();
+    let tenant_b = Uuid::new_v4();
+    let scope_a = AccessScope::for_tenants(vec![tenant_a]);
+    let scope_b = AccessScope::for_tenants(vec![tenant_b]);
+
+    let a = seed_tree(&conn, &scope_a, tenant_a, "a").await;
+    seed_tree(&conn, &scope_b, tenant_b, "b").await;
+
+    // What the CTE body itself contains. Joining on `id` would re-filter through
+    // the outer query's own tenant predicate, which masks an unscoped body
+    // completely -- so that shape cannot detect the leak this test exists for.
+    // Pinning the outer query to one row and joining on a tautology gives one
+    // result row per CTE entry, making the body's size observable.
+    let cte_entries = node::Entity::find()
+        .secure()
+        .scope_with(&scope_a)
+        .with_ctes()
+        .cte::<node::Entity>("all_nodes", |q| q)
+        .filter(Condition::all().add(node::Column::Id.eq(a.root)))
+        .join_cte(
+            "all_nodes",
+            Condition::all().add(Expr::val(1).eq(Expr::val(1))),
+        )
+        .all(&conn)
+        .await
+        .expect("cte query")
+        .len();
+
+    assert_eq!(
+        cte_entries, 4,
+        "the CTE body should hold only tenant A's four nodes; 8 means the body \
+         was not scoped and tenant B's rows are inside the WITH"
+    );
+
+    // And the ordinary shape returns tenant A's rows.
+    let rows = node::Entity::find()
+        .secure()
+        .scope_with(&scope_a)
+        .with_ctes()
+        .cte::<node::Entity>("all_nodes", |q| q)
+        .join_cte("all_nodes", join_on_id("all_nodes"))
+        .all(&conn)
+        .await
+        .expect("cte query");
+
+    assert_eq!(rows.len(), 4, "tenant A seeded four nodes");
+    assert!(
+        rows.iter().all(|r| r.tenant_id == tenant_a),
+        "leaked rows from another tenant: {rows:?}"
+    );
+    assert!(rows.iter().any(|r| r.id == a.root));
+}
+
+#[tokio::test]
+async fn recursive_cte_walks_the_subtree_and_excludes_unrelated_rows() {
+    let tdb = TestDb::new("subtree").await;
+    let conn = tdb.conn();
+
+    let tenant = Uuid::new_v4();
+    let scope = AccessScope::for_tenants(vec![tenant]);
+    let t = seed_tree(&conn, &scope, tenant, "t").await;
+
+    let rows = node::Entity::find()
+        .secure()
+        .scope_with(&scope)
+        .with_ctes()
+        .recursive_cte(subtree_of(t.root, 10))
+        .join_cte("subtree", join_on_id("subtree"))
+        .all(&conn)
+        .await
+        .expect("recursive cte query");
+
+    let ids: Vec<Uuid> = rows.iter().map(|r| r.id).collect();
+    assert!(ids.contains(&t.root), "seed row missing: {ids:?}");
+    assert!(ids.contains(&t.child), "depth-1 row missing: {ids:?}");
+    assert!(ids.contains(&t.grandchild), "depth-2 row missing: {ids:?}");
+    assert!(
+        !ids.contains(&t.detached),
+        "a node outside the subtree was returned: {ids:?}"
+    );
+    assert_eq!(ids.len(), 3);
+}
+
+#[tokio::test]
+async fn recursive_cte_never_crosses_a_tenant_boundary() {
+    // The reason the recursive member carries scope too. Both tenants get an
+    // identically shaped tree, so a walk that ignored scope after the seed would
+    // still find rows -- just the wrong ones.
+    let tdb = TestDb::new("cross_tenant").await;
+    let conn = tdb.conn();
+
+    let tenant_a = Uuid::new_v4();
+    let tenant_b = Uuid::new_v4();
+    let scope_a = AccessScope::for_tenants(vec![tenant_a]);
+    let scope_b = AccessScope::for_tenants(vec![tenant_b]);
+
+    let a = seed_tree(&conn, &scope_a, tenant_a, "a").await;
+    let b = seed_tree(&conn, &scope_b, tenant_b, "b").await;
+
+    // Deliberately graft tenant B's root under tenant A's child. The edge exists
+    // in the data, so only the scope predicate in the recursive member stops the
+    // walk from following it.
+    node::Entity::update_many()
+        .secure()
+        .scope_with(&scope_b)
+        .col_expr(node::Column::ParentId, Expr::value(a.child))
+        .filter(Condition::all().add(node::Column::Id.eq(b.root)))
+        .exec(&conn)
+        .await
+        .expect("graft b under a");
+
+    // Observing this needs care. Joining the CTE back on `id` would re-filter
+    // through the *outer* query's tenant predicate, which hides a leaking CTE
+    // body entirely -- the outer WHERE drops the foreign rows before they are
+    // visible, so the test would pass even with an unscoped recursive member.
+    //
+    // Instead: pin the outer query to a single row and join the CTE on a
+    // tautology, so the result has exactly one row per CTE entry. Then the row
+    // *count* reports how far the walk actually went, leak included.
+    let cte_entries = node::Entity::find()
+        .secure()
+        .scope_with(&scope_a)
+        .with_ctes()
+        .recursive_cte(subtree_of(a.root, 10))
+        .filter(Condition::all().add(node::Column::Id.eq(a.root)))
+        .join_cte(
+            "subtree",
+            Condition::all().add(Expr::val(1).eq(Expr::val(1))),
+        )
+        .all(&conn)
+        .await
+        .expect("recursive cte query")
+        .len();
+
+    assert_eq!(
+        cte_entries, 3,
+        "the walk should visit exactly tenant A's three nodes; more means it \
+         followed the grafted edge into tenant B"
+    );
+
+    // And the ordinary shape still returns only tenant A's rows.
+    let rows = node::Entity::find()
+        .secure()
+        .scope_with(&scope_a)
+        .with_ctes()
+        .recursive_cte(subtree_of(a.root, 10))
+        .join_cte("subtree", join_on_id("subtree"))
+        .all(&conn)
+        .await
+        .expect("recursive cte query");
+
+    assert!(
+        rows.iter().all(|r| r.tenant_id == tenant_a),
+        "walk crossed into another tenant: {rows:?}"
+    );
+    let ids: Vec<Uuid> = rows.iter().map(|r| r.id).collect();
+    assert!(
+        !ids.contains(&b.root) && !ids.contains(&b.child),
+        "tenant B rows reachable through the grafted edge: {ids:?}"
+    );
+    assert_eq!(ids.len(), 3, "still exactly tenant A's subtree");
+}
+
+#[tokio::test]
+async fn recursive_cte_depth_cap_truncates_the_walk() {
+    let tdb = TestDb::new("depth").await;
+    let conn = tdb.conn();
+
+    let tenant = Uuid::new_v4();
+    let scope = AccessScope::for_tenants(vec![tenant]);
+    let t = seed_tree(&conn, &scope, tenant, "t").await;
+
+    let ids_at = |depth: u32| {
+        let scope = scope.clone();
+        let conn = &conn;
+        async move {
+            let rows = node::Entity::find()
+                .secure()
+                .scope_with(&scope)
+                .with_ctes()
+                .recursive_cte(subtree_of(t.root, depth))
+                .join_cte("subtree", join_on_id("subtree"))
+                .all(conn)
+                .await
+                .expect("recursive cte query");
+            rows.iter().map(|r| r.id).collect::<Vec<Uuid>>()
+        }
+    };
+
+    let depth0 = ids_at(0).await;
+    assert_eq!(depth0, vec![t.root], "depth 0 is the seed row only");
+
+    let depth1 = ids_at(1).await;
+    assert_eq!(depth1.len(), 2, "depth 1 adds direct children: {depth1:?}");
+    assert!(depth1.contains(&t.child));
+    assert!(
+        !depth1.contains(&t.grandchild),
+        "depth 1 must not reach depth 2: {depth1:?}"
+    );
+
+    assert_eq!(ids_at(2).await.len(), 3, "depth 2 reaches the grandchild");
+}
+
+#[tokio::test]
+async fn recursive_cte_terminates_on_a_cyclic_graph() {
+    // sea_query drops PostgreSQL's CYCLE clause on MySQL/SQLite, so the depth cap
+    // is the only portable termination guarantee. Without it this query would
+    // recurse until the server gave up.
+    let tdb = TestDb::new("cycle").await;
+    let conn = tdb.conn();
+
+    let tenant = Uuid::new_v4();
+    let scope = AccessScope::for_tenants(vec![tenant]);
+    let t = seed_tree(&conn, &scope, tenant, "t").await;
+
+    // Close the loop: grandchild becomes the parent of root.
+    node::Entity::update_many()
+        .secure()
+        .scope_with(&scope)
+        .col_expr(node::Column::ParentId, Expr::value(t.grandchild))
+        .filter(Condition::all().add(node::Column::Id.eq(t.root)))
+        .exec(&conn)
+        .await
+        .expect("create cycle");
+
+    let walk = |cap: u32| {
+        let scope = scope.clone();
+        let conn = &conn;
+        async move {
+            node::Entity::find()
+                .secure()
+                .scope_with(&scope)
+                .with_ctes()
+                .recursive_cte(subtree_of(t.root, cap))
+                .join_cte("subtree", join_on_id("subtree"))
+                .all(conn)
+                .await
+                .expect("cyclic recursive cte must terminate, not hang or error")
+        }
+    };
+
+    // Going round the loop revisits nodes, so rows *repeat*: the walk yields one
+    // row per hop, not per distinct node, and nothing deduplicates it. The depth
+    // cap is what makes that finite -- row count tracks the cap exactly, which is
+    // the property being asserted. (Callers who want distinct nodes must dedup
+    // themselves; see `RecursiveCte`'s docs.)
+    let capped_3 = walk(3).await;
+    let capped_5 = walk(5).await;
+    assert_eq!(capped_3.len(), 4, "cap 3 should yield hops 0..=3");
+    assert_eq!(capped_5.len(), 6, "cap 5 should yield hops 0..=5");
+
+    // And it is genuinely cycling over the three real nodes, not inventing rows.
+    let mut distinct: Vec<Uuid> = capped_5.iter().map(|r| r.id).collect();
+    distinct.sort();
+    distinct.dedup();
+    assert_eq!(
+        distinct.len(),
+        3,
+        "expected the 3 cycle members, got {distinct:?}"
+    );
+}
+
+#[tokio::test]
+async fn cte_query_deserializes_into_a_custom_projection() {
+    // CTEs usually exist to compute something the entity model has no shape for,
+    // so `all_as` is the common case rather than an afterthought.
+    #[derive(Debug, sea_orm::FromQueryResult)]
+    struct NodeName {
+        name: String,
+    }
+
+    let tdb = TestDb::new("projection").await;
+    let conn = tdb.conn();
+
+    let tenant = Uuid::new_v4();
+    let scope = AccessScope::for_tenants(vec![tenant]);
+    seed_tree(&conn, &scope, tenant, "p").await;
+
+    let names = node::Entity::find()
+        .secure()
+        .scope_with(&scope)
+        .with_ctes()
+        .cte::<node::Entity>("all_nodes", |q| q)
+        .join_cte("all_nodes", join_on_id("all_nodes"))
+        .all_as::<NodeName>(&conn)
+        .await
+        .expect("projection query");
+
+    let mut got: Vec<String> = names.into_iter().map(|n| n.name).collect();
+    got.sort();
+    assert_eq!(
+        got,
+        vec!["p-child", "p-detached", "p-grandchild", "p-root"],
+        "projection lost or duplicated rows"
+    );
+}
+
+#[tokio::test]
+async fn distinct_collapses_rows_duplicated_by_the_cte_join() {
+    // `join_cte` is an inner join, so a node with two matching CTE rows comes back
+    // twice. This is the frontier-expansion case: several edges converge on one
+    // node. Without `distinct()` a BFS hop would double-count.
+    let tdb = TestDb::new("distinct").await;
+    let conn = tdb.conn();
+
+    let tenant = Uuid::new_v4();
+    let scope = AccessScope::for_tenants(vec![tenant]);
+    let t = seed_tree(&conn, &scope, tenant, "d").await;
+
+    // Two extra children of root, so `parent_id = root` matches three rows.
+    for name in ["extra-1", "extra-2"] {
+        insert_node(&conn, &scope, Uuid::new_v4(), tenant, Some(t.root), name).await;
+    }
+
+    // CTE = every node whose parent is root; joined to the outer entity on the
+    // shared parent, so root itself matches once per CTE row.
+    let children_of_root = |distinct: bool| {
+        let scope = scope.clone();
+        let conn = &conn;
+        async move {
+            let q = node::Entity::find()
+                .secure()
+                .scope_with(&scope)
+                .with_ctes()
+                .cte::<node::Entity>("kids", |q| {
+                    q.filter(Condition::all().add(node::Column::ParentId.eq(t.root)))
+                })
+                .filter(Condition::all().add(node::Column::Id.eq(t.root)))
+                .join_cte(
+                    "kids",
+                    Condition::all().add(
+                        Expr::col((Alias::new("kids"), Alias::new("parent_id")))
+                            .equals((node::Entity, node::Column::Id)),
+                    ),
+                );
+            let q = if distinct { q.distinct() } else { q };
+            q.all(conn).await.expect("cte query")
+        }
+    };
+
+    let duplicated = children_of_root(false).await;
+    assert_eq!(
+        duplicated.len(),
+        3,
+        "inner join should repeat the outer row once per CTE match"
+    );
+
+    let collapsed = children_of_root(true).await;
+    assert_eq!(collapsed.len(), 1, "distinct() should collapse them to one");
+    assert_eq!(collapsed[0].id, t.root);
+}

--- a/libs/toolkit-db/tests/ui/fail/cte_from_unscoped.rs
+++ b/libs/toolkit-db/tests/ui/fail/cte_from_unscoped.rs
@@ -1,0 +1,39 @@
+//! Compile-fail test: a CTE cannot be built from an unscoped query.
+//!
+//! ADR-0001's central claim is that tenant isolation for CTEs is a *compile-time*
+//! guarantee: `with_ctes` is reachable only from `SecureSelect<E, Scoped>`, so a
+//! CTE body cannot exist without a scope to embed. If `with_ctes` were ever added
+//! to the `Unscoped` impl block, every CTE body would silently lose its scope
+//! predicate and the `WITH` clause would read unfiltered tables.
+//!
+//! Security: this is the guard that makes "embed scope inside the body of every
+//! CTE" structural rather than a convention a reviewer has to enforce.
+
+use sea_orm::entity::prelude::*;
+use toolkit_db::secure::SecureEntityExt;
+
+mod test_entity {
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "cte_unscoped_table")]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: i32,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+use test_entity::Entity;
+
+fn attempt_cte_without_scope() {
+    // ERROR: `with_ctes` is only available on the Scoped state.
+    // `.scope_with(&scope)` must come first.
+    let _cte_query = Entity::find().secure().with_ctes();
+}
+
+fn main() {}

--- a/libs/toolkit-db/tests/ui/fail/cte_from_unscoped.stderr
+++ b/libs/toolkit-db/tests/ui/fail/cte_from_unscoped.stderr
@@ -1,0 +1,11 @@
+error[E0599]: no method named `with_ctes` found for struct `SecureSelect<test_entity::Entity, Unscoped>` in the current scope
+  --> tests/ui/fail/cte_from_unscoped.rs:36:46
+   |
+36 |     let _cte_query = Entity::find().secure().with_ctes();
+   |                                              ^^^^^^^^^
+   |
+help: there is a method `white` with a similar name
+   |
+36 -     let _cte_query = Entity::find().secure().with_ctes();
+36 +     let _cte_query = Entity::find().secure().white();
+   |


### PR DESCRIPTION
- Adds WITH support to the Secure ORM: SecureSelect::with_ctes() ->
  SecureCteSelect, with cte(), recursive_cte(), join_cte(), filter(),
  limit(), distinct(), order_by(), and all()/one()/all_as::<T>().

- Scope is embedded in every CTE body, seeded from the outer query's own Arc<AccessScope>, so a differently-scoped CTE can't be constructed -- no runtime check needed.

- Recursive CTEs: reverses ADR-0001's original rejection of WITH RECURSIVE. The recursive member reads the real table joined to the CTE self-reference, so the same scope condition applies as to the seed. RecursiveCte::max_depth has no default -- sea_query no-ops PostgreSQL's CYCLE clause on MySQL/SQLite, so the depth cap is the only portable termination guarantee. No visited set: the walk enumerates paths, not distinct nodes, so it suits bounded sparse hierarchies, not general graphs.

- Added SeaOrmRunner::backend() (DBRunner has no methods, so this was the only way to learn the dialect for rendering).

- ADR-0001 updated: status accepted, Option D reversed, closure tables demoted from precondition to preference, sea_query 0.32.7 -> 1.0.2 facts refreshed. 11_database_patterns.md gets the corresponding rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure Common Table Expression (CTE) support for scoped queries.
  * Added CTE joins, filtering, ordering, projections, limits, distinct results, and custom expressions.
  * Added recursive CTEs with mandatory depth limits and configurable deduplication.
  * Added tenant and access-scope protections for CTE queries, including recursive traversal.

* **Documentation**
  * Documented CTE construction, scoping, recursion, depth limits, and prohibited raw SQL patterns.

* **Tests**
  * Added cross-database coverage for CTE rendering, execution, isolation, recursion, ordering, projections, and invalid query combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->