### PR TITLE
chore(testing): pin database container versions in one place

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,11 @@ jobs:
               # Input to `make check-release-config` in the test job: a config-only
               # edit must still get the release configuration validated.
               - 'release-plz.toml'
+              # Input to `e2e_sidecar_pins_the_same_timescaledb_image` in
+              # libs/test-containers: a Python-only edit to the E2E sidecar must
+              # still get the cross-lane TimescaleDB pin checked, or the guard
+              # silently never runs on exactly the diff it exists to catch.
+              - 'testing/e2e/lib/sidecars.py'
             fips:
               - 'libs/toolkit/**'
               - 'libs/toolkit-http/**'
@@ -166,6 +171,20 @@ jobs:
           else
             echo "sccache failed, falling back to plain rustc"
           fi
+
+      # Database image tags are pinned in libs/test-containers (docs/TESTING.md
+      # 4.4). A fixture that constructs a container any other way re-introduces
+      # the transitive pin through Cargo.lock that issue #4616 removed: a
+      # dependency bump then moves the database under every test with nothing in
+      # the diff to show it.
+      #
+      # This parses the workspace with `syn` rather than grepping it, so import
+      # renames, type aliases, non-literal image names and creative formatting
+      # cannot slip past. Placed here, after the cache and sccache setup, because
+      # it needs a toolchain -- but still ahead of clippy, which is the expensive
+      # step in this job.
+      - name: No unpinned database container images
+        run: cargo xtask check-test-container-pins
 
       - name: cargo clippy
         run: make clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,6 +1639,7 @@ dependencies = [
  "cf-gears-resource-group-sdk",
  "cf-gears-tenant-resolver",
  "cf-gears-tenant-resolver-sdk",
+ "cf-gears-test-containers",
  "cf-gears-toolkit",
  "cf-gears-toolkit-canonical-errors",
  "cf-gears-toolkit-db",
@@ -1833,6 +1834,7 @@ name = "cf-gears-bss-coord"
 version = "0.0.0"
 dependencies = [
  "async-trait",
+ "cf-gears-test-containers",
  "cf-gears-toolkit-db",
  "cf-gears-toolkit-db-macros",
  "cf-gears-toolkit-security",
@@ -1884,6 +1886,7 @@ dependencies = [
  "cf-gears-bss-coord",
  "cf-gears-bss-ledger",
  "cf-gears-bss-ledger-sdk",
+ "cf-gears-test-containers",
  "cf-gears-toolkit",
  "cf-gears-toolkit-canonical-errors",
  "cf-gears-toolkit-db",
@@ -1948,6 +1951,7 @@ dependencies = [
  "cf-gears-bss-fixtures-conformance",
  "cf-gears-bss-pricing",
  "cf-gears-bss-pricing-sdk",
+ "cf-gears-test-containers",
  "cf-gears-toolkit",
  "cf-gears-toolkit-canonical-errors",
  "cf-gears-toolkit-db",
@@ -2091,6 +2095,7 @@ dependencies = [
  "cf-gears-cluster-conformance",
  "cf-gears-cluster-sdk",
  "cf-gears-standalone-cluster-plugin",
+ "cf-gears-test-containers",
  "cf-gears-toolkit",
  "cf-postgres-cluster-plugin",
  "parking_lot",
@@ -2815,6 +2820,7 @@ dependencies = [
  "cf-gears-authz-resolver",
  "cf-gears-authz-resolver-sdk",
  "cf-gears-resource-group-sdk",
+ "cf-gears-test-containers",
  "cf-gears-toolkit",
  "cf-gears-toolkit-canonical-errors",
  "cf-gears-toolkit-db",
@@ -3158,12 +3164,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-gears-test-containers"
+version = "0.1.0"
+dependencies = [
+ "serial_test",
+ "temp-env",
+ "testcontainers",
+ "testcontainers-modules",
+]
+
+[[package]]
 name = "cf-gears-timescaledb-usage-collector-plugin"
 version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "bigdecimal",
+ "cf-gears-test-containers",
  "cf-gears-toolkit",
  "cf-gears-toolkit-macros",
  "cf-gears-toolkit-odata",
@@ -3400,6 +3417,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bigdecimal",
+ "cf-gears-test-containers",
  "cf-gears-toolkit-db-macros",
  "cf-gears-toolkit-odata",
  "cf-gears-toolkit-security",
@@ -3837,6 +3855,7 @@ dependencies = [
  "cf-gears-cluster-conformance",
  "cf-gears-cluster-sdk",
  "cf-gears-standalone-cluster-plugin",
+ "cf-gears-test-containers",
  "cf-gears-toolkit",
  "cf-gears-toolkit-macros",
  "dashmap",
@@ -12946,7 +12965,9 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 name = "xtask"
 version = "0.1.0"
 dependencies = [
+ "proc-macro2",
  "serde_json",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "libs/toolkit",
     "libs/toolkit-macros",
     "libs/toolkit-macros-tests",
+    "libs/test-containers",
     "libs/toolkit-db",
     "libs/toolkit-db-macros",
     "libs/toolkit-auth",
@@ -675,6 +676,11 @@ heck = "0.5"
 proc-macro-crate = "3"
 
 # Testing utilities
+# Internal, unpublished: the single place every database container tag is
+# pinned (see libs/test-containers). Lives here rather than with the other
+# `libs/**` entries because it is only ever a dev-dependency, alongside the
+# `testcontainers` pair it wraps.
+test-containers = { package = "cf-gears-test-containers", path = "libs/test-containers" }
 trybuild = "1"
 serial_test = { version = "3", features = ["file_locks"] }
 criterion = { version = "0.8", default-features = false }

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -50,6 +50,9 @@ make fuzz                  # fuzz — 30 s smoke per target
 make check                 # full quality gate (fmt + clippy + test + security)
 make all                   # full pipeline (build + check + test-sqlite + e2e-local)
 
+# CI gate: no database container built outside libs/test-containers (4.4)
+cargo xtask check-test-container-pins
+
 make build GEAR=file-parser      # one gear package plus SDK package
 make test GEAR=file-parser       # one gear package plus SDK package
 make run GEAR=file-parser        # server with only this gear feature set
@@ -154,6 +157,71 @@ make test-users-info-pg    # users-info Postgres integration
 
 The `integration` job in `ci.yml` runs SQLite, Postgres, and MySQL integration tests
 plus macro UI tests on every PR (Ubuntu only).
+
+### 4.4 Database container images
+
+Every fixture that starts a database container goes through
+[`libs/test-containers`](../libs/test-containers/src/lib.rs) (crate
+`cf-gears-test-containers`, imported as `test_containers`). It is the single place image
+versions are pinned, so a version change is one reviewed diff instead of a grep across the
+workspace.
+
+**Do not call `Postgres::default()` or `Mysql::default()` in a test**, and do not call
+`GenericImage::new()` outside that crate. Those constructors take their tag from
+`testcontainers-modules`, which pins it transitively through `Cargo.lock` — a dependency bump
+then changes the database under every test with nothing in the diff to show it.
+
+`cargo xtask check-test-container-pins` enforces this in CI (the `clippy` job). It parses every
+tracked `.rs` file with `syn`, so an import rename (`Postgres as Pg`), a type alias, a
+non-literal image name or an oddly wrapped call is caught the same as the plain spelling.
+
+```rust
+// Add to [dev-dependencies]:  test-containers = { workspace = true }
+use testcontainers::runners::AsyncRunner;
+
+let container = test_containers::postgres().start().await?;
+
+// Non-default database name (POSTGRES_DB is applied at image level):
+let container = test_containers::postgres_named("cluster_test").start().await?;
+
+// A suite pinned to a floor of its own, above or below the workspace pin —
+// "16-alpine" is just an illustration value here. GEARS_TEST_PG_TAG still
+// wins over it, so the suite stays in the CI version matrix; chaining
+// `.with_tag(...)` onto `postgres()` would silently opt out of the override.
+let container = test_containers::postgres_tagged("16-alpine").start().await?;
+```
+
+Helpers: `postgres()`, `postgres_named()`, `postgres_tagged()`, `postgres_graph()`, `mysql()`,
+`timescaledb()`, `mariadb()`.
+
+#### Version-matrix overrides
+
+Each tag can be overridden from the environment, so CI can run a matrix without touching code.
+An unset *or empty* variable means "use the pinned constant".
+
+| Variable | Overrides |
+|---|---|
+| `GEARS_TEST_PG_TAG` | `POSTGRES_TAG` |
+| `GEARS_TEST_PG_GRAPH_TAG` | `POSTGRES_GRAPH_TAG` |
+| `GEARS_TEST_MYSQL_TAG` | `MYSQL_TAG` |
+| `GEARS_TEST_TIMESCALEDB_TAG` | `TIMESCALEDB_TAG` |
+| `GEARS_TEST_MARIADB_TAG` | `MARIADB_TAG` |
+
+```bash
+GEARS_TEST_PG_TAG=16-alpine cargo nextest run -p cf-gears-toolkit-db --features pg,integration
+```
+
+`GEARS_TEST_TIMESCALEDB_TAG` is read by both lanes: the Rust plugin fixtures via
+`test_containers::timescaledb()`, and the Python E2E sidecar via `timescaledb_tag()` in
+[`testing/e2e/lib/sidecars.py`](../testing/e2e/lib/sidecars.py). A matrix run therefore keeps
+migrations and E2E on the same image instead of silently testing two different ones.
+
+`GEARS_TEST_PG_GRAPH_REQUIRED=1` turns an unavailable PostgreSQL 19 image into a failure rather
+than a graceful skip; it is off by default while that tag is pre-GA. Unset, empty, `0`, `false`,
+`off` and `no` all mean off.
+
+Only concrete tags belong in the constants — a floating alias such as `lts` or `latest`
+re-points under CI with nothing in the diff, which is the drift this crate exists to prevent.
 
 ---
 

--- a/docs/arch/secure-orm/ADR/0002-secure-property-graph-policy.md
+++ b/docs/arch/secure-orm/ADR/0002-secure-property-graph-policy.md
@@ -479,10 +479,14 @@ against a live PostgreSQL 19 beta 2 server by @vasylcf (probe branch
   mechanism and its two-branch gate (`Alias::new` always escapes; a `&'static str` used as an
   `Iden` escapes unless it passes `is_static_iden()`); the same reasoning must be applied here
   and pinned by hostile-name tests.
-- **PostgreSQL 19 is pre-GA and untested in this repo.** The PG integration harness starts
-  `Postgres::default()`, which is `postgres:11-alpine`
-  ([tests/common.rs:55](../../../../libs/toolkit-db/tests/common.rs#L55)), so live coverage
-  needs an explicit PG19 image tag and must be skipped where that image is unavailable.
+- **PostgreSQL 19 is pre-GA and untested in this repo.** The image-tag half of this blocker is
+  resolved: every fixture now starts through
+  [`libs/test-containers`](../../../../libs/test-containers/src/lib.rs), which pins
+  `POSTGRES_GRAPH_TAG` for the SQL/PGQ lane and exposes `postgres_graph()` to start it. The lane
+  is still opt-in — `graph_lane_required()` defaults to `false` while the tag is a pre-GA beta
+  that Docker Hub may withdraw at GA, and `GEARS_TEST_PG_GRAPH_REQUIRED=1` makes an unavailable
+  image a failure instead of a skip. What remains is live coverage: nothing consumes
+  `postgres_graph()` yet.
 - **Privileges give no isolation help — and no escalation risk.** Verbatim from the
   documentation: *"Access to the base relations underlying the `GRAPH_TABLE` clause is
   determined by the permissions of the user executing the query, rather than the property

--- a/gears/bss/ledger/ledger/Cargo.toml
+++ b/gears/bss/ledger/ledger/Cargo.toml
@@ -124,6 +124,7 @@ types-registry-sdk = { workspace = true, features = ["test-util"] }
 # `testcontainers` crate is not a direct dep. Raw SQL in tests goes through
 # sea-orm `Statement`, not `sqlx` directly.
 testcontainers-modules = { workspace = true }
+test-containers = { workspace = true }
 # `tower::ServiceExt` provides `.oneshot(...)` for the REST router tests.
 tower = { workspace = true }
 # TODO(broker): `jsonschema` validated event payloads against their vendored

--- a/gears/bss/ledger/ledger/src/api/local_client_tests.rs
+++ b/gears/bss/ledger/ledger/src/api/local_client_tests.rs
@@ -487,7 +487,7 @@ mod pg {
         LedgerLocalClient,
         Uuid,
     ) {
-        let container = Postgres::default().start().await.unwrap();
+        let container = test_containers::postgres().start().await.unwrap();
         let port = container.get_host_port_ipv4(5432).await.unwrap();
         let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -709,7 +709,7 @@ mod pg {
         LedgerLocalClient,
         Uuid,
     ) {
-        let container = Postgres::default().start().await.unwrap();
+        let container = test_containers::postgres().start().await.unwrap();
         let port = container.get_host_port_ipv4(5432).await.unwrap();
         let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -748,7 +748,7 @@ mod pg {
         LedgerLocalClient,
         Uuid,
     ) {
-        let container = Postgres::default().start().await.unwrap();
+        let container = test_containers::postgres().start().await.unwrap();
         let port = container.get_host_port_ipv4(5432).await.unwrap();
         let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -1275,7 +1275,7 @@ mod pg {
     #[tokio::test]
     #[ignore = "requires Docker (testcontainers)"]
     async fn provision_post_read_reverse_ties_out() {
-        let container = Postgres::default().start().await.unwrap();
+        let container = test_containers::postgres().start().await.unwrap();
         let port = container.get_host_port_ipv4(5432).await.unwrap();
         let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
         let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/src/infra/jobs/aged_alarms_tests.rs
+++ b/gears/bss/ledger/ledger/src/infra/jobs/aged_alarms_tests.rs
@@ -23,7 +23,6 @@ use std::sync::Arc;
 use chrono::{DateTime, Datelike, Duration as ChronoDuration, NaiveDate, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement, TransactionTrait};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
 use uuid::Uuid;
@@ -472,7 +471,7 @@ async fn setup(container_url: &str) -> (DatabaseConnection, DBProvider<DbError>)
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn run_over_empty_ledger_completes() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (_raw, provider) = setup(&url).await;
@@ -497,7 +496,7 @@ async fn run_over_empty_ledger_completes() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn aged_queue_row_is_detected_and_run_completes() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = setup(&url).await;
@@ -551,7 +550,7 @@ async fn aged_queue_row_is_detected_and_run_completes() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn aged_chargeback_queue_row_is_detected() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = setup(&url).await;
@@ -585,7 +584,7 @@ async fn aged_chargeback_queue_row_is_detected() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn aged_refund_clearing_is_detected_and_run_completes() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = setup(&url).await;
@@ -667,7 +666,7 @@ async fn aged_refund_clearing_is_detected_and_run_completes() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn stage1_orphan_refund_is_detected() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = setup(&url).await;
@@ -790,7 +789,7 @@ async fn seed_unallocated_grain(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn aged_unallocated_grain_is_detected_and_run_completes() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = setup(&url).await;
@@ -837,7 +836,7 @@ async fn aged_unallocated_grain_is_detected_and_run_completes() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn fresh_or_drained_unallocated_grain_is_not_aged() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = setup(&url).await;
@@ -900,7 +899,7 @@ async fn seed_tax_subbalance(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn negative_tax_subbalance_beyond_window_is_detected_and_run_completes() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = setup(&url).await;

--- a/gears/bss/ledger/ledger/src/infra/jobs/rate_sync_tests.rs
+++ b/gears/bss/ledger/ledger/src/infra/jobs/rate_sync_tests.rs
@@ -20,7 +20,6 @@ use bss_ledger_sdk::{CurrencyPair, UnconfiguredRateProviderV1};
 use chrono::Utc;
 use sea_orm::{ConnectionTrait, Database, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::{ConnectOpts, connect_db};
 
@@ -188,7 +187,7 @@ fn pg(sql: impl Into<String>) -> Statement {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn fans_rates_out_to_every_provisioned_tenant() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/src/infra/jobs/tieout_tests.rs
+++ b/gears/bss/ledger/ledger/src/infra/jobs/tieout_tests.rs
@@ -21,7 +21,6 @@ use bss_ledger_sdk::{AccountClass, MappingStatus, Side, SourceDocType};
 use chrono::{NaiveDate, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -442,7 +441,7 @@ async fn setup_with_one_balanced_post(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn run_over_clean_tenant_completes() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -483,7 +482,7 @@ async fn run_over_clean_tenant_completes() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn run_over_drifted_tenant_emits_alarm() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -1089,7 +1088,7 @@ fn cache_baseline_rows_roundtrip() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn incremental_tie_out_equals_full_across_periods() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, service, provider, f) = setup(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_allocate_fx.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_allocate_fx.rs
@@ -54,7 +54,6 @@ use bss_ledger_sdk::AccountClass;
 use chrono::{Datelike, NaiveDate, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -111,7 +110,7 @@ fn rate_locker(provider: &DBProvider<DbError>, fx_config: &FxConfig) -> RateLock
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn cross_currency_allocate_realizes_fx_and_closes_both_grains() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_audit.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_audit.rs
@@ -26,7 +26,6 @@ use chrono::{DateTime, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
 use serde_json::json;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::{AccessScope, TxConfig};
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -102,7 +101,7 @@ async fn append(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn appends_first_record_sealed_with_genesis_prev() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -177,7 +176,7 @@ async fn appends_first_record_sealed_with_genesis_prev() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn links_second_record_to_first() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -242,7 +241,7 @@ async fn links_second_record_to_first() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn append_only_trigger_rejects_update_and_delete() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -310,7 +309,7 @@ async fn append_only_trigger_rejects_update_and_delete() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn rewalk_detects_tamper() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -503,7 +502,7 @@ async fn fetch_hex_set(conn: &DatabaseConnection, sql: &str) -> Vec<String> {
 #[ignore = "requires Docker (testcontainers)"]
 async fn concurrent_appends_form_linear_audit_chain() {
     const N: usize = 8;
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_balance_caches.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_balance_caches.rs
@@ -26,7 +26,7 @@ async fn boot() -> (
     testcontainers_modules::testcontainers::ContainerAsync<Postgres>,
     DatabaseConnection,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let db = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_bola.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_bola.rs
@@ -23,7 +23,6 @@ use bss_ledger::infra::storage::repo::ReferenceRepo;
 use bss_ledger_sdk::ODataQuery;
 use sea_orm::Database;
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -47,7 +46,7 @@ fn account_row(tenant: Uuid) -> AccountRow {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn cross_tenant_reference_reads_are_sql_scoped_to_empty() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_chain.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_chain.rs
@@ -30,7 +30,6 @@ use bss_ledger_sdk::{AccountClass, MappingStatus, Side, SourceDocType};
 use chrono::{NaiveDate, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -235,7 +234,7 @@ fn line(f: &Fixture, account: Uuid, class: AccountClass, side: Side, amount: i64
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn seals_first_post_with_genesis_prev() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -323,7 +322,7 @@ async fn seals_first_post_with_genesis_prev() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn links_second_post_to_first() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -390,7 +389,7 @@ async fn links_second_post_to_first() {
 #[ignore = "requires Docker (testcontainers)"]
 async fn concurrent_posts_form_linear_chain() {
     const N: usize = 8;
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -525,7 +524,7 @@ async fn concurrent_posts_form_linear_chain() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn tip_rollback_orphaning_sealed_rows_freezes_tenant() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -589,7 +588,7 @@ async fn tip_rollback_orphaning_sealed_rows_freezes_tenant() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn verifier_freeze_writes_freeze_set_clear_audit_record() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -667,7 +666,7 @@ async fn fetch_hex_set(conn: &DatabaseConnection, sql: &str) -> Vec<String> {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn append_only_trigger_rejects_reseal_update_and_delete() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -728,7 +727,7 @@ async fn append_only_trigger_rejects_reseal_update_and_delete() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn frozen_scope_blocks_posting() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -779,7 +778,7 @@ async fn frozen_scope_blocks_posting() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn verifier_passes_clean_chain() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -834,7 +833,7 @@ async fn verifier_passes_clean_chain() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn verifier_freezes_tampered_chain() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -929,7 +928,7 @@ async fn verifier_freezes_tampered_chain() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn journal_entry_column_set_is_pinned_for_trigger_drift() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_chargeback_concurrency.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_chargeback_concurrency.rs
@@ -65,7 +65,7 @@ async fn boot() -> (
     sea_orm::DatabaseConnection,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_chargeback_fx.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_chargeback_fx.rs
@@ -132,7 +132,7 @@ async fn setup(
     Chart,
     String,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_chargebacks.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_chargebacks.rs
@@ -89,7 +89,7 @@ async fn boot() -> (
     sea_orm::DatabaseConnection,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_credit.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_credit.rs
@@ -68,7 +68,7 @@ async fn boot() -> (
     sea_orm::DatabaseConnection,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_credit_concurrency.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_credit_concurrency.rs
@@ -64,7 +64,7 @@ async fn boot() -> (
     sea_orm::DatabaseConnection,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_credit_note.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_credit_note.rs
@@ -50,7 +50,6 @@ use bss_ledger_sdk::{AccountClass, Side};
 use chrono::NaiveDate;
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -353,7 +352,7 @@ async fn credit_note_against_unposted_invoice_is_note_invoice_not_found() {
     // F4 (design §4.2 / §5): a credit note MUST link an originating posted invoice.
     // No `INVOICE_POST` entry for the referenced invoice ⇒ `NOTE_INVOICE_NOT_FOUND`
     // (404), BEFORE any read/split/post — no orphan compensating entry.
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -389,7 +388,7 @@ async fn credit_note_against_unposted_invoice_is_note_invoice_not_found() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn deferred_credit_note_reduces_cl_ar_and_schedule_total() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -460,7 +459,7 @@ async fn deferred_credit_note_reduces_cl_ar_and_schedule_total() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn headroom_check_blocks_over_cap_credit_note() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -509,7 +508,7 @@ async fn headroom_check_blocks_over_cap_credit_note() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn goodwill_credit_uses_goodwill_class_not_contra() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -551,7 +550,7 @@ async fn goodwill_credit_uses_goodwill_class_not_contra() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn paid_invoice_credit_seeds_reusable_credit_wallet() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -615,7 +614,7 @@ async fn mixed_credit_note_books_both_contra_and_cl() {
     // (→ DR CONTRA_REVENUE) AND a deferred part (→ DR CONTRACT_LIABILITY), both
     // against CR AR. The recognized-leg path + the per-stream CL reduction fire
     // together in one balanced post.
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -682,7 +681,7 @@ async fn goodwill_credit_over_open_ar_is_rejected() {
     // cash-equivalent grant. (A non-goodwill paid-invoice credit DOES seed the
     // wallet — that is the `paid_invoice_credit_seeds_reusable_credit_wallet` path;
     // this proves goodwill is held to the stricter AR-only rule.)
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_cross_tenant.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_cross_tenant.rs
@@ -32,7 +32,6 @@ use bss_ledger::infra::authz::cross_tenant::{CrossTenantGateway, TargetScope};
 use bss_ledger::infra::storage::migrations::Migrator;
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -68,7 +67,7 @@ async fn setup(container_url: &str) -> (DatabaseConnection, DBProvider<DbError>)
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn routine_resolve_writes_no_record_returns_home_scope() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = setup(&url).await;
@@ -114,7 +113,7 @@ async fn routine_resolve_writes_no_record_returns_home_scope() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn cross_tenant_resolve_writes_record_returns_target_scope() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = setup(&url).await;
@@ -198,7 +197,7 @@ async fn cross_tenant_resolve_writes_record_returns_target_scope() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn cross_tenant_resolve_without_reason_is_rejected_no_record() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = setup(&url).await;
@@ -245,7 +244,7 @@ async fn cross_tenant_resolve_without_reason_is_rejected_no_record() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn cross_tenant_resolve_without_role_is_denied_no_record() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = setup(&url).await;
@@ -292,7 +291,7 @@ async fn cross_tenant_resolve_without_role_is_denied_no_record() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn audit_retrieval_and_tamper_status_reads() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = setup(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_debit_note.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_debit_note.rs
@@ -51,7 +51,6 @@ use bss_ledger_sdk::{AccountClass, Side};
 use chrono::NaiveDate;
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -452,7 +451,7 @@ async fn debit_note_against_unposted_invoice_is_note_invoice_not_found() {
     // F4 (design §4.3 / §5): a debit note MUST link an originating posted invoice.
     // No `INVOICE_POST` entry for the referenced invoice ⇒ `NOTE_INVOICE_NOT_FOUND`
     // (404), BEFORE any ledger effect — no orphan charge entry, no exposure row.
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -509,7 +508,7 @@ async fn debit_note_against_unposted_invoice_is_note_invoice_not_found() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn deferred_debit_note_books_ar_revenue_cl_and_builds_schedule() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -592,7 +591,7 @@ async fn deferred_debit_note_books_ar_revenue_cl_and_builds_schedule() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn debit_note_raises_headroom_for_a_later_credit_note() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -676,7 +675,7 @@ async fn debit_note_raises_headroom_for_a_later_credit_note() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn fully_recognized_debit_note_books_no_contract_liability() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -736,7 +735,7 @@ async fn deferred_debit_note_extends_the_live_schedule_not_a_second() {
     // total_deferred grows, overlapping-period segments fold in, and there is still
     // exactly ONE schedule_id. Without the fix the note's SCHEDULE_BUILD claim
     // collided with the base build → replay → skip, and its 600 deferred was lost.
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -802,7 +801,7 @@ async fn deferred_debit_note_extends_the_live_schedule_not_a_second() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn debit_note_for_closed_payer_is_rejected() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_dual_control.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_dual_control.rs
@@ -76,7 +76,7 @@ async fn boot() -> (
     sea_orm::DatabaseConnection,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_entry_annotation.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_entry_annotation.rs
@@ -33,7 +33,6 @@ use bss_ledger_sdk::{AccountClass, MappingStatus, Side, SourceDocType};
 use chrono::{NaiveDate, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -238,7 +237,7 @@ fn line(f: &Fixture, account: Uuid, class: AccountClass, side: Side, amount: i64
     reason = "one container boot amortizes the full pre-write rejection matrix + happy-path upsert + journal-unchanged proof"
 )]
 async fn annotation_set_upserts_and_leaves_journal_unchanged() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_exception.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_exception.rs
@@ -25,7 +25,6 @@ use bss_ledger::infra::storage::migrations::Migrator;
 use bss_ledger::infra::storage::repo::ExceptionQueueRepo;
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -79,7 +78,7 @@ async fn count_rows(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn route_opens_one_period_bound_row_and_dedups() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -123,7 +122,7 @@ async fn route_opens_one_period_bound_row_and_dedups() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn resolve_transitions_and_list_filters() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -160,7 +159,7 @@ async fn resolve_transitions_and_list_filters() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn gl_writeoff_approved_exception_does_not_block_close() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_executor.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_executor.rs
@@ -55,7 +55,7 @@ async fn boot() -> (
     testcontainers_modules::testcontainers::ContainerAsync<Postgres>,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_fx_revaluation_mode.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_fx_revaluation_mode.rs
@@ -40,7 +40,7 @@ async fn boot() -> (
     testcontainers_modules::testcontainers::ContainerAsync<Postgres>,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_idempotency.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_idempotency.rs
@@ -21,7 +21,6 @@ use bss_ledger::infra::posting::idempotency::{ClaimOutcome, IdempotencyGate};
 use bss_ledger::infra::storage::migrations::Migrator;
 use sea_orm::{ConnectionTrait, Database, DbErr, Statement, TransactionTrait};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
 use uuid::Uuid;
@@ -39,7 +38,7 @@ fn lift(e: RepoError) -> DbError {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn claim_then_finalize_then_replay() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_inquiry.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_inquiry.rs
@@ -40,7 +40,6 @@ use bss_ledger_sdk::{AccountClass, Side};
 use chrono::NaiveDate;
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -216,7 +215,7 @@ fn svc(provider: &DBProvider<DbError>, metrics: &MetricsHarness) -> InvoicePostS
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn filter_export_and_drill() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -351,7 +350,7 @@ async fn filter_export_and_drill() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn cross_tenant_pack_writes_forensic_record() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_invoice_post.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_invoice_post.rs
@@ -48,7 +48,6 @@ use bss_ledger_sdk::{AccountClass, EntryView, LineView, MappingStatus, Side, Sou
 use chrono::{DateTime, NaiveDate, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -243,7 +242,7 @@ async fn bal(raw: &DatabaseConnection, s: &Seller, account: Uuid) -> Option<i64>
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn posts_balanced_invoice_and_emits_metrics() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -325,7 +324,7 @@ async fn posts_balanced_invoice_and_emits_metrics() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn closed_payer_is_rejected_but_a_reversal_still_posts() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -438,7 +437,7 @@ async fn closed_payer_is_rejected_but_a_reversal_still_posts() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn closed_ar_account_post_is_rejected_at_the_db_guard() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -481,7 +480,7 @@ async fn closed_ar_account_post_is_rejected_at_the_db_guard() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn revenue_line_missing_revenue_stream_is_rejected_by_the_foundation() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (_raw, provider, s) = setup(&url).await;
@@ -510,7 +509,7 @@ async fn revenue_line_missing_revenue_stream_is_rejected_by_the_foundation() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn a_pending_suspense_line_blocks_period_close() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (_raw, provider, s) = setup(&url).await;
@@ -569,7 +568,7 @@ async fn a_pending_suspense_line_blocks_period_close() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn mapping_correction_retry_replays_idempotently() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -664,7 +663,7 @@ async fn mapping_correction_retry_replays_idempotently() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn reverse_of_a_reversal_is_rejected() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (_raw, provider, s) = setup(&url).await;
@@ -762,7 +761,7 @@ async fn reverse_of_a_reversal_is_rejected() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn concurrent_same_invoice_posts_exactly_once() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -851,7 +850,7 @@ async fn concurrent_same_invoice_posts_exactly_once() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn concurrent_reversals_of_one_entry_post_exactly_once() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_invoice_post_fx.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_invoice_post_fx.rs
@@ -38,7 +38,6 @@ use bss_ledger_sdk::AccountClass;
 use chrono::{NaiveDate, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -84,7 +83,7 @@ fn eur_account(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn cross_currency_invoice_stamps_functional_and_balances_both_columns() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_journal.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_journal.rs
@@ -48,7 +48,7 @@ async fn boot() -> (
     testcontainers_modules::testcontainers::ContainerAsync<Postgres>,
     DatabaseConnection,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let db = Database::connect(&url).await.unwrap();
@@ -606,7 +606,7 @@ async fn setup_posted_invoice(url: &str) -> (DatabaseConnection, DBProvider<DbEr
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn reads_return_entry_lines_balances_and_ar_invoice() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (_raw, provider, f) = setup_posted_invoice(&url).await;
@@ -710,7 +710,7 @@ async fn reads_return_entry_lines_balances_and_ar_invoice() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn cross_tenant_reads_are_sql_scoped_to_empty() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (_raw, provider, f) = setup_posted_invoice(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_manual_adjustment.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_manual_adjustment.rs
@@ -44,7 +44,6 @@ use bss_ledger::infra::storage::repo::ReferenceRepo;
 use bss_ledger_sdk::{AccountClass, Side};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -246,7 +245,7 @@ fn req(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn rounding_correction_posts_then_replays_idempotently() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -319,7 +318,7 @@ async fn rounding_correction_posts_then_replays_idempotently() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn class_outside_allow_list_is_not_allowed() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -362,7 +361,7 @@ async fn class_outside_allow_list_is_not_allowed() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn contra_revenue_write_off_is_not_allowed_and_does_not_post() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_migration_idempotency.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_migration_idempotency.rs
@@ -28,7 +28,6 @@
 
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::migration_runner::run_migrations_for_testing;
 use toolkit_db::{ConnectOpts, connect_db};
@@ -64,7 +63,7 @@ fn url_with_search_path(port: u16, search_path: &str) -> String {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn migrations_idempotent_under_public_first_search_path() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
 
     let db = connect_db(
@@ -136,7 +135,7 @@ async fn migrations_idempotent_under_public_first_search_path() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers); documents the C1 crash"]
 async fn bss_first_search_path_crash_loops_on_second_boot() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
 
     let db = connect_db(
@@ -169,7 +168,7 @@ async fn bss_first_search_path_crash_loops_on_second_boot() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn payment_tables_created_on_up_and_dropped_on_down() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let db = Database::connect(&url).await.unwrap();
@@ -225,7 +224,7 @@ async fn payment_tables_created_on_up_and_dropped_on_down() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn pending_event_queue_created_on_up_and_dropped_on_down() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let db = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_payer_state.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_payer_state.rs
@@ -41,7 +41,7 @@ async fn boot() -> (
     sea_orm::DatabaseConnection,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_payment_concurrency.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_payment_concurrency.rs
@@ -69,7 +69,7 @@ async fn boot() -> (
     sea_orm::DatabaseConnection,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_payment_returns.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_payment_returns.rs
@@ -60,7 +60,7 @@ async fn boot() -> (
     sea_orm::DatabaseConnection,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_payments.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_payments.rs
@@ -71,7 +71,7 @@ async fn boot() -> (
     sea_orm::DatabaseConnection,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_period_close.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_period_close.rs
@@ -38,7 +38,6 @@ use bss_ledger_sdk::{AccountClass, MappingStatus, Side, SourceDocType};
 use chrono::{NaiveDate, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -254,7 +253,7 @@ fn noop_publisher() -> Arc<LedgerEventPublisher> {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn close_blocked_by_tieout_variance() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -300,7 +299,7 @@ async fn close_blocked_by_tieout_variance() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn clean_close_succeeds_and_is_idempotent() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -346,7 +345,7 @@ async fn clean_close_succeeds_and_is_idempotent() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn close_unknown_period_is_not_found() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -376,7 +375,7 @@ async fn close_unknown_period_is_not_found() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn close_blocked_by_open_exception() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -441,7 +440,7 @@ async fn close_blocked_by_open_exception() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn close_blocked_by_due_recognition_segment() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -488,7 +487,7 @@ async fn close_blocked_by_due_recognition_segment() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn reopen_after_close_flips_to_open_and_records_reopened() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_period_guard.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_period_guard.rs
@@ -15,7 +15,6 @@ use bss_ledger::infra::posting::period::{FiscalPeriodGuard, PeriodError};
 use bss_ledger::infra::storage::migrations::Migrator;
 use sea_orm::{ConnectionTrait, Database, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
 use uuid::Uuid;
@@ -27,7 +26,7 @@ fn pg(sql: impl Into<String>) -> Statement {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn pin_open_admits_open_rejects_closed_and_missing() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_period_open.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_period_open.rs
@@ -20,7 +20,6 @@ use bss_ledger::infra::storage::migrations::Migrator;
 use chrono::Utc;
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
 use uuid::Uuid;
@@ -43,7 +42,7 @@ async fn count(db: &DatabaseConnection, sql: impl Into<String>) -> i64 {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn period_open_creates_current_and_next_and_is_idempotent() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_pii.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_pii.rs
@@ -36,7 +36,6 @@ use bss_ledger_sdk::{AccountClass, MappingStatus, Side, SourceDocType};
 use chrono::{NaiveDate, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -257,7 +256,7 @@ fn line(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn erase_tombstones_and_leaves_journal_unchanged_then_reidentify() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -526,7 +525,7 @@ async fn erase_tombstones_and_leaves_journal_unchanged_then_reidentify() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn erase_is_idempotent_and_unmapped_noleak_and_reidentify_404() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_policy_version.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_policy_version.rs
@@ -41,7 +41,6 @@ use bss_ledger_sdk::{AccountClass, EntryView, LineView, MappingStatus, Side, Sou
 use chrono::{DateTime, NaiveDate, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -305,7 +304,7 @@ fn view_line(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn correction_must_reuse_original_evidence_refs() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (_raw, posting, invoice, f) = setup(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_posting.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_posting.rs
@@ -34,7 +34,6 @@ use sea_orm::{
     ActiveValue::Set, ConnectionTrait, Database, DatabaseConnection, EntityTrait, Statement,
 };
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::{AccessScope, SecureInsertExt, SecureOnConflict};
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -237,7 +236,7 @@ fn line(f: &Fixture, account: Uuid, class: AccountClass, side: Side, amount: i64
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn post_balanced_replay_period_and_negative() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -394,7 +393,7 @@ async fn post_balanced_replay_period_and_negative() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn concurrent_same_key_posts_once() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -465,7 +464,7 @@ async fn concurrent_same_key_posts_once() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn secure_orm_isolates_cross_tenant_entry_reads() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -517,7 +516,7 @@ async fn secure_orm_isolates_cross_tenant_entry_reads() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn reverses_fields_persist_on_a_reversal_post() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -611,7 +610,7 @@ async fn reverses_fields_persist_on_a_reversal_post() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn concurrent_overdraw_of_guarded_account_stays_non_negative() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -668,7 +667,7 @@ async fn concurrent_overdraw_of_guarded_account_stays_non_negative() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn concurrent_close_never_certifies_a_period_a_post_landed_in() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -818,7 +817,7 @@ impl PostSidecar for RejectingSidecar {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn post_sidecar_commits_with_entry_and_rolls_back_on_err() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -911,7 +910,7 @@ fn cross_currency_entry(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn cross_currency_post_populates_functional_balance() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -987,7 +986,7 @@ async fn cross_currency_post_populates_functional_balance() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn post_with_request_hash_rejects_same_key_different_payload() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -1053,7 +1052,7 @@ async fn post_with_request_hash_rejects_same_key_different_payload() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn post_with_request_hash_same_hash_replays() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -1101,7 +1100,7 @@ async fn post_with_request_hash_same_hash_replays() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn single_currency_post_leaves_functional_null() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -1134,7 +1133,7 @@ async fn single_currency_post_leaves_functional_null() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn tenant_posting_lock_blocks_posting() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -1193,7 +1192,7 @@ async fn tenant_posting_lock_blocks_posting() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn clock_skew_beyond_24h_is_quarantined() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_precedence_policy.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_precedence_policy.rs
@@ -61,7 +61,7 @@ async fn boot() -> (
     sea_orm::DatabaseConnection,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_projector.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_projector.rs
@@ -23,7 +23,6 @@ use bss_ledger_sdk::{AccountClass, MappingStatus, Side, SourceDocType};
 use chrono::{DateTime, NaiveDate, Utc};
 use sea_orm::{ConnectionTrait, Database, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -133,7 +132,7 @@ async fn ar_invoice_stamps(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn projects_deltas_and_enforces_no_negative() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -279,7 +278,7 @@ async fn run_project(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn projects_ar_invoice_and_tax_subgrains() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -373,7 +372,7 @@ async fn projects_ar_invoice_and_tax_subgrains() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn projects_unallocated_balance_and_enforces_no_negative() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -513,7 +512,7 @@ async fn projects_unallocated_balance_and_enforces_no_negative() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn stamps_ar_invoice_original_posted_at_and_due_date_first_write_wins() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_provisioning.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_provisioning.rs
@@ -27,7 +27,6 @@ use bss_ledger_sdk::{
 };
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -90,7 +89,7 @@ fn utc_calendar() -> FiscalCalendarSpec {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn provision_is_idempotent_and_additive() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -262,7 +261,7 @@ async fn provision_is_idempotent_and_additive() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn provision_rolls_back_on_out_of_range_scale() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_queue.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_queue.rs
@@ -71,7 +71,7 @@ async fn boot() -> (
     sea_orm::DatabaseConnection,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_queue_concurrency.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_queue_concurrency.rs
@@ -74,7 +74,7 @@ async fn boot() -> (
     sea_orm::DatabaseConnection,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_read_surface.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_read_surface.rs
@@ -16,7 +16,7 @@
 //! Rows are seeded by RAW SQL `INSERT` directly into `bss.ledger_*` (the simplest
 //! reliable way to populate a read test — mirrors `postgres_refund_dispute_hold.rs`
 //! / `postgres_credit_note.rs`), for two tenants A and B. The shared harness
-//! (the `pg()` helper, `Postgres::default().start()`,
+//! (the `pg()` helper, `test_containers::postgres().start()`,
 //! `Migrator::up`, the `search_path=bss,public` provider) is duplicated from
 //! `postgres_refund.rs` per the established convention (no shared module across
 //! these test files). Ignored by default; run with `-- --ignored` (needs Docker).
@@ -43,7 +43,6 @@ use bss_ledger_sdk::ODataQuery;
 use chrono::{DateTime, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement, TransactionTrait};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -252,7 +251,7 @@ async fn seed_journal_entry(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn refund_list_is_tenant_scoped() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = boot(&url).await;
@@ -304,7 +303,7 @@ async fn refund_list_is_tenant_scoped() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn refund_by_id_foreign_tenant_is_none() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = boot(&url).await;
@@ -348,7 +347,7 @@ async fn refund_by_id_foreign_tenant_is_none() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn refund_list_cursor_paginates() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = boot(&url).await;
@@ -425,7 +424,7 @@ async fn refund_list_cursor_paginates() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn refund_list_filter_narrows() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = boot(&url).await;
@@ -468,7 +467,7 @@ async fn refund_list_filter_narrows() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn credit_note_list_is_tenant_scoped() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = boot(&url).await;
@@ -494,7 +493,7 @@ async fn credit_note_list_is_tenant_scoped() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn credit_note_by_id_foreign_tenant_is_none() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = boot(&url).await;
@@ -525,7 +524,7 @@ async fn credit_note_by_id_foreign_tenant_is_none() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn debit_note_list_is_tenant_scoped() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = boot(&url).await;
@@ -551,7 +550,7 @@ async fn debit_note_list_is_tenant_scoped() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn debit_note_by_id_foreign_tenant_is_none() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = boot(&url).await;
@@ -582,7 +581,7 @@ async fn debit_note_by_id_foreign_tenant_is_none() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn dispute_list_is_tenant_scoped() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = boot(&url).await;
@@ -608,7 +607,7 @@ async fn dispute_list_is_tenant_scoped() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn dispute_by_id_foreign_tenant_is_none() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = boot(&url).await;
@@ -639,7 +638,7 @@ async fn dispute_by_id_foreign_tenant_is_none() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn recognition_run_list_is_tenant_scoped() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = boot(&url).await;
@@ -666,7 +665,7 @@ async fn recognition_run_list_is_tenant_scoped() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn recognition_run_by_id_foreign_tenant_is_none() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = boot(&url).await;
@@ -701,7 +700,7 @@ async fn recognition_run_by_id_foreign_tenant_is_none() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn journal_entries_list_is_tenant_scoped() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = boot(&url).await;
@@ -748,7 +747,7 @@ async fn journal_entries_list_is_tenant_scoped() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn dual_control_policy_effective_read_resolves_and_is_scoped() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = boot(&url).await;
@@ -789,7 +788,7 @@ async fn dual_control_policy_effective_read_resolves_and_is_scoped() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn dual_control_policy_absent_row_yields_no_effective_version() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (_raw, provider) = boot(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_recognition_build.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_recognition_build.rs
@@ -48,7 +48,6 @@ use bss_ledger_sdk::{AccountClass, Side};
 use chrono::NaiveDate;
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -289,7 +288,7 @@ async fn schedule_count(raw: &DatabaseConnection, s: &Seller, invoice_id: &str) 
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn deferred_invoice_materializes_schedule_in_one_txn() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -362,7 +361,7 @@ async fn deferred_invoice_materializes_schedule_in_one_txn() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn over_ceiling_derivation_rolls_back_the_whole_post() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -417,7 +416,7 @@ async fn over_ceiling_derivation_rolls_back_the_whole_post() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn duplicate_build_lands_on_existing_active_schedule() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -479,7 +478,7 @@ async fn duplicate_build_lands_on_existing_active_schedule() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn non_deferred_invoice_posts_with_no_schedule_or_cl_line() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -539,7 +538,7 @@ async fn non_deferred_invoice_posts_with_no_schedule_or_cl_line() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn list_schedules_filters_by_invoice_and_stream_and_is_tenant_scoped() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (_raw, provider, s) = setup(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_recognition_change.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_recognition_change.rs
@@ -52,7 +52,6 @@ use bss_ledger_sdk::{AccountClass, ChangeRecognitionSchedule, ChangeSegment, Sid
 use chrono::NaiveDate;
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -369,7 +368,7 @@ fn seg(period_id: &str, amount: i64) -> ChangeSegment {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn replace_prospective_re_plans_remaining_and_old_segments_do_not_release() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -530,7 +529,7 @@ async fn replace_prospective_re_plans_remaining_and_old_segments_do_not_release(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn cancel_marks_cancelled_and_later_run_releases_nothing() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -605,7 +604,7 @@ async fn cancel_marks_cancelled_and_later_run_releases_nothing() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn catch_up_treatment_is_review_and_leaves_schedule_active() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -655,7 +654,7 @@ async fn catch_up_treatment_is_review_and_leaves_schedule_active() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn replace_is_idempotent_on_change_id() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -775,7 +774,7 @@ fn replace_cmd(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn replace_with_descending_periods_is_rejected() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -815,7 +814,7 @@ async fn replace_with_descending_periods_is_rejected() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn replace_with_duplicate_period_is_rejected() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -849,7 +848,7 @@ async fn replace_with_duplicate_period_is_rejected() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn replace_with_malformed_period_is_rejected() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -880,7 +879,7 @@ async fn replace_with_malformed_period_is_rejected() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn replace_overlapping_an_already_done_period_is_rejected() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_recognition_disaggregation.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_recognition_disaggregation.rs
@@ -47,7 +47,6 @@ use bss_ledger_sdk::{AccountClass, RecognitionRunOutcome, Side};
 use chrono::NaiveDate;
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -303,7 +302,7 @@ async fn bal(raw: &DatabaseConnection, s: &Seller, account: Uuid) -> Option<i64>
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn per_stream_bundle_drains_each_stream_and_disaggregates() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -497,7 +496,7 @@ async fn per_stream_bundle_drains_each_stream_and_disaggregates() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn missed_close_disaggregates_under_the_open_period() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await; // setup opens 202606 + seeds accounts

--- a/gears/bss/ledger/ledger/tests/postgres_recognition_run.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_recognition_run.rs
@@ -58,7 +58,6 @@ use bss_ledger_sdk::{AccountClass, RecognitionRunOutcome, Side};
 use chrono::NaiveDate;
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -359,7 +358,7 @@ async fn segment_status(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn run_releases_atomically_and_is_not_double_credited() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -452,7 +451,7 @@ async fn run_releases_atomically_and_is_not_double_credited() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn over_recognition_blocked_at_per_schedule_check_with_sibling_positive() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -538,7 +537,7 @@ async fn over_recognition_blocked_at_per_schedule_check_with_sibling_positive() 
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn reversal_decrements_and_segment_stays_done() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -639,7 +638,7 @@ async fn reversal_decrements_and_segment_stays_done() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn racing_runs_credit_each_segment_exactly_once() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -710,7 +709,7 @@ async fn queued_successor_drains_behind_its_predecessor_in_one_pass() {
     // segment_no, is released first in the same ascending pass). Pins that a
     // QUEUED segment is not stuck — it is picked up and drained behind its
     // predecessor, never ahead of it.
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -807,7 +806,7 @@ async fn queued_successor_re_parks_when_predecessor_excluded_from_window() {
     // successor but NOT its still-un-DONE predecessor (a narrower run target),
     // the successor is re-parked QUEUED (the §4.6 gate holds) — never released
     // ahead of its predecessor — and a LATER, wider run drains it.
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -903,7 +902,7 @@ fn recognized_item_no_link(amount: i64, periods: u32, first_period: &str) -> Inv
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn get_schedule_returns_header_and_segments_and_none_when_absent() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -973,7 +972,7 @@ async fn get_schedule_returns_header_and_segments_and_none_when_absent() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn deferred_post_without_invoice_link_is_rejected() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -1082,7 +1081,7 @@ async fn try_insert_active_schedule(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn drained_schedule_completes_and_frees_the_one_live_slot() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_reconciliation.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_reconciliation.rs
@@ -38,7 +38,6 @@ use bss_ledger_sdk::{
 };
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
 use toolkit_security::SecurityContext;
@@ -260,7 +259,7 @@ async fn boot(url: &str) -> (DatabaseConnection, DBProvider<DbError>, Uuid) {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn k1_ar_variance_opens_recon_mismatch_and_blocks_close() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, tenant) = boot(&url).await;
@@ -324,7 +323,7 @@ async fn k1_ar_variance_opens_recon_mismatch_and_blocks_close() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn k2_missed_posting_blocks_then_idempotent_repost_clears() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, tenant) = boot(&url).await;
@@ -426,7 +425,7 @@ async fn k2_missed_posting_blocks_then_idempotent_repost_clears() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn k3_psp_variance_opens_exception() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, tenant) = boot(&url).await;
@@ -477,7 +476,7 @@ async fn k3_psp_variance_opens_exception() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn k6_psp_check_is_period_scoped() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, tenant) = boot(&url).await;
@@ -533,7 +532,7 @@ async fn k6_psp_check_is_period_scoped() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn k7_fx_revaluation_gate_blocks_until_marker() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, tenant) = boot(&url).await;
@@ -589,7 +588,7 @@ async fn k7_fx_revaluation_gate_blocks_until_marker() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn k4_bill_run_gate_blocks_until_asserted() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, tenant) = boot(&url).await;
@@ -660,7 +659,7 @@ async fn k4_bill_run_gate_blocks_until_asserted() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn k5_inert_until_feed_lands() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, tenant) = boot(&url).await;
@@ -720,7 +719,7 @@ async fn k5_inert_until_feed_lands() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn k5b_unconfigured_psp_check_is_inert() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, tenant) = boot(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_reference.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_reference.rs
@@ -26,7 +26,7 @@ async fn boot() -> (
     testcontainers_modules::testcontainers::ContainerAsync<Postgres>,
     DatabaseConnection,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let db = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_refund.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_refund.rs
@@ -60,7 +60,6 @@ use bss_ledger_sdk::{AccountClass, Side};
 use chrono::{DateTime, Datelike, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::{AccessScope, DbTx};
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -409,7 +408,7 @@ fn clawback_req(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn pattern_a_two_stage_drains_refund_clearing_to_zero() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -490,7 +489,7 @@ async fn pattern_a_two_stage_drains_refund_clearing_to_zero() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn pattern_b_two_stage_restores_ar_then_drains_clearing() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -567,7 +566,7 @@ async fn pattern_b_two_stage_restores_ar_then_drains_clearing() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn refund_against_unsettled_payment_is_origin_not_found() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -603,7 +602,7 @@ async fn refund_against_unsettled_payment_is_origin_not_found() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn refund_currency_mismatch_is_rejected() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (_raw, provider, s) = setup(&url).await;
@@ -636,7 +635,7 @@ async fn refund_currency_mismatch_is_rejected() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn refund_stage_is_idempotent_on_psp_phase() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -690,7 +689,7 @@ async fn refund_stage_is_idempotent_on_psp_phase() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn stage1_initiation_reserves_refunded_cap_both_patterns() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -760,7 +759,7 @@ async fn stage1_initiation_reserves_refunded_cap_both_patterns() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn stage1_over_settled_is_refund_exceeds_settled() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -807,7 +806,7 @@ async fn stage1_over_settled_is_refund_exceeds_settled() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn pattern_a_refund_consumes_unallocated_headroom() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -867,7 +866,7 @@ async fn pattern_a_refund_consumes_unallocated_headroom() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn pattern_b_per_invoice_cap_blocks_over_allocated() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -931,7 +930,7 @@ async fn pattern_b_per_invoice_cap_blocks_over_allocated() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn rejected_stage1_reverses_and_frees_cap() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -1059,7 +1058,7 @@ async fn rejected_stage1_reverses_and_frees_cap() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn reject_without_stage1_is_invalid_request() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -1200,7 +1199,7 @@ async fn pending_refund_approvals(raw: &DatabaseConnection, s: &Seller) -> i64 {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn refund_over_threshold_gates_then_a_second_actor_approve_posts_it() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -1304,7 +1303,7 @@ async fn refund_over_threshold_gates_then_a_second_actor_approve_posts_it() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn preparer_cannot_self_approve_their_refund() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -1381,7 +1380,7 @@ async fn preparer_cannot_self_approve_their_refund() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn refund_under_threshold_posts_inline_without_an_approval() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -1463,7 +1462,7 @@ async fn age_clawback_row(raw: &DatabaseConnection, s: &Seller) {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn clawback_after_outbound_decrements_net_refunded() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -1560,7 +1559,7 @@ async fn clawback_after_outbound_decrements_net_refunded() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn additional_outbound_refund_of_refund_increments_under_cap() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -1624,7 +1623,7 @@ async fn additional_outbound_refund_of_refund_increments_under_cap() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn out_of_order_clawback_defers_then_applies_after_outbound() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -1727,7 +1726,7 @@ async fn out_of_order_clawback_defers_then_applies_after_outbound() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn never_reconciled_clawback_is_cancelled_and_escalated() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -1840,7 +1839,7 @@ impl SecuredAuditSink for SpyAuditSink {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn unknown_final_parks_refund_clearing_to_suspense_and_audits() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -2053,7 +2052,7 @@ async fn open_dispute(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn quarantine_then_settle_drains_and_posts() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -2125,7 +2124,7 @@ async fn quarantine_then_settle_drains_and_posts() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn quarantine_drain_still_missing_backs_off() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -2179,7 +2178,7 @@ async fn quarantine_drain_still_missing_backs_off() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn quarantine_aged_out_is_cancelled_and_escalated() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -2235,7 +2234,7 @@ async fn quarantine_aged_out_is_cancelled_and_escalated() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn quarantine_over_threshold_awaits_approval() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -2304,7 +2303,7 @@ async fn quarantine_over_threshold_awaits_approval() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn quarantine_drain_into_open_dispute_marks_applied() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -2367,7 +2366,7 @@ async fn quarantine_drain_into_open_dispute_marks_applied() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn out_of_order_clawback_replay_resignals_deferred() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -2437,7 +2436,7 @@ async fn out_of_order_clawback_replay_resignals_deferred() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn applied_clawback_replay_returns_posted() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -2537,7 +2536,7 @@ async fn applied_clawback_replay_returns_posted() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn quarantine_conflict_payload_is_idempotency_conflict() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_refund_dispute_hold.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_refund_dispute_hold.rs
@@ -60,7 +60,6 @@ use bss_ledger_sdk::{AccountClass, Side};
 use chrono::{Datelike, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -408,7 +407,7 @@ fn clawback_req(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn forward_refund_on_payment_with_open_dispute_is_held() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -534,7 +533,7 @@ async fn forward_refund_on_payment_with_open_dispute_is_held() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn clawback_on_payment_with_open_dispute_is_not_held() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -708,7 +707,7 @@ async fn age_dispute_hold_row(raw: &DatabaseConnection, s: &Seller) {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn dispute_hold_drain_won_redrives_and_posts() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -776,7 +775,7 @@ async fn dispute_hold_drain_won_redrives_and_posts() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn dispute_hold_drain_lost_cancels_never_posts() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -843,7 +842,7 @@ async fn dispute_hold_drain_lost_cancels_never_posts() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn dispute_hold_drain_still_open_backs_off() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -896,7 +895,7 @@ async fn dispute_hold_drain_still_open_backs_off() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn dispute_hold_aged_out_escalates() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;
@@ -954,7 +953,7 @@ async fn dispute_hold_aged_out_escalates() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn dispute_hold_won_over_threshold_awaits_approval() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider, s) = setup(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_refund_fx.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_refund_fx.rs
@@ -127,7 +127,7 @@ async fn setup_and_settle(
     DBProvider<DbError>,
     Chart,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_retention.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_retention.rs
@@ -37,7 +37,6 @@ use sea_orm::{
     ColumnTrait, Condition, ConnectionTrait, Database, DatabaseConnection, EntityTrait, Statement,
 };
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::{AccessScope, SecureEntityExt};
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -126,7 +125,7 @@ fn bytea(hash: &[u8]) -> String {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn checkpoint_derives_count_and_rejects_noncontiguous() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = setup(&url).await;
@@ -208,7 +207,7 @@ async fn checkpoint_derives_count_and_rejects_noncontiguous() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn detach_gate_requires_sealed_and_checkpoint_covered() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let (raw, provider) = setup(&url).await;

--- a/gears/bss/ledger/ledger/tests/postgres_revaluation_fx.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_revaluation_fx.rs
@@ -54,7 +54,6 @@ use bss_ledger_sdk::{AccountClass, MappingStatus, Side, SourceDocType};
 use chrono::{Datelike, NaiveDate, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -100,7 +99,7 @@ fn account(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn cross_currency_revaluation_then_next_period_reversal() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -407,7 +406,7 @@ async fn cross_currency_revaluation_then_next_period_reversal() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn revaluation_with_no_period_end_rate_is_fx_rate_unavailable() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_scale_lock.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_scale_lock.rs
@@ -19,7 +19,6 @@ use bss_ledger::infra::storage::migrations::Migrator;
 use bss_ledger::infra::storage::repo::ReferenceRepo;
 use sea_orm::{ConnectionTrait, Database, Statement, TransactionTrait};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
 use uuid::Uuid;
@@ -31,7 +30,7 @@ fn pg(sql: impl Into<String>) -> Statement {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn scale_locked_once_postings_exist() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/postgres_schema.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_schema.rs
@@ -12,7 +12,6 @@
 
 use sea_orm::{ConnectionTrait, Database, Statement};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 
 use bss_ledger::infra::storage::migrations::Migrator;
@@ -20,7 +19,7 @@ use bss_ledger::infra::storage::migrations::Migrator;
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn migrator_creates_bss_schema() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let db = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_settlement_return_fx.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_settlement_return_fx.rs
@@ -156,7 +156,7 @@ async fn setup_and_settle(
     DBProvider<DbError>,
     Chart,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/postgres_tieout.rs
+++ b/gears/bss/ledger/ledger/tests/postgres_tieout.rs
@@ -41,7 +41,6 @@ use bss_ledger_sdk::{AccountClass, MappingStatus, Side, SourceDocType};
 use chrono::{Datelike, NaiveDate, Utc};
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement, TransactionTrait};
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit_db::secure::AccessScope;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -240,7 +239,7 @@ fn noop_publisher() -> Arc<LedgerEventPublisher> {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn clean_tenant_ties_out() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -265,7 +264,7 @@ async fn clean_tenant_ties_out() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn account_balance_drift_is_detected() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -302,7 +301,7 @@ async fn account_balance_drift_is_detected() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn ar_sub_grain_drift_is_detected() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -337,7 +336,7 @@ async fn ar_sub_grain_drift_is_detected() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn pending_mapping_is_flagged() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -373,7 +372,7 @@ async fn pending_mapping_is_flagged() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn entry_balance_backstop_catches_imbalanced_entry() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -465,7 +464,7 @@ async fn entry_balance_backstop_catches_imbalanced_entry() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn entry_backstop_catches_mixed_payer_entry() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -565,7 +564,7 @@ async fn entry_backstop_catches_mixed_payer_entry() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn run_emits_negative_grain_and_entry_imbalance_arms() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -866,7 +865,7 @@ async fn seed_ar_invoice(
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn payment_counter_reconcile_through_full_tie_out() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
@@ -988,7 +987,7 @@ async fn payment_counter_reconcile_through_full_tie_out() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn incremental_tie_out_covers_reusable_credit_grain() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 

--- a/gears/bss/ledger/ledger/tests/rest_adjustments.rs
+++ b/gears/bss/ledger/ledger/tests/rest_adjustments.rs
@@ -213,7 +213,7 @@ async fn boot() -> (
     DBProvider<DbError>,
     Seller,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/rest_audit.rs
+++ b/gears/bss/ledger/ledger/tests/rest_audit.rs
@@ -48,7 +48,6 @@ use bss_ledger::infra::pii::ErasureService;
 use bss_ledger::infra::storage::migrations::Migrator;
 use sea_orm::Database;
 use sea_orm_migration::MigratorTrait;
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use toolkit::api::OpenApiRegistryImpl;
 use toolkit_db::{ConnectOpts, DBProvider, DbError, connect_db};
@@ -147,7 +146,7 @@ async fn body_string(response: axum::http::Response<Body>) -> String {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn cross_tenant_tamper_status_denied_returns_403() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let provider = provider_for(&url).await;
@@ -191,7 +190,7 @@ async fn cross_tenant_tamper_status_denied_returns_403() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn cross_tenant_erasure_without_reason_returns_400() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let provider = provider_for(&url).await;
@@ -245,7 +244,7 @@ async fn cross_tenant_erasure_without_reason_returns_400() {
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn cross_tenant_erasure_unauthorized_returns_403() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let provider = provider_for(&url).await;

--- a/gears/bss/ledger/ledger/tests/rest_credit.rs
+++ b/gears/bss/ledger/ledger/tests/rest_credit.rs
@@ -420,7 +420,7 @@ async fn boot() -> (
     sea_orm::DatabaseConnection,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/rest_disputes.rs
+++ b/gears/bss/ledger/ledger/tests/rest_disputes.rs
@@ -390,7 +390,7 @@ async fn boot() -> (
     sea_orm::DatabaseConnection,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/rest_payments.rs
+++ b/gears/bss/ledger/ledger/tests/rest_payments.rs
@@ -479,7 +479,7 @@ async fn boot() -> (
     sea_orm::DatabaseConnection,
     DBProvider<DbError>,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/ledger/ledger/tests/rest_refunds.rs
+++ b/gears/bss/ledger/ledger/tests/rest_refunds.rs
@@ -212,7 +212,7 @@ async fn boot() -> (
     DBProvider<DbError>,
     Seller,
 ) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let raw = Database::connect(&url).await.unwrap();

--- a/gears/bss/libs/coord/Cargo.toml
+++ b/gears/bss/libs/coord/Cargo.toml
@@ -56,3 +56,4 @@ tokio = { workspace = true, features = [
   "sync",
 ] }
 testcontainers-modules = { workspace = true }
+test-containers = { workspace = true }

--- a/gears/bss/libs/coord/tests/postgres_fence.rs
+++ b/gears/bss/libs/coord/tests/postgres_fence.rs
@@ -47,7 +47,6 @@ use toolkit_security::AccessScope;
 
 use coord::{AckError, LeaseManager};
 
-use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 
 const KEY: &str = "fence-job";
@@ -114,7 +113,7 @@ async fn force_expire(db: &Db) {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires Docker (testcontainers)"]
 async fn fence_rejects_a_lease_stolen_after_the_ack_snapshot() {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let db = setup(&url).await;

--- a/gears/bss/libs/coord/tests/postgres_two_gear_migration.rs
+++ b/gears/bss/libs/coord/tests/postgres_two_gear_migration.rs
@@ -47,7 +47,7 @@ use testcontainers_modules::testcontainers::runners::AsyncRunner;
 /// A bare sea-orm connection rather than the toolkit `Db` the lease tests use:
 /// the subject is the migration's SQL and `SchemaManager` is what applies it.
 async fn fresh_pg() -> (ContainerAsync<Postgres>, DatabaseConnection) {
-    let container = Postgres::default().start().await.unwrap();
+    let container = test_containers::postgres().start().await.unwrap();
     let port = container.get_host_port_ipv4(5432).await.unwrap();
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
     let conn = Database::connect(&url).await.expect("connect postgres");

--- a/gears/bss/pricing/pricing/Cargo.toml
+++ b/gears/bss/pricing/pricing/Cargo.toml
@@ -147,6 +147,9 @@ serde_json = { workspace = true }
 # D-159 and D-135 describe — SQLite serializes writers, so it can neither
 # confirm nor refute a claim about two of them.
 testcontainers-modules = { workspace = true }
+# Pins the image tag used by test_containers::postgres_tagged(PG_TAG); see the
+# same rationale in libs/toolkit-db and docs/TESTING.md 4.4.
+test-containers = { workspace = true }
 toolkit = { workspace = true, features = ["db"] }
 # `tower::ServiceExt::oneshot` drives the REST router in `tests/rest_*.rs`
 # without binding a socket.

--- a/gears/bss/pricing/pricing/tests/pg_support/mod.rs
+++ b/gears/bss/pricing/pricing/tests/pg_support/mod.rs
@@ -162,6 +162,13 @@ use toolkit_db::{ConnectOpts, Db, connect_db};
 
 /// The image tag every Postgres suite pins, matching `postgres_migrations.rs`;
 /// see its note on why the image default is not used.
+///
+/// Below the workspace floor (`test_containers::POSTGRES_TAG`) on purpose: this
+/// suite's own floor predates it and nothing here depends on 18-only behavior.
+/// Going through `postgres_tagged` rather than `postgres().with_tag(PG_TAG)`
+/// keeps this floor overridable by `GEARS_TEST_PG_TAG` for a CI version matrix
+/// — chaining `.with_tag` onto the workspace default would silently opt out of
+/// it (docs/TESTING.md 4.4).
 pub const PG_TAG: &str = "16-alpine";
 
 /// The one container's name — fixed, so a later run finds it instead of
@@ -292,8 +299,7 @@ async fn start_named() -> Option<ContainerAsync<Postgres>> {
         // Bound per iteration rather than carried across them: the sibling check
         // below returns without reading it, which makes a loop-scoped `last` a
         // dead assignment on that path (`-D unused-assignments`).
-        let last = match Postgres::default()
-            .with_tag(PG_TAG)
+        let last = match test_containers::postgres_tagged(PG_TAG)
             .with_container_name(HARNESS_CONTAINER)
             .start()
             .await

--- a/gears/bss/pricing/pricing/tests/postgres_migrations.rs
+++ b/gears/bss/pricing/pricing/tests/postgres_migrations.rs
@@ -68,8 +68,8 @@ use bss_pricing::infra::storage::migrations::Migrator;
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
 use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::ContainerAsync;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
-use testcontainers_modules::testcontainers::{ContainerAsync, ImageExt};
 use toolkit_db::migration_runner::run_migrations_for_testing;
 use toolkit_db::{ConnectOpts, connect_db};
 
@@ -91,11 +91,9 @@ fn chain_len() -> usize {
     Migrator::migrations().len()
 }
 
-/// `testcontainers-modules` defaults to `postgres:11-alpine`, which reached end
-/// of life in 2023. Nothing in this repository pins the production server
-/// version, so "the backend it targets" is an assumption either way; running on
-/// a current major is the closer of the two guesses, and pinning it here means a
-/// bump is a diff rather than a dependency's default quietly moving.
+/// Below the workspace floor (`test_containers::POSTGRES_TAG`) on purpose,
+/// matching `pg_support::PG_TAG`; see its note on why `postgres_tagged` and not
+/// the bare default. `GEARS_TEST_PG_TAG` still overrides it.
 const PG_TAG: &str = "16-alpine";
 
 /// A running Postgres, its port, and the container guard.
@@ -103,8 +101,7 @@ const PG_TAG: &str = "16-alpine";
 /// The guard is returned because dropping it stops the container: a caller that
 /// bound only the port would race its own database to the end of the test.
 async fn pg() -> (u16, ContainerAsync<Postgres>) {
-    let container = Postgres::default()
-        .with_tag(PG_TAG)
+    let container = test_containers::postgres_tagged(PG_TAG)
         .start()
         .await
         .expect("start postgres");

--- a/gears/system/account-management/account-management/Cargo.toml
+++ b/gears/system/account-management/account-management/Cargo.toml
@@ -118,3 +118,4 @@ opentelemetry_sdk = { workspace = true, features = ["testing"] }
 # not require Docker.
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
+test-containers = { workspace = true }

--- a/gears/system/account-management/account-management/tests/common/mod.rs
+++ b/gears/system/account-management/account-management/tests/common/mod.rs
@@ -1669,7 +1669,7 @@ pub mod pg {
 
     use anyhow::Result;
     use sea_orm::ConnectionTrait;
-    use testcontainers::{ContainerRequest, ImageExt, runners::AsyncRunner};
+    use testcontainers::{ImageExt, runners::AsyncRunner};
     use testcontainers_modules::postgres::Postgres;
     use toolkit_db::migration_runner::run_migrations_for_testing;
     use toolkit_db::{ConnectOpts, connect_db};
@@ -1702,8 +1702,7 @@ pub mod pg {
     /// — a missing Docker daemon shows up as a clear container-start
     /// failure rather than a silent skip.
     pub async fn bring_up_postgres() -> Result<PgHarness> {
-        let postgres_image = Postgres::default();
-        let request = ContainerRequest::from(postgres_image)
+        let request = test_containers::postgres()
             .with_env_var("POSTGRES_PASSWORD", "pass")
             .with_env_var("POSTGRES_USER", "user")
             .with_env_var("POSTGRES_DB", "app");

--- a/gears/system/cluster/cluster/Cargo.toml
+++ b/gears/system/cluster/cluster/Cargo.toml
@@ -53,6 +53,7 @@ testcontainers = { workspace = true, optional = true }
 testcontainers-modules = { workspace = true, optional = true }
 
 [dev-dependencies]
+test-containers = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "test-util"] }
 serde-saphyr = { workspace = true }
 uuid = { workspace = true }

--- a/gears/system/cluster/cluster/tests/mixed_backend_integration.rs
+++ b/gears/system/cluster/cluster/tests/mixed_backend_integration.rs
@@ -91,8 +91,7 @@ async fn spawn_postgres() -> (ContainerAsync<Postgres>, String) {
     let attempts = backoffs.len() + 1;
     let mut last_error = String::new();
     for attempt in 1..=attempts {
-        let container = match Postgres::default()
-            .with_db_name("cluster_test")
+        let container = match test_containers::postgres_named("cluster_test")
             .start()
             .await
         {

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/Cargo.toml
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/Cargo.toml
@@ -100,6 +100,7 @@ testcontainers = { workspace = true, optional = true }
 testcontainers-modules = { workspace = true, optional = true }
 
 [dev-dependencies]
+test-containers = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 # `pg_spec_006` reads the `cluster_postgres_lock_active_names` gauge back through
 # an in-process OTel reader (`InMemoryMetricExporter`, gated by the `testing`

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/docs/TESTING.md
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/docs/TESTING.md
@@ -168,9 +168,11 @@ Before this turn, `leader_conformance` was missing entirely — only the cache a
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
 
+// Image tags are pinned workspace-wide in `libs/test-containers`; never call
+// `Postgres::default()` here (see /docs/TESTING.md §4.4).
+
 pub async fn start_postgres() -> (ContainerAsync<Postgres>, PostgresClusterConfig) {
-    let container = Postgres::default()
-        .with_db_name("cluster_test")
+    let container = test_containers::postgres_named("cluster_test")
         .start()
         .await
         .expect("Postgres container starts");
@@ -190,8 +192,7 @@ pub async fn start_postgres() -> (ContainerAsync<Postgres>, PostgresClusterConfi
 /// Same container, but returns `PostgresLockConfig` (§3.5 DESIGN.md) for tests
 /// exercising the standalone lock-only provider path.
 pub async fn start_postgres_lock_only() -> (ContainerAsync<Postgres>, PostgresLockConfig) {
-    let container = Postgres::default()
-        .with_db_name("cluster_test")
+    let container = test_containers::postgres_named("cluster_test")
         .start()
         .await
         .expect("Postgres container starts");

--- a/gears/system/cluster/plugins/postgres-cluster-plugin/tests/common/mod.rs
+++ b/gears/system/cluster/plugins/postgres-cluster-plugin/tests/common/mod.rs
@@ -104,8 +104,7 @@ async fn spawn_postgres() -> (ContainerAsync<Postgres>, String) {
     let attempts = backoffs.len() + 1;
     let mut last_error = String::new();
     for attempt in 1..=attempts {
-        let container = match Postgres::default()
-            .with_db_name("cluster_test")
+        let container = match test_containers::postgres_named("cluster_test")
             .start()
             .await
         {

--- a/gears/system/resource-group/resource-group/Cargo.toml
+++ b/gears/system/resource-group/resource-group/Cargo.toml
@@ -95,6 +95,7 @@ toolkit-db = { workspace = true, features = ["sqlite", "pg", "test-support"] }
 # Cargo.toml), used here as test-only dev-dependencies.
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
+test-containers = { workspace = true }
 tower = { workspace = true }
 http-body-util = { workspace = true }
 # Enable the SDK `test-util` feature so integration-test fakes can build the

--- a/gears/system/resource-group/resource-group/tests/pg_smoke_test.rs
+++ b/gears/system/resource-group/resource-group/tests/pg_smoke_test.rs
@@ -72,7 +72,7 @@ use resource_group::infra::storage::type_repo::TypeRepository;
 use resource_group_sdk::{CreateTypeRequest, UpdateTypeRequest};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
 use sea_orm_migration::MigratorTrait;
-use testcontainers::{ContainerRequest, ImageExt, runners::AsyncRunner};
+use testcontainers::{ImageExt, runners::AsyncRunner};
 use testcontainers_modules::postgres::Postgres;
 use toolkit_db::secure::{SecureEntityExt, secure_insert};
 use toolkit_db::{
@@ -107,11 +107,9 @@ fn require_docker() -> bool {
 /// graceful skip. Skipping is right locally, but wrong in CI, where a broken
 /// daemon would otherwise pass vacuously -- `RG_PG_REQUIRE_DOCKER=1` panics.
 async fn pg_fixture() -> Option<PgFixture> {
-    // testcontainers-modules' Postgres image defaults to "11-alpine", which
-    // predates gen_random_uuid() becoming a built-in (PG13+) -- RG's
-    // migrations use it, so pin a modern tag.
-    let request = ContainerRequest::from(Postgres::default())
-        .with_tag("16-alpine")
+    // No local tag override: the workspace floor is now PG 18, well past the
+    // PG13 that made gen_random_uuid() built-in (RG's migrations use it).
+    let request = test_containers::postgres()
         .with_env_var("POSTGRES_PASSWORD", "pass")
         .with_env_var("POSTGRES_USER", "user")
         .with_env_var("POSTGRES_DB", "app");

--- a/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/Cargo.toml
+++ b/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/Cargo.toml
@@ -73,6 +73,7 @@ inventory = { workspace = true }
 tokio = { workspace = true }
 # Unconditional: [dev-dependencies] can't be optional; usage is #![cfg(feature="postgres")]-gated.
 testcontainers = { workspace = true }
+test-containers = { workspace = true }
 # In-memory metric reader for the metrics-recording unit tests; the `testing`
 # feature gates `InMemoryMetricExporter`.
 opentelemetry_sdk = { workspace = true, features = ["testing"] }

--- a/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/storage/error.rs
+++ b/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/storage/error.rs
@@ -41,7 +41,14 @@ pub fn classify_db(code: &str, constraint: Option<&str>) -> DbErrorClass {
             Some("usage_type_catalog_pkey") => DbErrorClass::CatalogUniqueViolation,
             _ => DbErrorClass::Other,
         },
-        "23503" => DbErrorClass::ForeignKeyViolation,
+        // 23503 `foreign_key_violation` is what PostgreSQL <= 17 reports for the
+        // `usage_records.gts_id` -> catalog RESTRICT guard. PostgreSQL 18
+        // reports the standard 23001 `restrict_violation` for `ON DELETE
+        // RESTRICT` instead ("violates RESTRICT setting of foreign key
+        // constraint ..."), so both codes mean the same thing to this plugin:
+        // the row is still referenced. Verified against
+        // timescale/timescaledb:2.17.2-pg16 (23503) and 2.29.2-pg18 (23001).
+        "23503" | "23001" => DbErrorClass::ForeignKeyViolation,
         c if is_transient_sqlstate(c) => DbErrorClass::Transient,
         _ => DbErrorClass::Other,
     }

--- a/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/storage/error_tests.rs
+++ b/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/src/infra/storage/error_tests.rs
@@ -38,6 +38,18 @@ fn fk_violation_is_type_referenced() {
         DbErrorClass::ForeignKeyViolation
     );
 }
+
+/// `PostgreSQL` 18 reports `ON DELETE RESTRICT` as the standard 23001
+/// `restrict_violation`, where <= 17 reported 23503. Both are "the row is
+/// still referenced" for this plugin; dropping either one would turn a
+/// `UsageTypeReferenced` back into an opaque `Internal`.
+#[test]
+fn restrict_violation_is_also_type_referenced() {
+    assert_eq!(
+        classify_db("23001", Some("usage_records_gts_id_fk")),
+        DbErrorClass::ForeignKeyViolation
+    );
+}
 #[test]
 fn connection_class_is_transient() {
     assert_eq!(classify_db("08006", None), DbErrorClass::Transient);

--- a/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/tests/common/mod.rs
+++ b/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/tests/common/mod.rs
@@ -119,10 +119,11 @@ pub async fn bring_up_with(
     pool_size_max: u32,
     retention_secs: u64,
 ) -> anyhow::Result<TsHarness> {
-    // Keep this image tag in sync with `TimescaleDbSidecar.IMAGE` in
-    // `testing/e2e/lib/sidecars.py`. A skew means these migrations are
-    // validated against a different PostgreSQL major than E2E runs.
-    let image = GenericImage::new("timescale/timescaledb", "2.17.2-pg16")
+    // The tag lives in `test_containers::TIMESCALEDB_TAG`; keep that constant
+    // in sync with `TimescaleDbSidecar.IMAGE` in `testing/e2e/lib/sidecars.py`.
+    // A skew means these migrations are validated against a different
+    // PostgreSQL major than E2E runs.
+    let image = test_containers::timescaledb()
         .with_wait_for(WaitFor::message_on_stderr(
             "database system is ready to accept connections",
         ))

--- a/libs/rustls-corecrypto-provider/tests/handshake_smoke.rs
+++ b/libs/rustls-corecrypto-provider/tests/handshake_smoke.rs
@@ -93,10 +93,10 @@ impl rustls::client::danger::ServerCertVerifier for AcceptAnyServerCert {
 /// LibreSSL (or nothing) is available, so callers can skip rather than fail.
 fn resolve_openssl() -> Option<PathBuf> {
     let mut candidates: Vec<PathBuf> = Vec::new();
-    if let Ok(p) = std::env::var("OPENSSL_BIN") {
-        if !p.is_empty() {
-            candidates.push(PathBuf::from(p));
-        }
+    if let Ok(p) = std::env::var("OPENSSL_BIN")
+        && !p.is_empty()
+    {
+        candidates.push(PathBuf::from(p));
     }
     candidates.push(PathBuf::from("openssl")); // resolved via PATH
     for p in [
@@ -312,8 +312,9 @@ fn do_handshake_and_get(
     Vec<u8>,
 ) {
     let mut sock = TcpStream::connect(("localhost", port)).expect("tcp connect");
-    sock.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
-    sock.set_write_timeout(Some(Duration::from_secs(5)))
+    sock.set_read_timeout(Some(Duration::from_secs(30)))
+        .unwrap();
+    sock.set_write_timeout(Some(Duration::from_secs(30)))
         .unwrap();
 
     let server = ServerName::try_from("localhost").unwrap();
@@ -508,8 +509,9 @@ fn run_one_request(
     // Server thread.
     let server_handle = std::thread::spawn(move || {
         let (mut tcp, _) = listener.accept().expect("accept");
-        tcp.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
-        tcp.set_write_timeout(Some(Duration::from_secs(5))).unwrap();
+        tcp.set_read_timeout(Some(Duration::from_secs(30))).unwrap();
+        tcp.set_write_timeout(Some(Duration::from_secs(30)))
+            .unwrap();
         let mut conn = ServerConnection::new(server_cfg).expect("server conn");
         let mut tls = Stream::new(&mut conn, &mut tcp);
 

--- a/libs/test-containers/Cargo.toml
+++ b/libs/test-containers/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "cf-gears-test-containers"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Pinned database container images for the workspace's integration tests (not published)"
+publish = false
+
+[lib]
+name = "test_containers"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Regular (not dev) dependencies: their types appear in this crate's public
+# signatures (`ContainerRequest<Postgres>`, `GenericImage`). They are not
+# re-exported — consumers keep their own `testcontainers` dev-dependency, which
+# keeps `Postgres::default()` unreachable through `test_containers::`.
+testcontainers = { workspace = true }
+testcontainers-modules = { workspace = true }
+
+[dev-dependencies]
+# Scoped env-var mutation for the override tests; `std::env::set_var` is
+# `unsafe` on edition 2024 and this workspace forbids `unsafe_code`.
+temp-env = { workspace = true }
+# Env-var tests mutate shared process state; `#[serial]` keeps them off each
+# other's toes.
+serial_test = { workspace = true }

--- a/libs/test-containers/src/lib.rs
+++ b/libs/test-containers/src/lib.rs
@@ -1,0 +1,557 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+//! Single source of truth for the database container images this workspace's
+//! integration tests start.
+//!
+//! Every fixture that brings up a database goes through this crate, so a
+//! version change is one edit here instead of a grep across ~240 call sites
+//! (<https://github.com/constructorfabric/gears-rust/issues/4616>).
+//!
+//! # Why not `Postgres::default()`
+//!
+//! `testcontainers-modules` hardcodes its own tags — `postgres:11-alpine` and
+//! `mysql:8.1`, both long past end of life. Calling the default constructor
+//! pins the database version transitively, through `Cargo.lock`: bumping
+//! `testcontainers-modules` then changes the database under every test in the
+//! repository with nothing in the diff to show it. [`postgres()`] and
+//! [`mysql()`] delegate to those same images but override the tag with the
+//! constants below, so the version is stated in one place and reviewed like
+//! any other change.
+//!
+//! # Overrides
+//!
+//! Each tag can be overridden by an environment variable, so CI can run a
+//! version matrix without touching code:
+//!
+//! | Variable | Overrides |
+//! |---|---|
+//! | `GEARS_TEST_PG_TAG` | [`POSTGRES_TAG`] |
+//! | `GEARS_TEST_PG_GRAPH_TAG` | [`POSTGRES_GRAPH_TAG`] |
+//! | `GEARS_TEST_MYSQL_TAG` | [`MYSQL_TAG`] |
+//! | `GEARS_TEST_TIMESCALEDB_TAG` | [`TIMESCALEDB_TAG`] |
+//! | `GEARS_TEST_MARIADB_TAG` | [`MARIADB_TAG`] |
+//!
+//! An unset *or empty* variable means "use the constant".
+//!
+//! Only concrete tags belong in the constants below. A floating alias such as
+//! `lts` or `latest` re-points under CI with nothing in the diff to show it,
+//! which is the same silent drift as `Postgres::default()`.
+//!
+//! # Usage
+//!
+//! Callers keep their own `testcontainers` dev-dependency for the runner and
+//! extension traits; this crate deliberately does not re-export them, so the
+//! banned `Postgres::default()` stays out of reach through `test_containers::`.
+//!
+//! ```no_run
+//! use testcontainers::runners::AsyncRunner;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! // Bare, on the pinned tag:
+//! let container = test_containers::postgres().start().await?;
+//!
+//! // Extra settings chain on as usual — the helper returns a
+//! // `ContainerRequest`, which `ImageExt` is implemented for:
+//! use testcontainers::ImageExt;
+//! let container = test_containers::postgres()
+//!     .with_env_var("POSTGRES_DB", "app")
+//!     .start()
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+
+use testcontainers::{ContainerRequest, GenericImage, ImageExt};
+use testcontainers_modules::{mysql::Mysql, postgres::Postgres};
+
+/// Tag of the official `postgres` image. The workspace floor.
+pub const POSTGRES_TAG: &str = "18-alpine";
+
+/// Tag of the `postgres` image for the future graph-storage gear, which needs
+/// `SQL/PGQ` (`GRAPH_TABLE`) — `PostgreSQL` 19 only.
+///
+/// Reserved: nothing consumes this yet. Pre-`GA`, so it names a beta build;
+/// replace it with `19-alpine` once `PostgreSQL` 19 ships (expected
+/// September/October 2026, see `docs/arch/secure-orm/ADR/0002`). Beta tags are
+/// routinely withdrawn from Docker Hub after `GA`, which is why
+/// [`graph_lane_required()`] defaults to `false`.
+pub const POSTGRES_GRAPH_TAG: &str = "19beta3-alpine";
+
+/// Tag of the official `mysql` image.
+///
+/// 9.7 was verified to still emit both literals
+/// `testcontainers-modules`' `Mysql::ready_conditions()` waits on
+/// (`X Plugin ready for connections. Bind-address` and
+/// `/usr/sbin/mysqld: ready for connections.`) — a reword there would hang
+/// every container to its timeout rather than fail fast.
+pub const MYSQL_TAG: &str = "9.7";
+
+/// Repository of the `TimescaleDB` image (not on Docker Hub's official list,
+/// so the name is spelled out rather than derived from an image module).
+pub const TIMESCALEDB_IMAGE: &str = "timescale/timescaledb";
+
+/// Tag of the `TimescaleDB` image.
+///
+/// Keep in sync with `TimescaleDbSidecar.IMAGE` in
+/// `testing/e2e/lib/sidecars.py`: a skew means the plugin's migrations are
+/// validated against a different `PostgreSQL` major than E2E runs.
+pub const TIMESCALEDB_TAG: &str = "2.29.2-pg18";
+
+/// Repository of the `MariaDB` image.
+pub const MARIADB_IMAGE: &str = "mariadb";
+
+/// Tag of the `MariaDB` image.
+///
+/// A concrete version, not the `lts` alias this replaced: an alias re-points
+/// across major versions on any pull, so the bench would silently change
+/// engines with nothing in the diff.
+pub const MARIADB_TAG: &str = "11.8";
+
+/// Environment variable overriding [`POSTGRES_TAG`].
+pub const ENV_POSTGRES_TAG: &str = "GEARS_TEST_PG_TAG";
+/// Environment variable overriding [`POSTGRES_GRAPH_TAG`].
+pub const ENV_POSTGRES_GRAPH_TAG: &str = "GEARS_TEST_PG_GRAPH_TAG";
+/// Environment variable overriding [`MYSQL_TAG`].
+pub const ENV_MYSQL_TAG: &str = "GEARS_TEST_MYSQL_TAG";
+/// Environment variable overriding [`TIMESCALEDB_TAG`].
+pub const ENV_TIMESCALEDB_TAG: &str = "GEARS_TEST_TIMESCALEDB_TAG";
+/// Environment variable overriding [`MARIADB_TAG`].
+pub const ENV_MARIADB_TAG: &str = "GEARS_TEST_MARIADB_TAG";
+
+/// Environment variable turning an unavailable `PostgreSQL` 19 image into a
+/// failure instead of a skip. See [`graph_lane_required()`].
+pub const ENV_GRAPH_LANE_REQUIRED: &str = "GEARS_TEST_PG_GRAPH_REQUIRED";
+
+/// Resolves an override against a default. Split out from the public tag
+/// accessors so the precedence rule is unit-testable without mutating the
+/// process environment (`std::env::set_var` is `unsafe` on edition 2024, and
+/// this workspace forbids `unsafe_code`).
+fn tag_from(override_value: Option<String>, default: &str) -> String {
+    override_value.unwrap_or_else(|| default.to_owned())
+}
+
+/// Reads `var`, treating unset and empty alike: both yield `None`, so the
+/// caller falls back to the pinned constant.
+///
+/// A value that is set but not valid Unicode is a mistake worth surfacing
+/// rather than absorbing — silently falling back would run the suite against a
+/// different image than the operator asked for, which is the failure mode this
+/// crate exists to end.
+fn env_override(var: &str) -> Option<String> {
+    match std::env::var(var) {
+        Ok(value) if value.is_empty() => None,
+        Ok(value) => Some(value),
+        Err(std::env::VarError::NotPresent) => None,
+        Err(std::env::VarError::NotUnicode(raw)) => {
+            panic!(
+                "{var} is set to a non-UTF-8 value ({}); expected a container tag",
+                raw.display()
+            )
+        }
+    }
+}
+
+/// `PostgreSQL` tag in effect, honoring `GEARS_TEST_PG_TAG`.
+#[must_use]
+pub fn postgres_tag() -> String {
+    tag_from(env_override(ENV_POSTGRES_TAG), POSTGRES_TAG)
+}
+
+/// Graph-lane `PostgreSQL` tag in effect, honoring `GEARS_TEST_PG_GRAPH_TAG`.
+#[must_use]
+pub fn postgres_graph_tag() -> String {
+    tag_from(env_override(ENV_POSTGRES_GRAPH_TAG), POSTGRES_GRAPH_TAG)
+}
+
+/// `MySQL` tag in effect, honoring `GEARS_TEST_MYSQL_TAG`.
+#[must_use]
+pub fn mysql_tag() -> String {
+    tag_from(env_override(ENV_MYSQL_TAG), MYSQL_TAG)
+}
+
+/// `TimescaleDB` tag in effect, honoring `GEARS_TEST_TIMESCALEDB_TAG`.
+#[must_use]
+pub fn timescaledb_tag() -> String {
+    tag_from(env_override(ENV_TIMESCALEDB_TAG), TIMESCALEDB_TAG)
+}
+
+/// `MariaDB` tag in effect, honoring `GEARS_TEST_MARIADB_TAG`.
+#[must_use]
+pub fn mariadb_tag() -> String {
+    tag_from(env_override(ENV_MARIADB_TAG), MARIADB_TAG)
+}
+
+/// A `PostgreSQL` container request on the pinned tag.
+///
+/// Chain `ImageExt` methods (`with_env_var`, `with_mount`, …) onto the result
+/// exactly as you would onto `Postgres::default()`.
+pub fn postgres() -> ContainerRequest<Postgres> {
+    ContainerRequest::from(Postgres::default()).with_tag(postgres_tag())
+}
+
+/// A `PostgreSQL` container request on the pinned tag, with a non-default
+/// database name.
+///
+/// `POSTGRES_DB` is an image-level setting on `Postgres`, so it has to be
+/// applied before the tag override converts the image into a
+/// `ContainerRequest` — which is why this exists rather than callers chaining
+/// `with_db_name` onto [`postgres()`].
+pub fn postgres_named(db_name: &str) -> ContainerRequest<Postgres> {
+    ContainerRequest::from(Postgres::default().with_db_name(db_name)).with_tag(postgres_tag())
+}
+
+/// A `PostgreSQL` container request for a suite whose migrations need a higher
+/// floor than [`POSTGRES_TAG`].
+///
+/// `fallback` applies only when `GEARS_TEST_PG_TAG` is unset, so a CI version
+/// matrix still reaches the suite — unlike chaining `.with_tag("16-alpine")`
+/// onto [`postgres()`], which discards the resolved tag and makes the suite
+/// invisible to the override. Delete the call once [`POSTGRES_TAG`] clears the
+/// floor the caller needs.
+///
+/// No caller today: resource-group's PG13 floor was the last one, and the
+/// workspace floor cleared it at PG 18. Kept as the escape hatch for the next
+/// suite that outruns the floor, so the answer isn't a local `.with_tag(...)`
+/// that silently opts out of the override.
+pub fn postgres_tagged(fallback: &str) -> ContainerRequest<Postgres> {
+    let tag = tag_from(env_override(ENV_POSTGRES_TAG), fallback);
+    ContainerRequest::from(Postgres::default()).with_tag(tag)
+}
+
+/// A `PostgreSQL` 19 container request, for the graph-storage gear's `SQL/PGQ`
+/// suite. Reserved — nothing consumes it yet; see [`POSTGRES_GRAPH_TAG`].
+pub fn postgres_graph() -> ContainerRequest<Postgres> {
+    ContainerRequest::from(Postgres::default()).with_tag(postgres_graph_tag())
+}
+
+/// A `MySQL` container request on the pinned tag.
+pub fn mysql() -> ContainerRequest<Mysql> {
+    ContainerRequest::from(Mysql::default()).with_tag(mysql_tag())
+}
+
+/// A `TimescaleDB` image on the pinned tag.
+///
+/// Unlike [`postgres()`] and [`mysql()`] there is no image module for this
+/// one, so the caller still supplies the wait strategy and environment.
+pub fn timescaledb() -> GenericImage {
+    // Both parameters share one generic type, so the name is owned too.
+    GenericImage::new(TIMESCALEDB_IMAGE.to_owned(), timescaledb_tag())
+}
+
+/// A `MariaDB` image on the pinned tag. Same caveat as [`timescaledb()`].
+pub fn mariadb() -> GenericImage {
+    GenericImage::new(MARIADB_IMAGE.to_owned(), mariadb_tag())
+}
+
+/// Whether an unavailable `PostgreSQL` 19 image must fail the run rather than
+/// skip it.
+///
+/// Defaults to `false` while the image is pre-`GA`: the tag can disappear from
+/// Docker Hub at `GA`, and no lane should go red for that. `CI` sets
+/// `GEARS_TEST_PG_GRAPH_REQUIRED=1` once the lane is meant to be mandatory —
+/// the same shape as `RG_PG_REQUIRE_DOCKER` in resource-group's smoke test.
+#[must_use]
+pub fn graph_lane_required() -> bool {
+    flag_from(env_override(ENV_GRAPH_LANE_REQUIRED))
+}
+
+/// Truthiness rule behind [`graph_lane_required()`].
+///
+/// Unset, empty and the usual falsy spellings all mean "off". Reading
+/// `GEARS_TEST_PG_GRAPH_REQUIRED=false` as *on* would invert the documented
+/// default, so the negatives are matched explicitly rather than by "anything
+/// that is not `0`".
+fn flag_from(value: Option<String>) -> bool {
+    value.is_some_and(|value| {
+        !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "off" | "no"
+        )
+    })
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use testcontainers::Image;
+
+    // Tests that read or write `GEARS_TEST_*` are `#[serial]`: `temp_env`
+    // mutates real process environment, which is shared by every test thread
+    // in this binary, so running them concurrently makes the tag a race.
+
+    /// Canary, not a preference: it asserts what `testcontainers-modules`
+    /// currently defaults to, which is exactly what this crate exists to stop
+    /// anyone from inheriting silently.
+    ///
+    /// If this fails, the dependency changed its built-in tags. That is not a
+    /// reason to update the literals below and move on — re-read
+    /// <https://github.com/constructorfabric/gears-rust/issues/4616>, check
+    /// whether the new upstream default is above or below our floor, and
+    /// decide deliberately.
+    #[test]
+    fn upstream_defaults_are_still_the_eol_images_we_override() {
+        assert_eq!(
+            Postgres::default().tag(),
+            "11-alpine",
+            "testcontainers-modules changed its default Postgres tag"
+        );
+        assert_eq!(
+            Mysql::default().tag(),
+            "8.1",
+            "testcontainers-modules changed its default MySQL tag"
+        );
+    }
+
+    /// The pins themselves, as literals.
+    ///
+    /// Asserting a helper against its own constant proves only that the value
+    /// was copied, so the value has to be nailed down somewhere. Changing a
+    /// database version is then a two-line diff — the constant and this test —
+    /// which is the review signal the crate is for.
+    #[test]
+    fn the_pinned_tags_are_the_values_we_reviewed() {
+        assert_eq!(POSTGRES_TAG, "18-alpine");
+        assert_eq!(POSTGRES_GRAPH_TAG, "19beta3-alpine");
+        assert_eq!(MYSQL_TAG, "9.7");
+        assert_eq!(TIMESCALEDB_IMAGE, "timescale/timescaledb");
+        assert_eq!(TIMESCALEDB_TAG, "2.29.2-pg18");
+        assert_eq!(MARIADB_IMAGE, "mariadb");
+        assert_eq!(MARIADB_TAG, "11.8");
+    }
+
+    /// Known floating-alias words. Checked per component (split on `-`/`_`),
+    /// not as a whole-string match: `MariaDB` actually publishes `lts-noble`,
+    /// which a whole-string check would miss entirely.
+    const FLOATING_ALIAS_WORDS: [&str; 4] = ["latest", "lts", "stable", "edge"];
+
+    fn is_floating_alias(tag: &str) -> bool {
+        tag.split(['-', '_'])
+            .any(|part| FLOATING_ALIAS_WORDS.contains(&part.to_lowercase().as_str()))
+    }
+
+    /// No constant may carry a floating alias: the whole point is that a
+    /// version change is visible in a diff.
+    #[test]
+    fn no_pin_is_a_floating_alias() {
+        for tag in [
+            POSTGRES_TAG,
+            POSTGRES_GRAPH_TAG,
+            MYSQL_TAG,
+            TIMESCALEDB_TAG,
+            MARIADB_TAG,
+        ] {
+            assert!(
+                !is_floating_alias(tag),
+                "{tag} is a floating alias, not a pin"
+            );
+        }
+    }
+
+    /// Component-wise, not substring: a real version segment that merely
+    /// contains an alias word as a substring (`stablefoo`) must not be
+    /// flagged, only a standalone `-`/`_`-separated alias component.
+    #[test]
+    fn floating_alias_check_is_component_wise_not_substring() {
+        for tag in ["lts-noble", "latest-pg18", "LTS-noble", "edge_alpine"] {
+            assert!(
+                is_floating_alias(tag),
+                "{tag} should be flagged as a floating alias"
+            );
+        }
+        for tag in [
+            "18-alpine",
+            "19beta3-alpine",
+            "9.7",
+            "2.29.2-pg18",
+            "11.8",
+            "stablefoo",
+        ] {
+            assert!(!is_floating_alias(tag), "{tag} should not be flagged");
+        }
+    }
+
+    /// The env-var names are a published contract — module docs, `docs/TESTING.md`
+    /// and CI invocations all spell them out. A rename that compiles would leave
+    /// every one of those silently ignored.
+    #[test]
+    fn env_var_names_match_the_documented_contract() {
+        assert_eq!(ENV_POSTGRES_TAG, "GEARS_TEST_PG_TAG");
+        assert_eq!(ENV_POSTGRES_GRAPH_TAG, "GEARS_TEST_PG_GRAPH_TAG");
+        assert_eq!(ENV_MYSQL_TAG, "GEARS_TEST_MYSQL_TAG");
+        assert_eq!(ENV_TIMESCALEDB_TAG, "GEARS_TEST_TIMESCALEDB_TAG");
+        assert_eq!(ENV_MARIADB_TAG, "GEARS_TEST_MARIADB_TAG");
+        assert_eq!(ENV_GRAPH_LANE_REQUIRED, "GEARS_TEST_PG_GRAPH_REQUIRED");
+    }
+
+    /// Each accessor must consult *its own* variable. Swapping two of them
+    /// inside the accessor bodies compiles and would otherwise stay green.
+    #[test]
+    #[serial]
+    fn each_accessor_reads_its_own_variable() {
+        /// (environment variable, accessor it must reach, constant it falls back to)
+        type AccessorCase = (&'static str, fn() -> String, &'static str);
+
+        let cases: [AccessorCase; 5] = [
+            (ENV_POSTGRES_TAG, postgres_tag, POSTGRES_TAG),
+            (
+                ENV_POSTGRES_GRAPH_TAG,
+                postgres_graph_tag,
+                POSTGRES_GRAPH_TAG,
+            ),
+            (ENV_MYSQL_TAG, mysql_tag, MYSQL_TAG),
+            (ENV_TIMESCALEDB_TAG, timescaledb_tag, TIMESCALEDB_TAG),
+            (ENV_MARIADB_TAG, mariadb_tag, MARIADB_TAG),
+        ];
+        for (var, accessor, default) in cases {
+            temp_env::with_var(var, Some("sentinel-value"), || {
+                assert_eq!(
+                    accessor(),
+                    "sentinel-value",
+                    "{var} did not reach its accessor"
+                );
+            });
+            temp_env::with_var(var, None::<&str>, || {
+                assert_eq!(accessor(), default, "{var} unset should yield the constant");
+            });
+        }
+    }
+
+    /// Resolved accessors, not constants: asserting against `POSTGRES_TAG`
+    /// here would make the suite fail under the crate's own documented
+    /// overrides (`GEARS_TEST_PG_TAG=16-alpine`), which CI runs as a matrix.
+    #[test]
+    #[serial]
+    fn helpers_carry_the_resolved_tags() {
+        assert_eq!(
+            postgres().descriptor(),
+            format!("postgres:{}", postgres_tag())
+        );
+        assert_eq!(
+            postgres_graph().descriptor(),
+            format!("postgres:{}", postgres_graph_tag())
+        );
+        assert_eq!(mysql().descriptor(), format!("mysql:{}", mysql_tag()));
+        assert_eq!(
+            postgres_named("cluster_test").descriptor(),
+            format!("postgres:{}", postgres_tag())
+        );
+    }
+
+    /// The invariant the crate exists for: a helper must never inherit the
+    /// upstream default. Guards the case `helpers_carry_the_resolved_tags`
+    /// cannot — deleting `.with_tag(...)` from a helper.
+    #[test]
+    #[serial]
+    fn helpers_apply_a_tag_rather_than_inheriting_the_upstream_default() {
+        temp_env::with_var(ENV_POSTGRES_TAG, Some("tag-under-test"), || {
+            assert_eq!(postgres().descriptor(), "postgres:tag-under-test");
+            assert_eq!(postgres_named("db").descriptor(), "postgres:tag-under-test");
+        });
+        temp_env::with_var(ENV_MYSQL_TAG, Some("tag-under-test"), || {
+            assert_eq!(mysql().descriptor(), "mysql:tag-under-test");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn generic_images_carry_the_resolved_tags() {
+        assert_eq!(timescaledb().name(), TIMESCALEDB_IMAGE);
+        assert_eq!(timescaledb().tag(), timescaledb_tag());
+        assert_eq!(mariadb().name(), MARIADB_IMAGE);
+        assert_eq!(mariadb().tag(), mariadb_tag());
+    }
+
+    /// `postgres_tagged` exists so a higher local floor does not cost the
+    /// suite its place in the CI version matrix.
+    #[test]
+    #[serial]
+    fn a_local_floor_still_yields_to_the_override() {
+        temp_env::with_var(ENV_POSTGRES_TAG, None::<&str>, || {
+            assert_eq!(
+                postgres_tagged("16-alpine").descriptor(),
+                "postgres:16-alpine"
+            );
+        });
+        temp_env::with_var(ENV_POSTGRES_TAG, Some("18-alpine"), || {
+            assert_eq!(
+                postgres_tagged("16-alpine").descriptor(),
+                "postgres:18-alpine"
+            );
+        });
+    }
+
+    #[test]
+    fn an_override_wins_over_the_constant() {
+        assert_eq!(
+            tag_from(Some("16-alpine".to_owned()), POSTGRES_TAG),
+            "16-alpine"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn an_unset_or_empty_override_falls_back_to_the_constant() {
+        assert_eq!(tag_from(None, POSTGRES_TAG), POSTGRES_TAG);
+        temp_env::with_var(ENV_POSTGRES_TAG, Some(""), || {
+            assert_eq!(postgres_tag(), POSTGRES_TAG);
+        });
+    }
+
+    #[test]
+    fn graph_lane_flag_is_off_unless_explicitly_set() {
+        for off in ["", "0", "false", "False", "off", "no", "  false  "] {
+            assert!(!flag_from(Some(off.to_owned())), "{off:?} should be off");
+        }
+        assert!(!flag_from(None));
+        for on in ["1", "true", "yes"] {
+            assert!(flag_from(Some(on.to_owned())), "{on:?} should be on");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn graph_lane_required_reads_its_variable() {
+        temp_env::with_var(ENV_GRAPH_LANE_REQUIRED, Some("1"), || {
+            assert!(graph_lane_required());
+        });
+        temp_env::with_var(ENV_GRAPH_LANE_REQUIRED, Some("false"), || {
+            assert!(!graph_lane_required());
+        });
+        temp_env::with_var(ENV_GRAPH_LANE_REQUIRED, None::<&str>, || {
+            assert!(!graph_lane_required());
+        });
+    }
+
+    /// The `TimescaleDB` image is pinned twice — here and in the Python `E2E`
+    /// sidecar — so the comments that point at each other are backed by a
+    /// check. A skew validates plugin migrations against a different
+    /// `PostgreSQL` major than `E2E` actually runs.
+    ///
+    /// Three assertions, not one: the repo and the default tag catch a drifted
+    /// pin, and the environment variable catches the subtler failure — a Python
+    /// lane that stops reading the override and so silently ignores a CI
+    /// version matrix while the Rust fixtures follow it.
+    #[test]
+    fn e2e_sidecar_pins_the_same_timescaledb_image() {
+        let sidecars = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../testing/e2e/lib/sidecars.py"
+        );
+        let Ok(source) = std::fs::read_to_string(sidecars) else {
+            panic!("cannot read {sidecars}; update this test if the file moved");
+        };
+        for expected in [
+            format!("TIMESCALEDB_IMAGE = \"{TIMESCALEDB_IMAGE}\""),
+            format!("TIMESCALEDB_TAG = \"{TIMESCALEDB_TAG}\""),
+            format!("ENV_TIMESCALEDB_TAG = \"{ENV_TIMESCALEDB_TAG}\""),
+        ] {
+            assert!(
+                source.contains(&expected),
+                "testing/e2e/lib/sidecars.py does not define `{expected}`; \
+                 the E2E lane and the Rust plugin tests would run different \
+                 PostgreSQL majors"
+            );
+        }
+    }
+}

--- a/libs/toolkit-db/Cargo.toml
+++ b/libs/toolkit-db/Cargo.toml
@@ -135,6 +135,7 @@ toolkit-utils = { workspace = true, features = ["serde"] }
 serde-saphyr = { workspace = true }
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
+test-containers = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 anyhow = { workspace = true }
 temp-env = { workspace = true }

--- a/libs/toolkit-db/benches/outbox_throughput.rs
+++ b/libs/toolkit-db/benches/outbox_throughput.rs
@@ -1307,7 +1307,7 @@ mod pg_container {
         ConnectOpts, Duration, OnceLock, Runtime, connect_db, outbox_migrations,
         run_migrations_for_testing, wait_for_tcp,
     };
-    use testcontainers::{ContainerAsync, ContainerRequest, ImageExt, runners::AsyncRunner};
+    use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
     use testcontainers_modules::postgres::Postgres;
 
     pub struct PgContainer {
@@ -1320,7 +1320,7 @@ mod pg_container {
     pub fn get_pg(rt: &Runtime) -> &'static PgContainer {
         PG.get_or_init(|| {
             rt.block_on(async {
-                let container = ContainerRequest::from(Postgres::default())
+                let container = test_containers::postgres()
                     .with_env_var("POSTGRES_PASSWORD", "pass")
                     .with_env_var("POSTGRES_USER", "user")
                     .with_env_var("POSTGRES_DB", "bench")
@@ -1353,7 +1353,7 @@ mod mysql_container {
         ConnectOpts, Duration, OnceLock, Runtime, connect_db, outbox_migrations,
         run_migrations_for_testing, wait_for_tcp,
     };
-    use testcontainers::{ContainerAsync, ContainerRequest, ImageExt, runners::AsyncRunner};
+    use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
     use testcontainers_modules::mysql::Mysql;
 
     pub struct MysqlContainer {
@@ -1373,7 +1373,7 @@ mod mysql_container {
                 //   (COMMIT is 105x slower with binlog enabled vs PG)
                 // - innodb-flush-log-at-trx-commit=2: flush redo log once/sec
                 //   instead of per-commit (safe for benchmarks, not production)
-                let container = ContainerRequest::from(Mysql::default())
+                let container = test_containers::mysql()
                     .with_env_var("MYSQL_ROOT_PASSWORD", "root")
                     .with_env_var("MYSQL_USER", "user")
                     .with_env_var("MYSQL_PASSWORD", "pass")
@@ -1428,7 +1428,7 @@ mod mariadb_container {
         // MariaDB prints "ready for connections" twice: once during the
         // temporary bootstrap server, once for the real server. We match
         // the version line that only appears in the final startup message.
-        GenericImage::new("mariadb", "lts")
+        test_containers::mariadb()
             .with_wait_for(WaitFor::message_on_stderr(
                 "mariadb.org binary distribution",
             ))

--- a/libs/toolkit-db/tests/common.rs
+++ b/libs/toolkit-db/tests/common.rs
@@ -49,11 +49,7 @@ pub fn bring_up_sqlite() -> DbUnderTest {
 /// Returns an error if the container fails to start or become ready.
 #[cfg(feature = "pg")]
 pub async fn bring_up_postgres() -> Result<DbUnderTest> {
-    use testcontainers::ContainerRequest;
-    use testcontainers_modules::postgres::Postgres;
-
-    let postgres_image = Postgres::default();
-    let container_request = ContainerRequest::from(postgres_image)
+    let container_request = test_containers::postgres()
         .with_env_var("POSTGRES_PASSWORD", "pass")
         .with_env_var("POSTGRES_USER", "user")
         .with_env_var("POSTGRES_DB", "app");
@@ -74,10 +70,7 @@ pub async fn bring_up_postgres() -> Result<DbUnderTest> {
 /// Returns an error if the container fails to start or the port cannot be obtained.
 #[cfg(feature = "mysql")]
 pub async fn bring_up_mysql() -> Result<DbUnderTest> {
-    use testcontainers::ContainerRequest;
-    use testcontainers_modules::mysql::Mysql;
-    let mysql_image = Mysql::default();
-    let container_request = ContainerRequest::from(mysql_image)
+    let container_request = test_containers::mysql()
         .with_env_var("MYSQL_ROOT_PASSWORD", "root")
         .with_env_var("MYSQL_USER", "user")
         .with_env_var("MYSQL_PASSWORD", "pass")

--- a/testing/e2e/lib/sidecars.py
+++ b/testing/e2e/lib/sidecars.py
@@ -15,6 +15,7 @@ reaper below.
 from __future__ import annotations
 
 import atexit
+import os
 import shutil
 import subprocess
 import time
@@ -29,6 +30,27 @@ READY_POLL_INTERVAL = 0.5
 # Consecutive successful query probes required before a container is called
 # ready. See TimescaleDbSidecar._wait_ready for why one success is not enough.
 REQUIRED_CONSECUTIVE_OK = 3
+
+# The TimescaleDB pin, mirrored from libs/test-containers/src/lib.rs (TIMESCALEDB_IMAGE,
+# TIMESCALEDB_TAG, ENV_TIMESCALEDB_TAG). Split into repo + tag rather than one composed
+# literal so the environment override below can reach this lane too; the Rust test
+# `e2e_sidecar_pins_the_same_timescaledb_image` fails the build if any of the three
+# drifts from its constant.
+TIMESCALEDB_IMAGE = "timescale/timescaledb"
+TIMESCALEDB_TAG = "2.29.2-pg18"
+ENV_TIMESCALEDB_TAG = "GEARS_TEST_TIMESCALEDB_TAG"
+
+
+def timescaledb_tag() -> str:
+    """Effective TimescaleDB tag, honoring GEARS_TEST_TIMESCALEDB_TAG.
+
+    Unset *or empty* means "use the pinned constant", matching
+    `test_containers::timescaledb_tag()` on the Rust side. Without this, a CI
+    version matrix would move the Rust plugin tests while leaving E2E on the
+    default -- migrations validated against one PostgreSQL major, E2E run
+    against another, with nothing in the diff to show it.
+    """
+    return os.environ.get(ENV_TIMESCALEDB_TAG, "").strip() or TIMESCALEDB_TAG
 
 
 class DockerUnavailable(RuntimeError):
@@ -69,13 +91,14 @@ def skip_without_docker() -> None:
 class TimescaleDbSidecar:
     """A throwaway TimescaleDB container with a dynamically mapped host port.
 
-    Keep IMAGE in sync with the Rust plugin integration tests:
-    gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/tests/common/mod.rs
-    A skew between the two means the plugin's migrations are validated against
-    a different PostgreSQL major than E2E runs.
+    The image comes from the module-level pin (TIMESCALEDB_IMAGE) and
+    `timescaledb_tag()`, so GEARS_TEST_TIMESCALEDB_TAG moves this lane and the
+    Rust plugin tests together. Resolved once, at class-definition time: the
+    variable is set before pytest starts, and keeping IMAGE a plain attribute
+    spares every caller -- including test_sidecar_contract.py -- a method call.
     """
 
-    IMAGE = "timescale/timescaledb:2.17.2-pg16"
+    IMAGE = f"{TIMESCALEDB_IMAGE}:{timescaledb_tag()}"
     LABEL = "cf-gears-e2e=usage-collector"
 
     DB_USER = "uc"

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -11,3 +11,8 @@ publish = false
 
 [dependencies]
 serde_json = { workspace = true }
+# `visit` on top of the workspace feature set: the pin checker walks the AST.
+syn = { workspace = true, features = ["visit"] }
+# `span-locations` is what makes `Span::start()` report a real line/column instead
+# of 0 — check-test-container-pins needs it to point at the offending call.
+proc-macro2 = { workspace = true, features = ["span-locations"] }

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -3,6 +3,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
+mod pins;
+
 fn main() -> ExitCode {
     // codacy:ignore -- build helper CLI, no security context
     let args: Vec<String> = env::args().skip(1).collect();
@@ -11,6 +13,7 @@ fn main() -> ExitCode {
     match cmd {
         "split-debug" => split_debug(&args[1..]),
         "proto-regen" => proto_regen(&args[1..]),
+        "check-test-container-pins" => pins::check(&args[1..]),
         "help" | "--help" | "-h" => {
             print_help();
             ExitCode::SUCCESS
@@ -41,6 +44,13 @@ Commands:
                         for each.
                         With `--check`, fails if any tracked `.proto`
                         or `proto.lock.toml` would change (CI guard).
+
+  check-test-container-pins
+                        Fail if any tracked `.rs` file outside
+                        libs/test-containers constructs a database
+                        container directly -- `Postgres::default()`,
+                        `Mysql::default()` or `GenericImage::new(..)`,
+                        under any alias. See docs/TESTING.md 4.4.
 
   help                  Show this message."
     );

--- a/tools/xtask/src/pins.rs
+++ b/tools/xtask/src/pins.rs
@@ -1,0 +1,305 @@
+//! `check-test-container-pins` — enforce that every database container in the
+//! workspace comes from `libs/test-containers`.
+//!
+//! # Why a parser and not a grep
+//!
+//! Image tags are pinned in one place (`libs/test-containers`, docs/TESTING.md
+//! 4.4) so a version change is one reviewed diff. A fixture that calls the
+//! upstream default constructors instead re-introduces the transitive pin
+//! through `Cargo.lock` that issue #4616 removed: a dependency bump then moves
+//! the database under every test with nothing in the diff to show it.
+//!
+//! This started life as two `grep -E` steps in CI. A regex matches text, so it
+//! matched only the *spelling* it was given:
+//!
+//! ```ignore
+//! use testcontainers_modules::postgres::Postgres as Pg;
+//! Pg::default()                                   // invisible to the regex
+//! GenericImage::new("mariadb".to_owned(), tag)     // ditto — not a bare literal
+//! ```
+//!
+//! The old gate papered over the first case by *also* banning `Postgres as _`
+//! imports, which is a rule about how you write `use` statements rather than
+//! about the policy anyone cares about. Parsing with `syn` addresses the real
+//! rule directly: it resolves the local name for each banned type, then looks
+//! at calls, so formatting, comments, line breaks and renames stop mattering.
+//!
+//! # The rules
+//!
+//! 1. `Postgres::default()` / `Mysql::default()` — the upstream constructors
+//!    whose tag comes from `testcontainers-modules`.
+//! 2. `GenericImage::new(..)` — any argument, anywhere outside the centralized
+//!    crate. Banning the constructor outright is both simpler and safer than
+//!    trying to evaluate its first argument; every legitimate database generic
+//!    image in this workspace already comes from `test_containers`.
+
+use std::collections::HashSet;
+use std::fmt::Write as _;
+use std::path::Path;
+use std::process::{Command, ExitCode};
+
+use syn::spanned::Spanned;
+use syn::visit::Visit;
+
+/// Crate that *implements* the pins, and so is allowed to call the constructors.
+const IMPL_CRATE_PREFIX: &str = "libs/test-containers/";
+
+/// Upstream constructors taking their tag from `testcontainers-modules`.
+const BANNED_DEFAULT_TYPES: [&str; 2] = ["Postgres", "Mysql"];
+
+/// Constructor banned outright outside [`IMPL_CRATE_PREFIX`].
+const GENERIC_IMAGE_TYPE: &str = "GenericImage";
+
+const POINTER: &str =
+    "Database images must come from libs/test-containers (see docs/TESTING.md 4.4).";
+
+pub fn check(args: &[String]) -> ExitCode {
+    if let Some(flag) = args.first() {
+        eprintln!("error: unexpected argument `{flag}`");
+        eprintln!("usage: cargo xtask check-test-container-pins");
+        return ExitCode::FAILURE;
+    }
+
+    let files = match tracked_rust_files() {
+        Ok(files) => files,
+        Err(err) => {
+            eprintln!("error: {err}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let mut violations = Vec::new();
+    let mut scanned = 0usize;
+
+    for file in &files {
+        if file.starts_with(IMPL_CRATE_PREFIX) {
+            continue;
+        }
+        let Ok(source) = std::fs::read_to_string(Path::new(file)) else {
+            // A tracked path git knows about but we cannot read (sparse
+            // checkout, symlink into nowhere) is not a policy violation.
+            eprintln!("warning: cannot read {file}, skipping");
+            continue;
+        };
+        scanned += 1;
+        match scan_source(&source) {
+            Ok(found) => violations.extend(
+                found
+                    .into_iter()
+                    .map(|v| format!("{file}:{}:{} {}", v.line, v.column, v.rule)),
+            ),
+            Err(err) => {
+                // Deliberately-broken sources are tracked on purpose (trybuild
+                // UI fixtures). Failing the build on them would make this gate
+                // a syntax checker, which it is not.
+                eprintln!("warning: cannot parse {file} ({err}), skipping");
+            }
+        }
+    }
+
+    if violations.is_empty() {
+        eprintln!("check-test-container-pins: {scanned} files scanned, no violations");
+        return ExitCode::SUCCESS;
+    }
+
+    let mut report = String::new();
+    for violation in &violations {
+        let _ = writeln!(report, "  {violation}");
+    }
+    eprintln!("::error::{POINTER}");
+    eprint!("{report}");
+    ExitCode::FAILURE
+}
+
+/// Tracked `*.rs` paths, workspace-relative.
+///
+/// `git ls-files` rather than a directory walk: it excludes `target/` and every
+/// other ignored path by construction, and it means the gate covers exactly
+/// what a reviewer would see in the diff.
+fn tracked_rust_files() -> Result<Vec<String>, String> {
+    let output = Command::new("git")
+        .args(["ls-files", "-z", "--", "*.rs"])
+        .output()
+        .map_err(|err| format!("cannot run `git ls-files`: {err}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "`git ls-files` failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let stdout =
+        String::from_utf8(output.stdout).map_err(|err| format!("non-UTF-8 path: {err}"))?;
+    Ok(stdout
+        .split('\0')
+        .filter(|path| !path.is_empty())
+        .map(str::to_owned)
+        .collect())
+}
+
+/// One offending call.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Violation {
+    pub line: usize,
+    pub column: usize,
+    pub rule: String,
+}
+
+/// Parse `source` and report every banned constructor call in it.
+pub fn scan_source(source: &str) -> Result<Vec<Violation>, syn::Error> {
+    let file = syn::parse_file(source)?;
+    let mut names = Names::default();
+    names.collect(&file);
+
+    let mut visitor = PinVisitor {
+        names: &names,
+        violations: Vec::new(),
+    };
+    visitor.visit_file(&file);
+    Ok(visitor.violations)
+}
+
+/// The local names each banned type answers to in one file.
+///
+/// The canonical names are always in the set, so an unimported or
+/// fully-qualified call is caught the same as an imported one. On top of that
+/// we add every rename and type alias, which is what the old regex could not
+/// see.
+#[derive(Default)]
+struct Names {
+    banned_default: HashSet<String>,
+    generic_image: HashSet<String>,
+}
+
+impl Names {
+    fn collect(&mut self, file: &syn::File) {
+        for name in BANNED_DEFAULT_TYPES {
+            self.banned_default.insert(name.to_owned());
+        }
+        self.generic_image.insert(GENERIC_IMAGE_TYPE.to_owned());
+
+        self.collect_items(&file.items);
+    }
+
+    /// Aliases declared inside a `mod tests { .. }` block are the common case
+    /// in this workspace, so inline modules are walked too.
+    fn collect_items(&mut self, items: &[syn::Item]) {
+        for item in items {
+            match item {
+                syn::Item::Use(item) => self.collect_use(&item.tree),
+                syn::Item::Type(item) => self.collect_type_alias(item),
+                syn::Item::Mod(syn::ItemMod {
+                    content: Some((_, items)),
+                    ..
+                }) => self.collect_items(items),
+                _ => {}
+            }
+        }
+    }
+
+    /// Walk a `use` tree, recording `X as Y` renames of the banned types.
+    ///
+    /// Globs need no handling: `use ..::postgres::*;` brings in `Postgres`
+    /// under its canonical name, which is already in the set.
+    fn collect_use(&mut self, tree: &syn::UseTree) {
+        match tree {
+            syn::UseTree::Path(path) => self.collect_use(&path.tree),
+            syn::UseTree::Group(group) => {
+                for tree in &group.items {
+                    self.collect_use(tree);
+                }
+            }
+            syn::UseTree::Rename(rename) => {
+                let original = rename.ident.to_string();
+                let local = rename.rename.to_string();
+                if BANNED_DEFAULT_TYPES.contains(&original.as_str()) {
+                    self.banned_default.insert(local);
+                } else if original == GENERIC_IMAGE_TYPE {
+                    self.generic_image.insert(local);
+                }
+            }
+            syn::UseTree::Name(_) | syn::UseTree::Glob(_) => {}
+        }
+    }
+
+    /// `type Pg = Postgres;` — resolved one level deep, which covers the form
+    /// anyone would plausibly write. Chained aliases are not followed.
+    fn collect_type_alias(&mut self, item: &syn::ItemType) {
+        let syn::Type::Path(path) = &*item.ty else {
+            return;
+        };
+        let Some(target) = path.path.segments.last() else {
+            return;
+        };
+        let target = target.ident.to_string();
+        let local = item.ident.to_string();
+        if self.banned_default.contains(&target) {
+            self.banned_default.insert(local);
+        } else if self.generic_image.contains(&target) {
+            self.generic_image.insert(local);
+        }
+    }
+}
+
+struct PinVisitor<'a> {
+    names: &'a Names,
+    violations: Vec<Violation>,
+}
+
+impl PinVisitor<'_> {
+    /// `Type::method` in a call position, by the last two path segments — so
+    /// `Pg::default()` and `testcontainers_modules::postgres::Postgres::default()`
+    /// are the same match.
+    fn banned_rule(&self, path: &syn::Path) -> Option<String> {
+        let mut segments = path.segments.iter().rev();
+        let method = segments.next()?.ident.to_string();
+        let ty = segments.next()?.ident.to_string();
+
+        match method.as_str() {
+            "default" if self.names.banned_default.contains(&ty) => Some(format!(
+                "`{ty}::default()` takes its tag from testcontainers-modules; \
+                 use test_containers::postgres()/mysql() instead"
+            )),
+            "new" if self.names.generic_image.contains(&ty) => Some(format!(
+                "`{ty}::new(..)` builds an unpinned image; \
+                 use test_containers::timescaledb()/mariadb() instead"
+            )),
+            _ => None,
+        }
+    }
+
+    fn report(&mut self, span: proc_macro2::Span, rule: String) {
+        let start = span.start();
+        self.violations.push(Violation {
+            line: start.line,
+            column: start.column + 1,
+            rule,
+        });
+    }
+}
+
+/// Peel `(expr)` and the invisible grouping macros introduce, so a wrapped
+/// callee (`(Postgres::default)()`) is seen the same as a bare one.
+fn unwrap_expr(mut expr: &syn::Expr) -> &syn::Expr {
+    loop {
+        expr = match expr {
+            syn::Expr::Paren(paren) => &paren.expr,
+            syn::Expr::Group(group) => &group.expr,
+            _ => return expr,
+        };
+    }
+}
+
+impl<'ast> Visit<'ast> for PinVisitor<'_> {
+    fn visit_expr_call(&mut self, call: &'ast syn::ExprCall) {
+        if let syn::Expr::Path(path) = unwrap_expr(&call.func)
+            && let Some(rule) = self.banned_rule(&path.path)
+        {
+            self.report(path.span(), rule);
+        }
+        syn::visit::visit_expr_call(self, call);
+    }
+}
+
+#[cfg(test)]
+#[path = "pins_tests.rs"]
+mod tests;

--- a/tools/xtask/src/pins_tests.rs
+++ b/tools/xtask/src/pins_tests.rs
@@ -1,0 +1,234 @@
+//! Regression cases for `check-test-container-pins`.
+//!
+//! Fixtures are inline `&str` snippets rather than files under `tests/`: a
+//! fixture *file* would be tracked, so `git ls-files` would hand it to the very
+//! checker it exists to test. String literals are not calls, so this file being
+//! scanned is a non-issue.
+
+use super::*;
+
+/// Rules that fired, as `line:column rule-prefix`, for terse assertions.
+fn rules(source: &str) -> Vec<String> {
+    scan_source(source)
+        .expect("fixture must parse")
+        .into_iter()
+        .map(|v| format!("{}:{}", v.line, v.column))
+        .collect()
+}
+
+fn count(source: &str) -> usize {
+    scan_source(source).expect("fixture must parse").len()
+}
+
+#[test]
+fn canonical_default_constructors_are_rejected() {
+    assert_eq!(count("fn f() { let _ = Postgres::default(); }"), 1);
+    assert_eq!(count("fn f() { let _ = Mysql::default(); }"), 1);
+}
+
+#[test]
+fn aliased_postgres_is_rejected() {
+    // The form the old regex could not see: renamed on import, called by the
+    // local name.
+    let source = r#"
+use testcontainers_modules::postgres::Postgres as Pg;
+
+fn f() {
+    let _ = Pg::default();
+}
+"#;
+    assert_eq!(count(source), 1);
+}
+
+#[test]
+fn aliased_generic_image_is_rejected() {
+    let source = r#"
+use testcontainers::GenericImage as Img;
+
+fn f() {
+    let _ = Img::new("mariadb", "11.8");
+}
+"#;
+    assert_eq!(count(source), 1);
+}
+
+#[test]
+fn grouped_and_nested_use_renames_are_rejected() {
+    let source = r#"
+use testcontainers_modules::{mysql::Mysql as My, postgres::Postgres as Pg};
+
+fn f() {
+    let _ = (Pg::default(), My::default());
+}
+"#;
+    assert_eq!(count(source), 2);
+}
+
+#[test]
+fn generic_image_with_a_non_literal_image_name_is_rejected() {
+    // The second form the old regex missed: the image name is an expression,
+    // not the bare string literal the pattern anchored on.
+    let source = r#"
+fn f(tag: String) {
+    let _ = GenericImage::new("mariadb".to_owned(), tag);
+}
+"#;
+    assert_eq!(count(source), 1);
+}
+
+#[test]
+fn generic_image_is_rejected_whatever_the_arguments() {
+    let source = r#"
+fn f(image: String, tag: String) {
+    let _ = GenericImage::new(image, tag);
+}
+"#;
+    assert_eq!(count(source), 1);
+}
+
+#[test]
+fn fully_qualified_paths_are_rejected() {
+    let source = r#"
+fn f() {
+    let _ = testcontainers_modules::postgres::Postgres::default();
+}
+"#;
+    assert_eq!(count(source), 1);
+}
+
+#[test]
+fn type_aliases_are_rejected() {
+    let source = r#"
+use testcontainers_modules::postgres::Postgres;
+
+type Pg = Postgres;
+
+fn f() {
+    let _ = Pg::default();
+}
+"#;
+    assert_eq!(count(source), 1);
+}
+
+#[test]
+fn aliases_declared_inside_an_inline_test_module_are_rejected() {
+    let source = r#"
+#[cfg(test)]
+mod tests {
+    use testcontainers_modules::postgres::Postgres as Pg;
+
+    #[test]
+    fn t() {
+        let _ = Pg::default();
+    }
+}
+"#;
+    assert_eq!(count(source), 1);
+}
+
+#[test]
+fn formatting_does_not_hide_a_violation() {
+    // Line breaks, interleaved comments and stray whitespace are exactly what
+    // a line-oriented regex is fragile about.
+    let source = r#"
+fn f() {
+    let _ = Postgres
+        // a comment in the middle of the path
+        ::  default (
+        );
+}
+"#;
+    assert_eq!(count(source), 1);
+}
+
+#[test]
+fn a_violation_reports_its_line_and_column() {
+    let source = "fn f() {\n    let _ = Postgres::default();\n}\n";
+    assert_eq!(rules(source), ["2:13"]);
+}
+
+#[test]
+fn glob_imports_do_not_hide_the_canonical_name() {
+    let source = r#"
+use testcontainers_modules::postgres::*;
+
+fn f() {
+    let _ = Postgres::default();
+}
+"#;
+    assert_eq!(count(source), 1);
+}
+
+#[test]
+fn centralized_helpers_are_clean() {
+    let source = r#"
+use testcontainers::{ContainerAsync, GenericImage, ImageExt};
+
+struct Harness {
+    _container: ContainerAsync<GenericImage>,
+}
+
+fn image() -> GenericImage {
+    test_containers::mariadb()
+}
+
+async fn f() {
+    let _ = test_containers::postgres().start().await;
+    let _ = test_containers::postgres_tagged("16-alpine");
+}
+"#;
+    assert_eq!(count(source), 0);
+}
+
+#[test]
+fn unrelated_default_and_new_calls_are_clean() {
+    let source = r#"
+fn f() {
+    let _ = Config::default();
+    let _ = String::new();
+    let _ = Postgres::builder();
+}
+"#;
+    assert_eq!(count(source), 0);
+}
+
+#[test]
+fn the_banned_names_inside_string_literals_are_clean() {
+    // This file itself relies on it, and so does pins.rs's own documentation.
+    let source = r#"
+fn f() {
+    let _ = "Postgres::default()";
+    let _ = "GenericImage::new(\"mariadb\", tag)";
+}
+"#;
+    assert_eq!(count(source), 0);
+}
+
+#[test]
+fn parenthesized_default_callee_is_rejected() {
+    // `(Postgres::default)()` is still a call to the banned constructor; the
+    // parens must not hide the path from the visitor.
+    let source = r#"
+fn f() {
+    let _ = (Postgres::default)();
+}
+"#;
+    assert_eq!(count(source), 1);
+}
+
+#[test]
+fn parenthesized_generic_image_callee_is_rejected() {
+    let source = r#"
+fn f() {
+    let _ = (GenericImage::new)("mariadb", "11.8");
+}
+"#;
+    assert_eq!(count(source), 1);
+}
+
+#[test]
+fn unparseable_source_is_an_error_not_a_violation() {
+    // `check` downgrades this to a warning and skips the file: the workspace
+    // tracks deliberately-broken trybuild UI fixtures.
+    assert!(scan_source("fn f( {").is_err());
+}


### PR DESCRIPTION
- Add libs/test-containers (cf-gears-test-containers, not published) as the single place these versions are pinned, with env var overrides (GEARS_TEST_PG_TAG etc.) for running a version matrix in CI. Route every fixture through it: ~240 call sites across ledger, toolkit-db, account-management, coord, resource-group, cluster, and the timescaledb plugin.

- Raise the pins: PostgreSQL 11 -> 18, MySQL 8.1 -> 9.7, TimescaleDB 2.17.2-pg16 -> 2.29.2-pg18, MariaDB lts -> 11.8.
PostgreSQL 19 is reserved for the future graph-storage gear (needs SQL/PGQ) but unused for now.

- The version bump surfaced one real bug: PostgreSQL 18 reports ON DELETE RESTRICT as SQLSTATE 23001 (restrict_violation) instead of the old 23503 (foreign_key_violation). Fixed to accept both codes, with a test.

- Add a CI check that fails if anything outside libs/test-containers calls the default constructors again.

Closes #4616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized pinned database containers for PostgreSQL, graph PostgreSQL, MySQL, MariaDB, and TimescaleDB integration tests.
  * Added environment-based image tag overrides and optional graph-database test requirements.
  * Updated TimescaleDB testing to use a PostgreSQL 18 image.

* **Bug Fixes**
  * Improved classification of PostgreSQL foreign-key constraint errors.

* **Documentation**
  * Documented image pinning, overrides, and graph test behavior.

* **Tests**
  * Standardized container setup and added CI validation against unpinned images.
  * Added coverage for an additional foreign-key error code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->