### PR TITLE
chore(build): trim dev debuginfo, enable local incremental compilation

### DIFF
--- a/.github/workflows/cfs.yml
+++ b/.github/workflows/cfs.yml
@@ -25,6 +25,11 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Local dev enables incremental compilation via [profile.dev]; CI does not want
+  # the extra codegen and disk churn.
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   validate_artifacts:
     name: Validate CFS Artifacts

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,11 @@ on:
 permissions:
   contents: read
 
+env:
+  # Local dev enables incremental compilation via [profile.dev]; CI does not want
+  # the extra codegen and disk churn.
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   # Gate: detect whether anything other than docs changed. Doc-only PRs skip the
   # expensive CodeQL steps below but the analyze job still runs and reports green,

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,6 +31,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
+  # Local dev enables incremental via [profile.dev]; CI does not want the churn.
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   e2e:

--- a/.github/workflows/gts-validation.yml
+++ b/.github/workflows/gts-validation.yml
@@ -19,6 +19,11 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Local dev enables incremental compilation via [profile.dev]; CI does not want
+  # the extra codegen and disk churn.
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   gts_validate:
     name: Validate GTS Identifiers

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -19,6 +19,11 @@ on:
 permissions:
   contents: read
 
+env:
+  # `cargo publish` compiles every crate; CI does not want incremental churn
+  # (see [profile.dev] in Cargo.toml, which enables it for local dev).
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   # `release-plz release` publishes only versions present in the manifests and absent
   # from crates.io, so running it on every push is safe and makes an interrupted release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,14 @@ rust-version = "1.95.0"
 readme = "README.md"
 
 [profile.dev]
-incremental = false
+# Incremental is for local dev cycles. CI workflows set CARGO_INCREMENTAL=0 in
+# their env, which overrides this (the env var wins in both directions).
+incremental = true
 codegen-units = 16
+debug = "line-tables-only" # line tables for backtraces without full debuginfo bloat
 
 [profile.test]
-incremental = false
+incremental = true # same rationale as [profile.dev] above
 codegen-units = 16
 debug = "line-tables-only" # to minimize build sizes in gitworkflows
 
@@ -21,6 +24,31 @@ debug = "line-tables-only" # to minimize build sizes in gitworkflows
 codegen-units = 1
 panic = "unwind"
 debug = "line-tables-only"
+
+# Dependencies usually don't need debuginfo. See the Cargo guide:
+# https://doc.rust-lang.org/cargo/guide/build-performance.html#reduce-amount-of-generated-debug-information
+# When you do need it, use the `debugging` profile below.
+[profile.dev.package."*"]
+debug = false
+
+# Redundant in practice — dependencies of a test build use the dev profile, so the
+# override above already covers them. Kept for symmetry with the dev/test pair.
+[profile.test.package."*"]
+debug = false
+
+# Escape hatch: `cargo build --profile debugging` gives full debuginfo for the
+# workspace and its dependencies. Builds into target/debugging/, safe to delete.
+[profile.debugging]
+inherits = "dev"
+debug = true
+
+[profile.debugging.package."*"]
+debug = true
+
+# Build scripts and the proc-macro copies rustc loads during macro expansion are
+# governed by build-override, not by the package overrides above.
+[profile.debugging.build-override]
+debug = true
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,10 @@ readme = "README.md"
 # Incremental is for local dev cycles. CI workflows set CARGO_INCREMENTAL=0 in
 # their env, which overrides this (the env var wins in both directions).
 incremental = true
-codegen-units = 16
 debug = "line-tables-only" # line tables for backtraces without full debuginfo bloat
 
 [profile.test]
 incremental = true # same rationale as [profile.dev] above
-codegen-units = 16
 debug = "line-tables-only" # to minimize build sizes in gitworkflows
 
 [profile.release]

--- a/Makefile
+++ b/Makefile
@@ -856,7 +856,7 @@ mini-chat-down:
 
 # -------- Main targets --------
 
-.PHONY: all check ci ci_test ci_docs build .cargo-build .split-debug quickstart example mini-chat mini-chat-docker mini-chat-helm mini-chat-helm-template mini-chat-up mini-chat-down mini-chat-port-forward
+.PHONY: all check ci ci_test ci_docs build build-debug .cargo-build .split-debug quickstart example mini-chat mini-chat-docker mini-chat-helm mini-chat-helm-template mini-chat-up mini-chat-down mini-chat-port-forward
 
 # Start server with quickstart config
 quickstart:
@@ -900,6 +900,13 @@ ci: fmt clippy test-no-macros test-macros test-db deny test-users-info-pg test-u
 # Use 'make cargo-build' if you don't need stripped artifacts or lack
 # platform debug-splitting tools (objcopy, dsymutil).
 build: .cargo-build .split-debug
