### PR TITLE
docs(oagw): document required_headers guard plugin, fix stale plugin lists

### DIFF
--- a/gears/system/oagw/docs/ADR/0003-plugin-system.md
+++ b/gears/system/oagw/docs/ADR/0003-plugin-system.md
@@ -118,21 +118,22 @@ Included in `oagw` crate (`infra/plugin/`):
 **Auth Plugins**:
 
 - `ApiKeyAuthPlugin`: API key injection (header/query)
-- `BasicAuthPlugin`: HTTP Basic authentication
-- `BearerTokenAuthPlugin`: Bearer token injection
-- `OAuth2ClientCredPlugin`: OAuth2 client credentials flow
+- `NoopAuthPlugin`: No authentication
+- `OAuth2ClientCredAuthPlugin`: OAuth2 client credentials flow (registered twice — `Form` and `Basic` client-auth-method variants — see [ADR: OAuth2 Client Credentials Auth Plugin](./0016-oauth2-client-credentials-auth-plugin.md))
+
+`cf.core.oagw.basic.v1` and `cf.core.oagw.bearer.v1` are reserved GTS identifiers cataloged in the types-registry with no backing `AuthPlugin` implementation in `infra/plugin/`.
 
 **Guard Plugins**:
 
-- `TimeoutGuardPlugin`: Request timeout enforcement
-- `CorsGuardPlugin`: CORS preflight validation
-- `RateLimitGuardPlugin`: Rate limiting (token bucket)
+- `RequiredHeadersGuardPlugin`: Required header enforcement (request/response)
+
+Request timeout and CORS are core Data Plane logic, not `GuardPlugin` trait implementations in `infra/plugin/` — see [ADR: CORS](./0006-cors.md). Their GTS identifiers (`cf.core.oagw.timeout.v1`, `cf.core.oagw.cors.v1`) exist for types-registry cataloging only and are not resolvable via `GuardPluginRegistry`.
 
 **Transform Plugins**:
 
-- `LoggingTransformPlugin`: Request/response logging
-- `MetricsTransformPlugin`: Prometheus metrics collection
 - `RequestIdTransformPlugin`: X-Request-ID propagation
+
+Request/response logging and Prometheus metrics collection are core Data Plane instrumentation (`infra/metrics.rs`, `tracing`), not `TransformPlugin` trait implementations. Their GTS identifiers (`cf.core.oagw.logging.v1`, `cf.core.oagw.metrics.v1`) exist for types-registry cataloging only and are not resolvable via `TransformPluginRegistry`.
 
 ### External Plugins
 

