### PR TITLE
Make file-storage and simple-user-settings publishable

### DIFF
--- a/gears/file-storage/file-storage-sdk/Cargo.toml
+++ b/gears/file-storage/file-storage-sdk/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "cf-gears-file-storage-sdk"
 version = "0.1.0"
-publish = false
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
 description = "SDK for file-storage gear: API trait, types, and error definitions"
+repository.workspace = true
+readme = "README.md"
+keywords = ["constructorfabric", "cf-gears", "file-storage"]
+categories = ["api-bindings"]
 
 [lib]
 name = "file_storage_sdk"

--- a/gears/file-storage/file-storage/Cargo.toml
+++ b/gears/file-storage/file-storage/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "cf-gears-file-storage"
 version = "0.1.0"
-publish = false
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
 description = "File Storage gear (control plane): metadata, authorization, versioning, signed URLs"
+repository.workspace = true
+readme = "README.md"
+keywords = ["constructorfabric", "cf-gears", "file-storage"]
+categories = ["web-programming"]
 # `src/bin/` also holds `sidecar_tests.rs`, the sidecar's out-of-line unit-test
 # module (required by the `de1101_tests_in_separate_files` repo lint — see
 # `#[path = "sidecar_tests.rs"] mod tests;` at the bottom of `sidecar.rs`).
@@ -28,10 +31,10 @@ default = []
 
 [dependencies]
 # SDK - public API, models, and errors
-cf-gears-file-storage-sdk = { path = "../file-storage-sdk" }
+cf-gears-file-storage-sdk = { version = "0.1.0", path = "../file-storage-sdk" }
 
 # Authorization Service (PEP) — per-type access decisions
-cf-gears-authz-resolver-sdk = { path = "../../system/authz-resolver/authz-resolver-sdk" }
+cf-gears-authz-resolver-sdk = { version = "0.3.20", path = "../../system/authz-resolver/authz-resolver-sdk" }
 authz-resolver = { workspace = true }
 
 # Core dependencies

--- a/gears/file-storage/file-storage/README.md
+++ b/gears/file-storage/file-storage/README.md
@@ -1,0 +1,34 @@
+# File Storage
+
+Control-plane gear for file storage in the Constructor Fabric gears runtime.
+Backed by `cf-gears-file-storage-sdk`, persisted via SeaORM, exposed over REST,
+and integrated with the AuthZ resolver.
+
+## Overview
+
+The `cf-gears-file-storage` gear provides:
+
+- **File metadata** — logical files with references, ownership and versioning
+- **Signed URLs** — short-lived upload/download URLs served by a data-plane sidecar
+- **AuthZ enforcement** — per-type access decisions through the AuthZ resolver (PEP flow)
+- **OData listing** — filterable, cursor-paginated reads over stored files
+- **ClientHub integration** — registers the file-storage client for in-process consumers
+
+The gear owns its database schema via the database capability and exposes a REST
+surface via the REST capability. Byte transfer is handled by a separate sidecar
+binary (`sidecar`) so the control plane never moves blob content itself.
+
+## Capabilities
+
+- `db` — SeaORM-backed storage with gear-owned migrations
+- `rest` — REST API for file metadata and signed URLs (OpenAPI-described)
+- Gear dependencies: `authz-resolver`
+
+## Usage (in-process)
+
+```rust
+use file_storage_sdk::FileStorageClient;
+
+let files = hub.get::<dyn FileStorageClient>()?;
+let file = files.get_file(&ctx, file_id).await?;
+```

--- a/gears/simple-user-settings/simple-user-settings-sdk/Cargo.toml
+++ b/gears/simple-user-settings/simple-user-settings-sdk/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cf-gears-simple-user-settings-sdk"
 version = "0.1.0"
-publish = false
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/gears/simple-user-settings/simple-user-settings/Cargo.toml
+++ b/gears/simple-user-settings/simple-user-settings/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cf-gears-simple-user-settings"
 version = "0.1.0"
-publish = false
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -21,7 +20,7 @@ workspace = true
 simple-user-settings-sdk = { package = "cf-gears-simple-user-settings-sdk", version = "0.1.0", path = "../simple-user-settings-sdk" }
 
 # AuthZ resolver for authorization (PEP flow)
-authz-resolver-sdk = { package = "cf-gears-authz-resolver-sdk", path = "../../../gears/system/authz-resolver/authz-resolver-sdk" }
+authz-resolver-sdk = { package = "cf-gears-authz-resolver-sdk", version = "0.3.20", path = "../../../gears/system/authz-resolver/authz-resolver-sdk" }
 authz-resolver = { workspace = true }
 
 anyhow = { workspace = true }


### PR DESCRIPTION
Drop publish = false from cf-gears-file-storage(-sdk) and cf-gears-simple-user-settings(-sdk), add standard package metadata where missing (repository, readme, keywords, categories) plus a README for the file-storage gear, and pin inline path dependencies to their versions so cargo can resolve path/version at publish time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - File-storage components are now publishable packages with improved marketplace metadata.
  - Added documentation covering file storage, signed URLs, authorization, OData, ClientHub, REST, database, and client capabilities.
  - Simple user settings components are now publishable packages.
- **Documentation**
  - Added a README for the file-storage control-plane component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->