+
+# Build the cf-gears-example-server with full debuginfo (the 'debugging' profile)
+# Artifacts land in target/debugging/ and are not stripped, so no split-debug step
+# here. Costs a separate rebuild of the dependency graph; target/debug is untouched.
+build-debug:
+	cargo build --profile debugging --bin cf-gears-example-server $(E2E_ARGS)
+	@echo "binary: target/debugging/cf-gears-example-server"
 
 # Run all necessary quality checks and tests and then build the release binary
 all: build check test-sqlite e2e-local openapi


### PR DESCRIPTION
Follows the Cargo guide's [Reduce amount of generated debug information](https://doc.rust-lang.org/cargo/guide/build-performance.html#reduce-amount-of-generated-debug-information) recommendation for the dev profile: line tables only for workspace crates, no debuginfo for dependencies, plus a `debugging` profile that restores full debuginfo on demand (builds into target/debugging/).

Enable incremental compilation in the dev and test profiles for local cycles, and set CARGO_INCREMENTAL=0 in every workflow that can invoke cargo, so CI keeps non-incremental builds. The env var overrides the profile in both directions, so CI does not inherit the local default.

Drop the split-debuginfo settings: unpacked is already the macOS default for dev profiles, it is silently ignored on windows-msvc (only packed is supported there), and on Linux it would be the one real behaviour change with little left to gain once dependencies carry no debuginfo.

## Measurements

One pass per configuration on macOS 14.8.4 / 10 cores / rustc 1.95.0, building into a
separate `CARGO_TARGET_DIR` that was deleted before each cold build. No `RUSTC_WRAPPER`
and no `CARGO_INCREMENTAL` in the environment, so the manifest setting is what is in
effect. Every build exited 0.

### TLDR

**a) CI uses less disk.** Every workflow that can invoke cargo now sets
`CARGO_INCREMENTAL=0`, so CI takes the debuginfo savings without paying for incremental
artifacts: `target/` after building test binaries drops from 40.0 GiB to **28.1 GiB
(−30%, ~12 GiB less)**, `deps/` from 36.6 GiB to 29.8 GiB, and the build steps
themselves run **13–16% faster**. That is immediately useful here — `ci.yml` and
`release-plz.yml` already run `free-disk-space` steps to fit on the runners.

**b) Local rebuilds get much faster.** With incremental compilation enabled for the dev
and test profiles, editing a central crate rebuilds in **~30s instead of ~86–121s, i.e.
3–4x faster**. The price is disk, and only locally: `incremental/` grows to ~19 GiB,
which is why the local `target/` ends up +17% overall. That is the intended trade —
spend disk for iteration speed on a dev machine, keep the disk savings in CI.

### Time

| Step | command | before | after | delta | driven by |
| --- | --- | --- | --- | --- | --- |
| cold build | `cargo build --workspace` | 322s | 271s | **−16%** | `[profile.dev.package."*"] debug = false` — no debuginfo to generate or link for ~1000 dependency units |
| build test binaries | `cargo test --workspace --no-run` | 468s | 405s | **−13%** | same; test executables link the full dependency graph, so this is where debuginfo linking cost the most |
| rebuild after an edit (two consecutive passes) | `touch libs/toolkit/src/lib.rs && cargo build --workspace` — a central crate with 28 dependents | 121s / 86s | 30s / 29s | **3–4x faster** | `incremental = true` in `[profile.dev]` and `[profile.test]` |

### Disk

| Metric | before | after | delta |
| --- | --- | --- | --- |
| `target/` after `cargo build --workspace` | 9.84 GiB | 8.94 GiB | −9% |
| &nbsp;&nbsp;├─ `deps/` | 7.56 GiB | 4.54 GiB | **−40%** |
| &nbsp;&nbsp;└─ `incremental/` | 0 | 3.59 GiB | new cost<br/>(only on the local dev host, not in CI) |
| `target/` after building test binaries | 40.01 GiB | 45.13 GiB | +13% |
| &nbsp;&nbsp;├─ `deps/` | 36.55 GiB | 29.75 GiB | **−19%** |
| &nbsp;&nbsp;└─ `incremental/` | 0 | 17.00 GiB | new cost<br/>(only on the local dev host, not in CI ) |
| `target/` total | 40.27 GiB | 47.15 GiB | +17% |
| **`target/` total excluding `incremental/`** | 40.27 GiB | **28.12 GiB** | **−30%** |
| `.rlib` files in `deps/` | 1840 | 1306 | −534 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Development**
  * Improved development and test build performance through optimized compilation settings.
  * Added a debug build option that produces binaries with full debugging information.
* **CI & Validation**
  * Standardized compilation behavior across automated checks, end-to-end tests, validation, and release workflows for more consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->