--- a/gears/system/oagw/docs/ADR/0017-required-headers-guard-plugin.md
+++ b/gears/system/oagw/docs/ADR/0017-required-headers-guard-plugin.md
@@ -1,0 +1,248 @@
+---
+status: accepted
+date: 2026-08-19
+decision-makers: Constructor Fabric Steering Committee
+---
+
+# Required Headers Guard Plugin — Request/Response Header Enforcement
+
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Plugin Config (ctx.config keys)](#plugin-config-ctxconfig-keys)
+  - [Decision Flow](#decision-flow)
+  - [Registry Integration](#registry-integration)
+  - [Upstream Configuration Example](#upstream-configuration-example)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [Dedicated builtin `GuardPlugin`](#dedicated-builtin-guardplugin)
+  - [Per-upstream custom Starlark guard plugin](#per-upstream-custom-starlark-guard-plugin)
+  - [Push the check into `Upstream.headers` passthrough config](#push-the-check-into-upstreamheaders-passthrough-config)
+- [Out of Scope](#out-of-scope)
+- [Future Considerations](#future-considerations)
+- [Related ADRs](#related-adrs)
+- [References](#references)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+**ID**: `cpt-cf-oagw-adr-required-headers-guard-plugin`
+
+## Context and Problem Statement
+
+Many upstreams need to enforce presence of specific headers before a request
+reaches them — for example, requiring a correlation ID or an API version
+header on inbound requests. Symmetrically, operators sometimes need to
+reject upstream responses that omit an expected header (e.g. `Content-Type`)
+as a defense against a misbehaving or compromised upstream. Without a
+built-in plugin for this common pattern, each operator would have to write
+and maintain a bespoke Starlark guard (per [ADR: Plugin System](./0003-plugin-system.md))
+for what is, in most cases, a simple presence check.
+
+## Decision Drivers
+
+* This is a common validation pattern that recurs across many upstreams and
+  should not require a custom Starlark guard each time.
+* The check must be opt-in per upstream and fail-open when unconfigured — an
+  upstream that doesn't configure the plugin should see no behavior change.
+* Both request and response phases are legitimate use cases and should be
+  handled symmetrically by the same plugin, independently configurable.
+
+## Considered Options
+
+* Dedicated builtin `GuardPlugin`
+* Per-upstream custom Starlark guard plugin
+* Push the check into `Upstream.headers` passthrough config
+
+## Decision Outcome
+
+Chosen option: "Dedicated builtin `GuardPlugin`". A stateless
+`RequiredHeadersGuardPlugin` checks for the presence of configured header
+names on the request (before proxying to upstream) and/or on the upstream's
+response (before returning to the caller), rejecting with a phase-specific
+status code on the first missing header.
+
+### Plugin Config (ctx.config keys)
+
+| Key | Required | Description |
+|---|---|---|
+| `required_request_headers` | No | Comma-separated header names checked in `guard_request`. Absent or blank (after trimming each entry) → phase is a no-op. |
+| `required_response_headers` | No | Comma-separated header names checked in `guard_response`. Absent or blank → phase is a no-op. |
+
+Both keys are independent — configuring one does not affect the other
+phase. Header names are matched case-insensitively; only presence is
+checked, not header values.
+
+### Decision Flow
+
+```text
+guard_request(ctx) / guard_response(ctx)
+  ├─ Read required_request_headers / required_response_headers from ctx.config
+  ├─ Absent or blank → Allow (fail-open, unconfigured)
+  ├─ Parse: split on ',', trim, lowercase, drop empty entries
+  ├─ Scan ctx.headers for each required name (case-insensitive), in order
+  ├─ All present → Allow
+  └─ First missing name found → Reject
+      ├─ Request phase  → status 400, error_code REQUIRED_HEADER_MISSING
+      └─ Response phase → status 502, error_code REQUIRED_HEADER_MISSING
+```
+
+Only the first missing header is reported per rejection, not the full set.
+
+### Registry Integration
+
+```rust
+impl GuardPluginRegistry {
+    pub fn with_builtins() -> Self {
+        let mut plugins: HashMap<String, Arc<dyn GuardPlugin>> = HashMap::new();
+        plugins.insert(
+            REQUIRED_HEADERS_GUARD_PLUGIN_ID.to_string(),
+            Arc::new(RequiredHeadersGuardPlugin),
+        );
+        Self { plugins }
+    }
+}
+```
+
+Note: `TIMEOUT_GUARD_PLUGIN_ID` and `CORS_GUARD_PLUGIN_ID` are declared as
+GTS constants and registered in the types-registry catalog
+(`type_catalog.rs`), but timeout and CORS enforcement are implemented as
+core Data Plane logic rather than `GuardPlugin` trait implementations —
+`RequiredHeadersGuardPlugin` is currently the only entry in
+`GuardPluginRegistry::with_builtins()`.
+
+### Upstream Configuration Example
+
+```json
+{
+  "plugins": {
+    "sharing": "private",
+    "items": [
+      {
+        "plugin_ref": "gts.cf.core.oagw.guard_plugin.v1~cf.core.oagw.required_headers.v1",
+        "config": {
+          "required_request_headers": "x-correlation-id,accept",
+          "required_response_headers": "content-type"
+        }
+      }
+    ]
+  }
+}
+```
+
+### Consequences
+
+#### Positive
+
+- Good, because a common validation need is covered without writing a
+  per-upstream custom Starlark guard.
+- Good, because request and response enforcement are both covered by the
+  same plugin, independently configurable.
+- Good, because fail-open on absent/blank config means adding the plugin to
+  the registry has no effect on upstreams that don't opt in.
+- Good, because the plugin is stateless — no cache, no security-sensitive
+  material, trivial to reason about and test.
+
+#### Negative
+
+- Bad, because only header *presence* is validated, not header *values* —
+  an upstream needing value validation (e.g. a specific API version) still
+  needs a custom guard.
+- Bad, because only the first missing header is reported per rejection,
+  which can require multiple round-trips to discover all missing headers.
+
+#### Risks
+
+- **Misconfigured comma list**: an all-blank or empty config value (e.g.
+  `", , ,"`) silently no-ops rather than erroring, matching the
+  `blank_header_names_are_ignored` test. An operator expecting enforcement
+  from a malformed config string will not be warned.
+
+### Confirmation
+
+Code review confirms: `RequiredHeadersGuardPlugin` implemented in
+`oagw/src/infra/plugin/required_headers_guard.rs`, registered under
+`REQUIRED_HEADERS_GUARD_PLUGIN_ID` (`oagw/src/domain/gts_helpers.rs`) in
+`GuardPluginRegistry::with_builtins()`
+(`oagw/src/infra/plugin/registry.rs`). Behavior is covered by 10 unit tests
+in the plugin module (unconfigured-allow, request/response allow and
+reject, case-insensitivity, first-missing-reported, phase isolation,
+blank-header-names-ignored) and 4 e2e tests in
+`testing/e2e/gears/oagw/test_guard_plugins.py`.
+
+## Pros and Cons of the Options
+
+### Dedicated builtin `GuardPlugin`
+
+A stateless plugin shipped in the `oagw` crate and registered by default.
+
+* Good, because it requires zero setup per upstream beyond config — no code
+  to write or deploy
+* Good, because it is covered by the same test and review process as other
+  builtin plugins
+* Bad, because it only covers presence checks — anything more elaborate
+  still needs a custom guard
+
+### Per-upstream custom Starlark guard plugin
+
+Each operator writes their own guard using the mechanism described in
+[ADR: Plugin System](./0003-plugin-system.md).
+
+* Good, because it is fully flexible — any check, including value
+  validation, is possible
+* Bad, because it duplicates the same presence-check logic across every
+  upstream that needs it
+* Bad, because it pushes maintenance and testing burden onto each operator
+  for a pattern that is almost always identical
+
+### Push the check into `Upstream.headers` passthrough config
+
+Extend the existing header passthrough/rewrite configuration to also
+support "required" markers.
+
+* Good, because it avoids introducing a new plugin type
+* Bad, because it conflates header *forwarding* concerns with header
+  *validation* concerns in a single config surface
+* Bad, because it does not naturally extend to response-phase enforcement,
+  which is a header validation concern independent of passthrough
+
+## Out of Scope
+
+- **Header value validation**: matching a header against a regex, allow-list,
+  or expected value. Only presence is checked today.
+
+## Future Considerations
+
+- **Header value validation**: extending the config schema to support
+  value constraints per header, not just presence.
+- **Reporting all missing headers**: returning the full set of missing
+  header names in the rejection detail instead of only the first.
+
+## Related ADRs
+
+- [ADR: Plugin System](./0003-plugin-system.md) — `GuardPlugin` trait and
+  execution model
+- [ADR: CORS](./0006-cors.md) — contrasting precedent: CORS was deliberately
+  built as core Data Plane logic rather than a `GuardPlugin` trait
+  implementation, for preflight-fast-path reasons that don't apply here
+
+## References
+
+- `oagw/src/infra/plugin/required_headers_guard.rs` — plugin implementation
+- `testing/e2e/gears/oagw/test_guard_plugins.py` — e2e coverage
+
+## Traceability
+
+- **PRD**: [PRD.md](../PRD.md)
+- **DESIGN**: [DESIGN.md](../DESIGN.md)
+- **Related ADR**: [ADR: Plugin System](./0003-plugin-system.md)
+
+This decision directly addresses the following requirements or design
+elements:
+
+* `cpt-cf-oagw-fr-builtin-plugins` — Built-in plugin implementation

--- a/gears/system/oagw/docs/DESIGN.md
+++ b/gears/system/oagw/docs/DESIGN.md
@@ -265,10 +265,10 @@ One per upstream. Named auth plugins resolved via in-process registries, not sto
 Built-in auth plugins:
 - `gts.cf.core.oagw.auth_plugin.v1~cf.core.oagw.noop.v1`
 - `gts.cf.core.oagw.auth_plugin.v1~cf.core.oagw.apikey.v1`
-- `gts.cf.core.oagw.auth_plugin.v1~cf.core.oagw.basic.v1`
-- `gts.cf.core.oagw.auth_plugin.v1~cf.core.oagw.bearer.v1`
 - `gts.cf.core.oagw.auth_plugin.v1~cf.core.oagw.oauth2_client_cred.v1`
 - `gts.cf.core.oagw.auth_plugin.v1~cf.core.oagw.oauth2_client_cred_basic.v1`
+
+`basic.v1` and `bearer.v1` are reserved GTS identifiers cataloged in the types-registry with no backing `AuthPlugin` implementation in `AuthPluginRegistry` — using either as `auth.plugin_type` fails with `unknown auth plugin`.
 
 **Guard Plugin** — Base type: `gts.cf.core.oagw.guard_plugin.v1~` — [schemas/guard_plugin.v1.schema.json](./schemas/guard_plugin.v1.schema.json)
 
@@ -276,10 +276,9 @@ Multiple per upstream/route. Can reject requests before they reach upstream.
 
 | Plugin ID | Description |
 |---|---|
-| `gts.cf.core.oagw.guard_plugin.v1~cf.core.oagw.timeout.v1` | Request timeout enforcement |
-| `gts.cf.core.oagw.guard_plugin.v1~cf.core.oagw.cors.v1` | CORS origin validation (actual requests; preflight handled at handler level — see [ADR: CORS](./ADR/0006-cors.md)) |
+| `gts.cf.core.oagw.guard_plugin.v1~cf.core.oagw.required_headers.v1` | Required header enforcement (request/response) — see [ADR: Required Headers Guard Plugin](./ADR/0017-required-headers-guard-plugin.md) |
 
-Circuit breaker is **core functionality** (not a plugin). See [ADR: Circuit Breaker](./ADR/0005-circuit-breaker.md).
+`required_headers.v1` is the only guard identifier resolvable via `GuardPluginRegistry` and bindable through `plugins.items[].plugin_ref`. Timeout and CORS are core Data Plane functionality, not `GuardPlugin` trait implementations: request timeout is gear-level configuration, and CORS is configured via the dedicated `cors` field on `Upstream`/`Route` (see [ADR: CORS](./ADR/0006-cors.md)). Their `gts.cf.core.oagw.guard_plugin.v1~cf.core.oagw.timeout.v1` / `...cors.v1` identifiers exist only for types-registry cataloging and cannot be bound via `plugins.items[].plugin_ref`. Circuit breaker is likewise **core functionality** (not a plugin). See [ADR: Circuit Breaker](./ADR/0005-circuit-breaker.md).
 
 **Transform Plugin** — Base type: `gts.cf.core.oagw.transform_plugin.v1~` — [schemas/transform_plugin.v1.schema.json](./schemas/transform_plugin.v1.schema.json)
 
@@ -287,9 +286,9 @@ Multiple per upstream/route, executed in order. Each plugin declares supported p
 
 | Plugin ID | Phase | Description |
 |---|---|---|
-| `gts.cf.core.oagw.transform_plugin.v1~cf.core.oagw.logging.v1` | request, response, error | Request/response logging |
-| `gts.cf.core.oagw.transform_plugin.v1~cf.core.oagw.metrics.v1` | request, response | Prometheus metrics |
 | `gts.cf.core.oagw.transform_plugin.v1~cf.core.oagw.request_id.v1` | request, response | X-Request-ID injection/propagation |
+
+`logging.v1` and `metrics.v1` are core Data Plane instrumentation (`infra/metrics.rs`, `tracing`), not `TransformPlugin` trait implementations. Their GTS identifiers exist for types-registry cataloging only and are not resolvable via `TransformPluginRegistry`.
 
 #### Plugin Identification Model
 
@@ -388,10 +387,15 @@ Execution order: Auth → Guards → Transform(on_request) → Upstream call →
 
 Plugin chain composition: upstream plugins execute before route plugins (`[U1, U2] + [R1, R2] => [U1, U2, R1, R2]`).
 
-**Built-in Plugins**:
-- Auth: `noop`, `apikey`, `basic`, `bearer`, `oauth2_client_cred`, `oauth2_client_cred_basic`
+**Built-in Plugins** (registered and resolvable via their plugin registry):
+- Auth: `noop`, `apikey`, `oauth2_client_cred`, `oauth2_client_cred_basic`
+- Guard: `required_headers`
+- Transform: `request_id`
+
+**Catalog-only identifiers** (reserved GTS ids, not resolvable via a plugin registry — `basic`/`bearer` have no backing implementation; `timeout`/`cors`/`logging`/`metrics` are core Data Plane logic instead):
+- Auth: `basic`, `bearer`
 - Guard: `timeout`, `cors`
-- Transform: `logging`, `metrics`, `request_id`
+- Transform: `logging`, `metrics`
 
 **Custom Plugins**: Starlark scripts with sandboxed execution (no network/file I/O, timeout/memory limits enforced). Immutable after creation; GC for unlinked plugins after configurable TTL.
 

--- a/gears/system/oagw/docs/PRD.md
+++ b/gears/system/oagw/docs/PRD.md
@@ -279,19 +279,20 @@ The system **MUST** include the following built-in plugins:
 **Auth Plugins**:
 - `gts.cf.core.oagw.auth_plugin.v1~cf.core.oagw.noop.v1` — No authentication
 - `gts.cf.core.oagw.auth_plugin.v1~cf.core.oagw.apikey.v1` — API key injection (header/query)
-- `gts.cf.core.oagw.auth_plugin.v1~cf.core.oagw.basic.v1` — HTTP Basic authentication
 - `gts.cf.core.oagw.auth_plugin.v1~cf.core.oagw.oauth2_client_cred.v1` — OAuth2 client credentials flow
 - `gts.cf.core.oagw.auth_plugin.v1~cf.core.oagw.oauth2_client_cred_basic.v1` — OAuth2 with Basic auth
-- `gts.cf.core.oagw.auth_plugin.v1~cf.core.oagw.bearer.v1` — Bearer token injection
+- `gts.cf.core.oagw.auth_plugin.v1~cf.core.oagw.basic.v1` — HTTP Basic authentication; catalog identifier only, no backing `AuthPlugin` implementation
+- `gts.cf.core.oagw.auth_plugin.v1~cf.core.oagw.bearer.v1` — Bearer token injection; catalog identifier only, no backing `AuthPlugin` implementation
 
 **Guard Plugins**:
-- `gts.cf.core.oagw.guard_plugin.v1~cf.core.oagw.timeout.v1` — Request timeout enforcement
-- `gts.cf.core.oagw.guard_plugin.v1~cf.core.oagw.cors.v1` — CORS preflight validation
+- `gts.cf.core.oagw.guard_plugin.v1~cf.core.oagw.required_headers.v1` — Required header enforcement (request/response); the only guard identifier bindable via `plugins.items[].plugin_ref`
+- `gts.cf.core.oagw.guard_plugin.v1~cf.core.oagw.timeout.v1` — Request timeout enforcement; core Data Plane config, catalog identifier only (not `plugins`-bindable)
+- `gts.cf.core.oagw.guard_plugin.v1~cf.core.oagw.cors.v1` — CORS preflight validation; core Data Plane config via `Upstream.cors`, catalog identifier only (not `plugins`-bindable)
 
 **Transform Plugins**:
-- `gts.cf.core.oagw.transform_plugin.v1~cf.core.oagw.logging.v1` — Request/response logging
-- `gts.cf.core.oagw.transform_plugin.v1~cf.core.oagw.metrics.v1` — Prometheus metrics collection
 - `gts.cf.core.oagw.transform_plugin.v1~cf.core.oagw.request_id.v1` — X-Request-ID propagation
+- `gts.cf.core.oagw.transform_plugin.v1~cf.core.oagw.logging.v1` — Request/response logging; core Data Plane instrumentation, catalog identifier only (not `TransformPluginRegistry`-resolvable)
+- `gts.cf.core.oagw.transform_plugin.v1~cf.core.oagw.metrics.v1` — Prometheus metrics collection; core Data Plane instrumentation, catalog identifier only (not `TransformPluginRegistry`-resolvable)
 
 - **Rationale**: Covers the most common outbound API authentication and observability patterns out of the box.
 - **Actors**: `cpt-cf-oagw-actor-platform-operator`


### PR DESCRIPTION
- Add required_headers guard plugin to DESIGN.md, PRD.md, ADR 0003
- Add ADR 0017 for the plugin
- Fix ADR 0003: remove nonexistent RateLimitGuardPlugin/TimeoutGuardPlugin/ CorsGuardPlugin/BasicAuthPlugin/BearerTokenAuthPlugin/LoggingTransformPlugin/ MetricsTransformPlugin struct names
- Mark timeout.v1, cors.v1, logging.v1, metrics.v1, basic.v1, bearer.v1 as catalog-only GTS identifiers not resolvable via their plugin registries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated plugin catalogs to accurately reflect available authentication and guard options.
  - Documented the Required Headers guard, including configuration, case-insensitive matching, fail-open behavior, and failure responses.
  - Clarified that Basic and Bearer authentication, Timeout, CORS, Logging, and Metrics are catalog-only identifiers or core functionality.
  - Added configuration examples, alternatives, consequences, references, and test traceability for required header enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->