### PR TITLE
test(rate-provider): Fixed the tests to use an unreachable domain res…

### DIFF
--- a/gears/bss/rate-provider/plugins/ecb-plugin/tests/ecb_integration.rs
+++ b/gears/bss/rate-provider/plugins/ecb-plugin/tests/ecb_integration.rs
@@ -116,13 +116,11 @@ async fn health_probe_passes_on_a_non_success_status() {
 
 #[tokio::test]
 async fn health_probe_fails_only_when_nothing_gets_through() {
-    // The other side of the bound above: with no listener the request dies at the
-    // transport level, the one genuinely unreachable case.
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-
-    let p = provider(format!("http://{addr}/eurofxref-daily.xml"));
+    // The other side of the bound above: a `.invalid` host (RFC 6761) can
+    // never resolve, so the request dies at the transport level — the one
+    // genuinely unreachable case — deterministically, with no ephemeral port
+    // for another test's listener to race for.
+    let p = provider("http://unreachable.invalid/eurofxref-daily.xml".to_owned());
     let ctx = SecurityContext::anonymous();
     let err = p.health(&ctx, "req").await.unwrap_err();
     assert!(
@@ -147,14 +145,11 @@ async fn a_future_dated_document_is_rejected_rather_than_served() {
 }
 
 #[tokio::test]
-async fn connection_refused_maps_to_unreachable() {
-    // Bind then immediately drop the listener: the port is free but nothing is
-    // listening, so the request fails at the transport level.
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-
-    let p = provider(format!("http://{addr}/eurofxref-daily.xml"));
+async fn unresolvable_host_maps_to_unreachable() {
+    // A `.invalid` host (RFC 6761) can never resolve, so the request fails at
+    // the transport level deterministically — no ephemeral port involved, so
+    // no other test can ever race for it.
+    let p = provider("http://unreachable.invalid/eurofxref-daily.xml".to_owned());
     let ctx = SecurityContext::anonymous();
     let err = p.fetch_latest(&ctx, &[], "req").await.unwrap_err();
     assert!(matches!(err, RateProviderError::Unreachable(_)));

--- a/gears/bss/rate-provider/plugins/http-json-plugin/tests/http_json_integration.rs
+++ b/gears/bss/rate-provider/plugins/http-json-plugin/tests/http_json_integration.rs
@@ -162,13 +162,11 @@ async fn health_probe_passes_on_a_non_success_status() {
 
 #[tokio::test]
 async fn health_probe_fails_only_when_nothing_gets_through() {
-    // The other side of the bound: bind then drop, so the port is free and the
-    // request dies at the transport level — the one genuinely unreachable case.
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-
-    let p = provider(format!("http://{addr}/rates"), Auth::None {});
+    // The other side of the bound: a `.invalid` host (RFC 6761) can never
+    // resolve, so the request dies at the transport level — the one
+    // genuinely unreachable case — deterministically, with no ephemeral port
+    // for another test's listener to race for.
+    let p = provider("http://unreachable.invalid/rates".to_owned(), Auth::None {});
     let ctx = SecurityContext::anonymous();
     let err = p.health(&ctx, "req").await.unwrap_err();
     assert!(
@@ -316,14 +314,11 @@ async fn upstream_503_maps_to_upstream_status() {
 }
 
 #[tokio::test]
-async fn connection_refused_maps_to_unreachable() {
-    // Bind then immediately drop the listener: the port is free, but nothing
-    // is listening, so any request to it fails at the transport level.
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-
-    let p = provider(format!("http://{addr}/rates"), Auth::None {});
+async fn unresolvable_host_maps_to_unreachable() {
+    // A `.invalid` host (RFC 6761) can never resolve, so the request fails at
+    // the transport level deterministically — no ephemeral port involved, so
+    // no other test can ever race for it.
+    let p = provider("http://unreachable.invalid/rates".to_owned(), Auth::None {});
     let ctx = SecurityContext::anonymous();
     let err = p.fetch_latest(&ctx, &[], "req").await.unwrap_err();
     assert!(matches!(err, RateProviderError::Unreachable(_)));

--- a/gears/bss/rate-provider/rate-provider-sdk/src/fetch_tests.rs
+++ b/gears/bss/rate-provider/rate-provider-sdk/src/fetch_tests.rs
@@ -228,15 +228,12 @@ async fn internal_parse_failure_is_labelled_internal() {
 
 #[tokio::test]
 async fn transport_failure_is_labelled_unreachable_and_records_no_status() {
-    // Bind then drop the listener: the port is free but nothing is listening, so
-    // the request fails before any response exists to count a status for.
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-
+    // A `.invalid` host (RFC 6761) can never resolve, so the request fails
+    // before any response exists to count a status for — deterministically,
+    // with no ephemeral port for another test's listener to race for.
     let metrics = RecordingMetrics::default();
     let err = fetch_and_parse(
-        client().get(&format!("http://{addr}/feed")),
+        client().get("http://unreachable.invalid/feed"),
         PROVIDER,
         &metrics,
         parse_ok(1),


### PR DESCRIPTION
Bug fix https://github.com/constructorfabric/gears-rust/issues/4560

## Description
Several integration tests simulated an unreachable upstream by binding an ephemeral TCP port and immediately dropping the listener. Under parallel test execution the OS could hand that same port to another process before the request was made, turning the expected transport failure into a spurious success and making the test flaky (e.g. `health_probe_fails_only_when_nothing_gets_through` in `ecb-plugin`). Replaced this pattern with a fixed hostname under the `.invalid` TLD (RFC 6761), which is guaranteed to never resolve, making the failure deterministic with no ephemeral-port race. Also renamed `connection_refused_maps_to_unreachable` → `unresolvable_host_maps_to_unreachable` in both plugins to match the new failure mode.

Affected: `bss-rate-provider-sdk`, `bss-rate-provider-ecb-plugin`, `bss-rate-provider-http-json-plugin` (5 test sites total).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved transport-failure test reliability by using deterministic unreachable hosts.
  * Preserved validation of unreachable error handling and upstream status behavior.
  * Renamed a test to more accurately describe unresolvable-host scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->