### PR TITLE
feat(grpc-hub): enforce inbound platform-plane auth at the gRPC boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,7 +2422,6 @@ dependencies = [
  "cf-gears-api-gateway",
  "cf-gears-system-sdks",
  "cf-gears-toolkit",
- "cf-gears-toolkit-k8s-auth",
  "cf-gears-toolkit-macros",
  "cf-gears-toolkit-security",
  "cf-gears-toolkit-transport-grpc",
@@ -2432,6 +2431,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
  "tonic",
  "tower",
  "tracing",
@@ -2445,12 +2445,16 @@ version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytes",
  "cf-gears-system-sdks",
  "cf-gears-toolkit",
+ "cf-gears-toolkit-k8s-auth",
+ "cf-gears-toolkit-security",
  "cf-gears-toolkit-transport-grpc",
  "http",
  "inventory",
  "parking_lot",
+ "secrecy",
  "serde",
  "serde_json",
  "tempfile",
@@ -3651,6 +3655,8 @@ dependencies = [
 name = "cf-gears-toolkit-security"
 version = "0.8.0"
 dependencies = [
+ "base64 0.22.1",
+ "parking_lot",
  "postcard",
  "secrecy",
  "serde",
@@ -3671,6 +3677,7 @@ version = "0.7.3"
 dependencies = [
  "anyhow",
  "cf-gears-toolkit-security",
+ "futures-util",
  "http",
  "parking_lot",
  "rand 0.10.1",
@@ -3683,6 +3690,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tonic",
+ "tower",
  "tracing",
 ]
 

--- a/gears/system/gear-orchestrator/Cargo.toml
+++ b/gears/system/gear-orchestrator/Cargo.toml
@@ -14,12 +14,6 @@ metadata.docs.rs.all-features = true
 [lib]
 name = "gear_orchestrator"
 
-[features]
-default = []
-# Enable the Kubernetes TokenReview validator for `internal_auth: { provider:
-# kube }` on the DirectoryService gRPC RPCs (Profile 3 platform host).
-k8s-auth = ["dep:toolkit-k8s-auth"]
-
 [lints]
 workspace = true
 
@@ -27,10 +21,6 @@ workspace = true
 cf-gears-system-sdks = { workspace = true, features = ["directory_grpc"] }
 toolkit = { workspace = true }
 toolkit-macros = { workspace = true }
-toolkit-security = { workspace = true }
-toolkit-transport-grpc = { workspace = true }
-toolkit-k8s-auth = { workspace = true, optional = true }
-secrecy = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true, features = ["transport"] }
 http = { workspace = true }
@@ -46,5 +36,9 @@ inventory = { workspace = true }
 [dev-dependencies]
 tower = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio-util = { workspace = true }
 api_gateway = { path = "../api-gateway", package = "cf-gears-api-gateway" }
 serde_json = { workspace = true }
+toolkit-security = { workspace = true }
+toolkit-transport-grpc = { workspace = true }
+secrecy = { workspace = true }

--- a/gears/system/gear-orchestrator/src/gear.rs
+++ b/gears/system/gear-orchestrator/src/gear.rs
@@ -3,7 +3,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::{Arc, OnceLock};
-use tokio::sync::RwLock;
 
 use toolkit::DirectoryClient;
 use toolkit::context::GearCtx;
@@ -16,21 +15,9 @@ use toolkit::registry::GearRegistry;
 use toolkit::runtime::GearManager;
 
 use cf_system_sdks::directory::DIRECTORY_SERVICE_NAME;
-use toolkit_security::{DynInternalAuthenticator, InternalAuthConfig};
 
 use crate::domain::service::GearsService;
 use crate::server;
-
-/// Configuration for the gear orchestrator
-#[derive(Clone, Debug, Default, serde::Deserialize)]
-pub struct GearOrchestratorConfig {
-    /// Platform-plane (internal) authentication for the `DirectoryService`
-    /// gRPC RPCs. When set, every RPC requires a valid
-    /// `x-toolkit-internal-token` (`cpt-cf-adr-two-plane-auth`); when absent,
-    /// enforcement is disabled (Profile 1 / in-process only).
-    #[serde(default)]
-    pub internal_auth: Option<toolkit_security::InternalAuthConfig>,
-}
 
 /// Gear Orchestrator - system gear for service discovery
 ///
@@ -45,69 +32,19 @@ pub struct GearOrchestratorConfig {
     client = cf_system_sdks::directory::DirectoryClient
 )]
 pub struct GearOrchestrator {
-    config: RwLock<GearOrchestratorConfig>,
     directory_api: OnceLock<Arc<dyn DirectoryClient>>,
     gear_manager: OnceLock<Arc<GearManager>>,
     gears_service: OnceLock<Arc<GearsService>>,
-    /// Platform-plane validator built from `config.internal_auth`, applied to
-    /// the `DirectoryService` gRPC RPCs. `None` disables enforcement.
-    authenticator: OnceLock<Option<DynInternalAuthenticator>>,
 }
 
 impl Default for GearOrchestrator {
     fn default() -> Self {
         Self {
-            config: RwLock::new(GearOrchestratorConfig::default()),
             directory_api: OnceLock::new(),
             gear_manager: OnceLock::new(),
             gears_service: OnceLock::new(),
-            authenticator: OnceLock::new(),
         }
     }
-}
-
-/// Build the platform-plane authenticator from configuration.
-///
-/// The dependency-light shared-secret provider is built here directly. The
-/// Kubernetes `TokenReview` provider requires the `k8s-auth` feature; without
-/// it, configuring `provider: kube` is a hard error rather than a silent
-/// enforcement downgrade.
-#[cfg_attr(not(feature = "k8s-auth"), allow(clippy::unused_async))]
-async fn build_internal_authenticator(
-    cfg: Option<&InternalAuthConfig>,
-) -> Result<Option<DynInternalAuthenticator>> {
-    let Some(cfg) = cfg else {
-        return Ok(None);
-    };
-
-    // Shared-secret (and any future dependency-light provider) builds here.
-    if let Some(auth) = cfg.build_authenticator() {
-        return Ok(Some(auth));
-    }
-
-    #[cfg(feature = "k8s-auth")]
-    {
-        if cfg.is_kube() {
-            let audiences = cfg.kube_audiences().unwrap_or_default().to_vec();
-            let authenticator =
-                toolkit_k8s_auth::K8sTokenReviewAuthenticator::try_default(audiences)
-                    .await
-                    .map_err(|e| {
-                        anyhow::anyhow!("failed to init Kubernetes TokenReview authenticator: {e}")
-                    })?;
-            return Ok(Some(DynInternalAuthenticator::new(authenticator)));
-        }
-    }
-    #[cfg(not(feature = "k8s-auth"))]
-    {
-        if cfg.is_kube() {
-            anyhow::bail!(
-                "gear-orchestrator internal_auth provider=kube requires the `k8s-auth` feature"
-            );
-        }
-    }
-
-    Ok(None)
 }
 
 #[async_trait]
@@ -123,19 +60,27 @@ impl SystemCapability for GearOrchestrator {
 #[async_trait]
 impl toolkit::Gear for GearOrchestrator {
     async fn init(&self, ctx: &GearCtx) -> Result<()> {
-        // Load configuration if present
-        let cfg = ctx.config_or_default::<GearOrchestratorConfig>()?;
-
-        // Build the platform-plane validator (if any) before moving `cfg`.
-        let authenticator = build_internal_authenticator(cfg.internal_auth.as_ref()).await?;
-        if authenticator.is_some() {
-            tracing::info!("DirectoryService platform-plane enforcement enabled");
+        // Migration guard: platform-plane enforcement lives on `grpc-hub` (a
+        // transport-level `InternalAuthGrpcLayer` applied to every inbound
+        // RPC, `cpt-cf-adr-platform-plane-auth`), not here. This gear reads no
+        // config at all, so a leftover `internal_auth` key would silently do
+        // nothing — fail loudly instead of booting the `DirectoryService`
+        // unauthenticated.
+        if let Some(internal_auth) = ctx
+            .config_provider()
+            .get_gear_config(ctx.gear_name())
+            .and_then(|raw| raw.get("config"))
+            .and_then(|config| config.get("internal_auth"))
+        {
+            let provider = internal_auth.get("provider").and_then(|p| p.as_str());
+            let detail = provider.map_or_else(String::new, |p| format!(" (provider = {p:?})"));
+            anyhow::bail!(
+                "gear-orchestrator config still sets `internal_auth`{detail}, which no longer \
+                 has any effect: platform-plane enforcement moved to grpc-hub's own \
+                 `internal_auth` config (cpt-cf-adr-platform-plane-auth). Move this key under \
+                 `gears.grpc-hub.config` instead."
+            );
         }
-        self.authenticator
-            .set(authenticator)
-            .map_err(|_| anyhow::anyhow!("authenticator already set (init called twice?)"))?;
-
-        *self.config.write().await = cfg;
 
         // Use the injected GearManager to create the DirectoryClient
         let manager = self
@@ -199,9 +144,7 @@ impl GrpcServiceCapability for GearOrchestrator {
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("DirectoryClient not initialized"))?;
 
-        // Build DirectoryService with the configured platform-plane validator.
-        let authenticator = self.authenticator.get().cloned().flatten();
-        let directory_svc = server::make_directory_service(api, authenticator);
+        let directory_svc = server::make_directory_service(api);
 
         Ok(vec![RegisterGrpcServiceFn {
             service_name: DIRECTORY_SERVICE_NAME,
@@ -209,5 +152,73 @@ impl GrpcServiceCapability for GearOrchestrator {
                 routes.add_service(directory_svc.clone());
             }),
         }])
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use tokio_util::sync::CancellationToken;
+    use toolkit::client_hub::ClientHub;
+    use toolkit::config::ConfigProvider;
+    use uuid::Uuid;
+
+    struct StaticConfigProvider(serde_json::Value);
+    impl ConfigProvider for StaticConfigProvider {
+        fn get_gear_config(&self, gear_name: &str) -> Option<&serde_json::Value> {
+            (gear_name == "gear-orchestrator").then_some(&self.0)
+        }
+    }
+
+    async fn init_with_config(config: serde_json::Value) -> Result<()> {
+        let mut wrapped = serde_json::Map::new();
+        wrapped.insert("config".to_owned(), config);
+        let ctx = GearCtx::new(
+            "gear-orchestrator",
+            Uuid::new_v4(),
+            Arc::new(StaticConfigProvider(serde_json::Value::Object(wrapped))),
+            Arc::new(ClientHub::default()),
+            CancellationToken::new(),
+        );
+        let gear = GearOrchestrator::default();
+        let gear_manager = Arc::new(GearManager::new());
+        gear.gear_manager
+            .set(gear_manager)
+            .map_err(|_| anyhow::anyhow!("gear_manager already set"))?;
+        toolkit::Gear::init(&gear, &ctx).await
+    }
+
+    #[tokio::test]
+    async fn init_rejects_leftover_internal_auth_config() {
+        let err = init_with_config(serde_json::json!({
+            "internal_auth": { "provider": "shared_secret", "secret": "top-secret-value" }
+        }))
+        .await
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("internal_auth"),
+            "expected a migration error mentioning internal_auth, got {err}"
+        );
+        assert!(
+            msg.contains("grpc-hub"),
+            "expected the error to point at grpc-hub's config, got {err}"
+        );
+        assert!(
+            msg.contains("shared_secret"),
+            "expected the non-sensitive provider tag to be named, got {err}"
+        );
+        assert!(
+            !msg.contains("top-secret-value"),
+            "the error must never leak the secret value, got {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn init_succeeds_without_internal_auth_config() {
+        init_with_config(serde_json::json!({}))
+            .await
+            .expect("init without a leftover internal_auth key must succeed");
     }
 }

--- a/gears/system/gear-orchestrator/src/lib.rs
+++ b/gears/system/gear-orchestrator/src/lib.rs
@@ -6,7 +6,7 @@
 
 // === MODULE DEFINITION ===
 pub mod gear;
-pub use gear::{GearOrchestrator, GearOrchestratorConfig};
+pub use gear::GearOrchestrator;
 
 // === INTERNAL MODULES (pub for integration tests) ===
 pub mod api;

--- a/gears/system/gear-orchestrator/src/server.rs
+++ b/gears/system/gear-orchestrator/src/server.rs
@@ -4,13 +4,7 @@
 
 use std::sync::Arc;
 
-use secrecy::ExposeSecret;
-use tonic::metadata::MetadataMap;
 use tonic::{Request, Response, Status};
-use toolkit_security::{
-    DynInternalAuthenticator, InternalAuthNError, InternalAuthenticator, PeerAuthenticated,
-};
-use toolkit_transport_grpc::extract_internal_token_grpc;
 
 use cf_system_sdks::directory::labels::is_valid_label_segment;
 use cf_system_sdks::directory::{
@@ -42,61 +36,25 @@ fn lookup_status(err: &anyhow::Error) -> Status {
     }
 }
 
-/// gRPC service implementation of Directory Service
+/// gRPC service implementation of Directory Service.
+///
+/// Platform-plane (`x-toolkit-internal-token`) enforcement is applied at the
+/// gRPC server boundary by `grpc-hub`'s `InternalAuthGrpcLayer`
+/// (`cpt-cf-adr-platform-plane-auth`): the token is validated and, on success, a
+/// `PlatformSecurityContext` / `PeerAuthenticated` is placed in the request
+/// extensions before the handler runs.
+///
+/// This is the authentication half only. Authorizing a peer against the gear
+/// name it claims when registering, deregistering, or heartbeating is deferred.
 #[derive(Clone)]
 pub struct DirectoryServiceImpl {
     api: Arc<dyn DirectoryClient>,
-    /// Platform-plane validator. When `Some`, every RPC requires a valid
-    /// `x-toolkit-internal-token` (`cpt-cf-adr-two-plane-auth`); when `None`,
-    /// enforcement is disabled (Profile 1 / in-process only).
-    authenticator: Option<DynInternalAuthenticator>,
 }
 
 impl DirectoryServiceImpl {
-    /// Create a `DirectoryService`. When `authenticator` is `Some`, every RPC
-    /// validates the platform-plane internal token; when `None`, enforcement
-    /// is disabled (Profile 1 / in-process only).
-    pub fn with_authenticator(
-        api: Arc<dyn DirectoryClient>,
-        authenticator: Option<DynInternalAuthenticator>,
-    ) -> Self {
-        Self { api, authenticator }
-    }
-
-    /// Enforce the platform plane on an inbound RPC.
-    ///
-    /// When an authenticator is configured, the `x-toolkit-internal-token`
-    /// metadata must be present and valid; the resolved [`PeerAuthenticated`]
-    /// is returned for workload-policy checks (and traced). When no
-    /// authenticator is configured, enforcement is skipped.
-    async fn authenticate_peer(
-        &self,
-        meta: &MetadataMap,
-    ) -> Result<Option<PeerAuthenticated>, Status> {
-        let Some(authenticator) = &self.authenticator else {
-            return Ok(None);
-        };
-
-        let token = extract_internal_token_grpc(meta)?;
-        match authenticator.authenticate(token.expose_secret()).await {
-            Ok(identity) => {
-                let peer = PeerAuthenticated {
-                    name: identity.peer_name().to_owned(),
-                };
-                tracing::debug!(peer = %peer.name, "platform-plane call authenticated");
-                Ok(Some(peer))
-            }
-            Err(InternalAuthNError::InvalidToken) => {
-                Err(Status::unauthenticated("invalid internal token"))
-            }
-            Err(InternalAuthNError::Unavailable) => {
-                Err(Status::unavailable("internal-auth backend unavailable"))
-            }
-            Err(err) => {
-                tracing::warn!(error = %err, "platform-plane authentication failed");
-                Err(Status::internal("internal authentication failure"))
-            }
-        }
+    /// Create a `DirectoryService` backed by `api`.
+    pub fn new(api: Arc<dyn DirectoryClient>) -> Self {
+        Self { api }
     }
 }
 
@@ -106,7 +64,6 @@ impl DirectoryService for DirectoryServiceImpl {
         &self,
         request: Request<ResolveGrpcServiceRequest>,
     ) -> Result<Response<ResolveGrpcServiceResponse>, Status> {
-        self.authenticate_peer(request.metadata()).await?;
         let service_name = request.into_inner().service_name;
         validate_lookup_name("service_name", &service_name)?;
 
@@ -125,7 +82,6 @@ impl DirectoryService for DirectoryServiceImpl {
         &self,
         request: Request<ResolveRestServiceRequest>,
     ) -> Result<Response<ResolveRestServiceResponse>, Status> {
-        self.authenticate_peer(request.metadata()).await?;
         let gear_name = request.into_inner().gear_name;
         validate_lookup_name("gear_name", &gear_name)?;
 
@@ -144,7 +100,6 @@ impl DirectoryService for DirectoryServiceImpl {
         &self,
         request: Request<GetOpenApiSpecRequest>,
     ) -> Result<Response<GetOpenApiSpecResponse>, Status> {
-        self.authenticate_peer(request.metadata()).await?;
         let gear_name = request.into_inner().gear_name;
         validate_lookup_name("gear_name", &gear_name)?;
 
@@ -161,7 +116,6 @@ impl DirectoryService for DirectoryServiceImpl {
         &self,
         request: Request<ListInstancesRequest>,
     ) -> Result<Response<ListInstancesResponse>, Status> {
-        self.authenticate_peer(request.metadata()).await?;
         let req = request.into_inner();
         let gear_name = req.gear_name;
         validate_lookup_name("gear_name", &gear_name)?;
@@ -205,7 +159,6 @@ impl DirectoryService for DirectoryServiceImpl {
         &self,
         _request: Request<ListAllInstancesRequest>,
     ) -> Result<Response<ListAllInstancesResponse>, Status> {
-        self.authenticate_peer(_request.metadata()).await?;
         let instances = self
             .api
             .list_all_instances()
@@ -234,7 +187,6 @@ impl DirectoryService for DirectoryServiceImpl {
         &self,
         request: Request<RegisterInstanceRequest>,
     ) -> Result<Response<()>, Status> {
-        self.authenticate_peer(request.metadata()).await?;
         let req = request.into_inner();
 
         validate_identity(&req.gear_name, &req.instance_id)?;
@@ -290,7 +242,6 @@ impl DirectoryService for DirectoryServiceImpl {
         &self,
         request: Request<DeregisterInstanceRequest>,
     ) -> Result<Response<()>, Status> {
-        self.authenticate_peer(request.metadata()).await?;
         let req = request.into_inner();
 
         validate_identity(&req.gear_name, &req.instance_id)?;
@@ -303,7 +254,6 @@ impl DirectoryService for DirectoryServiceImpl {
     }
 
     async fn heartbeat(&self, request: Request<HeartbeatRequest>) -> Result<Response<()>, Status> {
-        self.authenticate_peer(request.metadata()).await?;
         let req = request.into_inner();
 
         validate_identity(&req.gear_name, &req.instance_id)?;
@@ -506,16 +456,14 @@ fn validate_identity(gear_name: &str, instance_id: &str) -> Result<(), Status> {
     Ok(())
 }
 
-/// Create a `DirectoryService` server with the given API implementation and
-/// optional platform-plane `authenticator`.
+/// Create a `DirectoryService` server backed by `api`.
 ///
-/// When `authenticator` is `Some`, every RPC requires a valid
-/// `x-toolkit-internal-token`; when `None`, enforcement is disabled.
+/// Platform-plane enforcement is applied at the gRPC server boundary by
+/// `grpc-hub`'s `InternalAuthGrpcLayer`.
 pub fn make_directory_service(
     api: Arc<dyn DirectoryClient>,
-    authenticator: Option<DynInternalAuthenticator>,
 ) -> DirectoryServiceServer<DirectoryServiceImpl> {
-    DirectoryServiceServer::new(DirectoryServiceImpl::with_authenticator(api, authenticator))
+    DirectoryServiceServer::new(DirectoryServiceImpl::new(api))
 }
 
 #[cfg(test)]
@@ -534,7 +482,7 @@ mod tests {
     fn service() -> DirectoryServiceImpl {
         let manager = Arc::new(GearManager::new());
         let api: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(manager));
-        DirectoryServiceImpl::with_authenticator(api, None)
+        DirectoryServiceImpl::new(api)
     }
 
     #[tokio::test]
@@ -851,7 +799,7 @@ mod tests {
         // Directory service backed by an in-memory GearManager.
         let manager = Arc::new(GearManager::new());
         let api: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(manager));
-        let grpc_service = make_directory_service(api, None);
+        let grpc_service = make_directory_service(api);
 
         // Reserve a free port, then let the tonic server bind it.
         let addr = std::net::TcpListener::bind("127.0.0.1:0")
@@ -935,29 +883,48 @@ mod tests {
         assert!(gears.contains(&"catalog"));
     }
 
-    /// `cpt-cf-adr-platform-plane-auth` acceptance: with a platform-plane
-    /// authenticator installed, the
+    /// `cpt-cf-adr-platform-plane-auth` acceptance: with the platform-plane
+    /// [`InternalAuthGrpcLayer`] on the server (as `grpc-hub` wires it), the
     /// `DirectoryService` gRPC RPCs reject callers lacking a valid internal
-    /// token and accept those that attach the matching shared secret via an
-    /// [`InternalAuthInterceptor`] — the full outbound→inbound loop.
+    /// token and accept those attaching the matching shared secret via an
+    /// [`InternalAuthInterceptor`] — the full outbound→inbound loop. The
+    /// `probe_layer` (a [`tower::util::MapRequestLayer`] mounted just below
+    /// `InternalAuthGrpcLayer`) additionally proves the layer populates the
+    /// `PeerAuthenticated` extension on the request it forwards downstream.
     #[tokio::test]
     async fn grpc_enforces_internal_token_end_to_end() {
         use cf_system_sdks::directory::DirectoryGrpcClient;
         use secrecy::SecretString;
         use tonic::transport::Server;
         use toolkit_security::{DynInternalAuthenticator, SharedSecretInternalAuthenticator};
-        use toolkit_transport_grpc::InternalAuthInterceptor;
+        use toolkit_transport_grpc::{InternalAuthGrpcLayer, InternalAuthInterceptor};
 
         const SECRET: &str = "dev-internal-token";
 
-        // DirectoryService that enforces the platform plane via a shared secret.
         let manager = Arc::new(GearManager::new());
         let api: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(manager));
+        let grpc_service = make_directory_service(api);
+
+        // Required mode: an absent token is rejected.
         let authenticator = DynInternalAuthenticator::new(SharedSecretInternalAuthenticator::new(
             SecretString::from(SECRET),
             "peer".to_owned(),
         ));
-        let grpc_service = make_directory_service(api, Some(authenticator));
+        let auth_layer = InternalAuthGrpcLayer::new(authenticator);
+        let saw_expected_peer = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let probe_layer = tower::util::MapRequestLayer::new({
+            let saw_expected_peer = Arc::clone(&saw_expected_peer);
+            move |req: http::Request<_>| {
+                if req
+                    .extensions()
+                    .get::<toolkit_security::PeerAuthenticated>()
+                    .is_some_and(|peer| peer.name == "peer")
+                {
+                    saw_expected_peer.store(true, std::sync::atomic::Ordering::SeqCst);
+                }
+                req
+            }
+        });
 
         let addr = std::net::TcpListener::bind("127.0.0.1:0")
             .unwrap()
@@ -967,6 +934,8 @@ mod tests {
         // ephemeral port still bound.
         let server = tokio::spawn(async move {
             Server::builder()
+                .layer(auth_layer)
+                .layer(probe_layer)
                 .add_service(grpc_service)
                 .serve(addr)
                 .await
@@ -1015,6 +984,12 @@ mod tests {
             .expect("authenticated list");
         assert_eq!(all.len(), 1);
         assert_eq!(all[0].gear, "billing");
+
+        assert!(
+            saw_expected_peer.load(std::sync::atomic::Ordering::SeqCst),
+            "InternalAuthGrpcLayer must populate the PeerAuthenticated extension on the request \
+             it forwards to the layers below it"
+        );
 
         server.abort();
     }
@@ -1347,7 +1322,7 @@ mod tests {
 
         let manager = Arc::new(GearManager::new());
         let api: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(manager));
-        let grpc_service = make_directory_service(api, None);
+        let grpc_service = make_directory_service(api);
 
         let addr = std::net::TcpListener::bind("127.0.0.1:0")
             .unwrap()

--- a/gears/system/grpc-hub/Cargo.toml
+++ b/gears/system/grpc-hub/Cargo.toml
@@ -15,12 +15,20 @@ metadata.docs.rs.all-features = true
 [lib]
 name = "grpc_hub"
 
+[features]
+default = []
+# Enable the Kubernetes TokenReview validator for `internal_auth: { provider:
+# kube }` on the inbound gRPC platform-plane middleware (Profile 3 platform host).
+k8s-auth = ["dep:toolkit-k8s-auth"]
+
 [lints]
 workspace = true
 
 [dependencies]
 toolkit = { workspace = true }
 toolkit-transport-grpc = { workspace = true }
+toolkit-security = { workspace = true, features = ["internal-auth-cache"] }
+toolkit-k8s-auth = { workspace = true, optional = true }
 cf-gears-system-sdks = { workspace = true }
 inventory = { workspace = true }
 anyhow = { workspace = true }
@@ -41,3 +49,6 @@ tonic = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 uuid = { workspace = true }
+bytes = { workspace = true }
+secrecy = { workspace = true }
+tonic = { workspace = true, features = ["transport"] }

--- a/gears/system/grpc-hub/README.md
+++ b/gears/system/grpc-hub/README.md
@@ -19,6 +19,48 @@ gears:
       # Unix example (unix only): "uds:///tmp/cf-gears.sock"
       # Windows named pipe example (windows only): "pipe://\\\\.\\pipe\\cf-gears"
       listen_addr: "0.0.0.0:50051"
+
+      # Platform-plane (internal) authentication for ALL inbound gRPC RPCs
+      # served by this hub, enforced by a transport-level Tower layer
+      # (cpt-cf-adr-platform-plane-auth). When omitted, enforcement is
+      # disabled (Profile 1 / in-process only) and every inbound RPC is
+      # unauthenticated — a warning is logged at startup in that case.
+      internal_auth:
+        # "shared_secret": a single pre-shared token (dev / single-node).
+        provider: shared_secret
+        secret: "dev-internal-token"
+        peer_name: "toolkit-internal" # optional, defaults shown
+
+        # "kube": a projected ServiceAccount token, validated via the
+        # Kubernetes TokenReview API. Requires this gear's `k8s-auth`
+        # Cargo feature to be enabled at build time; without it,
+        # `provider: kube` is a hard `init` error, not a silent downgrade.
+        # provider: kube
+        # audiences: ["toolkit-internal"]
+        # token_path: /var/run/secrets/tokens/toolkit-internal
+
+      # How an ABSENT credential is treated when `internal_auth` is set.
+      # "required" (default) rejects every non-exempt RPC with no token;
+      # "permissive" lets an absent token through (a present-but-invalid
+      # token is always rejected, in either mode). Has no effect when
+      # `internal_auth` is unset.
+      internal_auth_enforcement: required
+
+      # Optional override of the exempt gRPC method-path prefixes (default:
+      # gRPC health-check + both reflection services). Each entry must be
+      # non-empty and start with "/"; entries are matched on a method-path
+      # segment boundary, so "/pkg.Svc/List" does not also exempt
+      # "/pkg.Svc/ListSecrets". An empty list enforces on every method.
+      # internal_auth_exempt_methods: ["/my.pkg.Svc/"]
+
+      # Seconds a SUCCESSFUL platform-plane validation is cached, collapsing
+      # a burst of calls carrying the same token into a single validation
+      # round-trip (only benefits a remote backend, i.e. `kube` — the
+      # shared-secret provider is a local comparison and is never cached).
+      # `0` disables caching. Bounded at `init` by a maximum of 300s (5
+      # minutes) to keep the token-revocation window tight; exceeding it is
+      # a hard `init` error.
+      internal_auth_cache_ttl_secs: 30
 ```
 
 ## License

--- a/gears/system/grpc-hub/src/gear.rs
+++ b/gears/system/grpc-hub/src/gear.rs
@@ -27,11 +27,28 @@ use tokio_stream::wrappers::TcpListenerStream;
 use tokio_util::sync::CancellationToken;
 use tonic::{service::RoutesBuilder, transport::Server};
 
+use toolkit_security::{DynInternalAuthenticator, InternalAuthConfig};
+use toolkit_transport_grpc::{InternalAuthEnforcement, InternalAuthGrpcLayer};
+
 #[cfg(windows)]
 use toolkit_transport_grpc::create_named_pipe_incoming;
 
 const DEFAULT_LISTEN_ADDR: SocketAddr =
     SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 50051));
+
+/// Default seconds a positive platform-plane validation result is cached.
+/// Derived from `toolkit_security::DEFAULT_TOKEN_REVIEW_CACHE_TTL` (not just
+/// mirrored as a literal) so the config surface cannot drift from the shared
+/// cache implementation while still not depending on the optional `k8s-auth`
+/// feature.
+const DEFAULT_INTERNAL_AUTH_CACHE_TTL_SECS: u64 =
+    toolkit_security::DEFAULT_TOKEN_REVIEW_CACHE_TTL.as_secs();
+/// Upper bound on the internal-auth cache TTL. Caps how long a revoked or
+/// expired token can keep validating from cache, so a misconfiguration cannot
+/// widen the revocation window unboundedly. Derived from
+/// `toolkit_security::MAX_TOKEN_REVIEW_CACHE_TTL` for the same reason.
+const MAX_INTERNAL_AUTH_CACHE_TTL_SECS: u64 =
+    toolkit_security::MAX_TOKEN_REVIEW_CACHE_TTL.as_secs();
 
 /// Configuration for the gRPC Hub gear.
 ///
@@ -40,7 +57,7 @@ const DEFAULT_LISTEN_ADDR: SocketAddr =
 /// - Unix Domain Socket (Unix only): `"uds:///path/to/socket.sock"`
 /// - Named Pipe (Windows only): `"pipe://\\.\pipe\my_pipe"` or `"npipe://\\.\pipe\my_pipe"`
 #[derive(Debug, Clone, Deserialize)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct GrpcHubConfig {
     /// Listen address for the gRPC server.
     /// Defaults to `0.0.0.0:50051` if not specified.
@@ -56,6 +73,38 @@ pub struct GrpcHubConfig {
     /// The address is parsed and validated during gear `init`; an
     /// unparsable port segment (e.g. `host:abc`) causes `init` to fail.
     pub advertise_addr: Option<String>,
+
+    /// Platform-plane (internal) authentication for **all** inbound gRPC RPCs
+    /// served by this hub. When set, an [`InternalAuthGrpcLayer`] validates the
+    /// `x-toolkit-internal-token` on every non-exempt RPC
+    /// (`cpt-cf-adr-platform-plane-auth`); when absent, enforcement is disabled
+    /// (Profile 1 / in-process only).
+    ///
+    /// Mirrors the REST `oop_http.internal_auth` surface: a single flat
+    /// `InternalAuthConfig` provider, with the gRPC-only enforcement / exempt /
+    /// cache knobs as sibling fields below.
+    pub internal_auth: Option<InternalAuthConfig>,
+
+    /// How an **absent** internal credential is treated when `internal_auth` is
+    /// set. Defaults to [`InternalAuthEnforcement::Required`]. Has no effect
+    /// when `internal_auth` is `None`. (gRPC-only: the REST middleware is always
+    /// permissive.)
+    pub internal_auth_enforcement: InternalAuthEnforcement,
+
+    /// Optional override of the gRPC method-path prefixes exempt from
+    /// enforcement. When `None`, the transport default
+    /// (`toolkit_transport_grpc::DEFAULT_EXEMPT_PREFIXES` — health + reflection)
+    /// applies. An empty vector enforces on every method.
+    pub internal_auth_exempt_methods: Option<Vec<String>>,
+
+    /// Seconds a **successful** platform-plane validation is cached, collapsing a
+    /// burst of calls carrying the same token into a single validation-backend
+    /// round-trip. Only positive results are cached, and only providers that make
+    /// a remote call benefit — in practice `kube` (the shared-secret provider is
+    /// a local comparison and is never wrapped). `0` disables caching (every call
+    /// re-validates). Bounded at boot by [`MAX_INTERNAL_AUTH_CACHE_TTL_SECS`] to
+    /// keep the token-revocation window tight.
+    pub internal_auth_cache_ttl_secs: u64,
 }
 
 impl Default for GrpcHubConfig {
@@ -63,6 +112,10 @@ impl Default for GrpcHubConfig {
         Self {
             listen_addr: DEFAULT_LISTEN_ADDR.to_string(),
             advertise_addr: None,
+            internal_auth: None,
+            internal_auth_enforcement: InternalAuthEnforcement::default(),
+            internal_auth_exempt_methods: None,
+            internal_auth_cache_ttl_secs: DEFAULT_INTERNAL_AUTH_CACHE_TTL_SECS,
         }
     }
 }
@@ -94,6 +147,100 @@ fn parse_advertise_addr(advertise_addr: &str) -> anyhow::Result<(String, Option<
     }
 }
 
+/// Build the inbound platform-plane validator from configuration.
+///
+/// The dependency-light shared-secret provider is built directly. The
+/// Kubernetes `TokenReview` provider requires the `k8s-auth` feature and is
+/// constructed (with the caching decision) by the single shared
+/// `toolkit_k8s_auth::build_cached_k8s_authenticator` helper also used by the
+/// `OoP` HTTP bootstrap, so the two never drift on what `provider: kube`
+/// means or how it is cached. Without the feature, configuring `provider:
+/// kube` is a hard error rather than a silent enforcement downgrade — as is
+/// any other unrecognized provider value.
+#[cfg_attr(
+    not(feature = "k8s-auth"),
+    allow(clippy::unused_async, unused_variables)
+)]
+async fn build_internal_authenticator(
+    cfg: Option<&InternalAuthConfig>,
+    cache_ttl_secs: u64,
+) -> anyhow::Result<Option<DynInternalAuthenticator>> {
+    let Some(cfg) = cfg else {
+        return Ok(None);
+    };
+
+    // Shared-secret (and any future dependency-light provider) builds here.
+    if let Some(auth) = cfg.build_authenticator() {
+        return Ok(Some(auth));
+    }
+
+    #[cfg(feature = "k8s-auth")]
+    {
+        if cfg.is_kube() {
+            let audiences = cfg.kube_audiences().unwrap_or_default().to_vec();
+            // `0` disables caching; any positive TTL wraps the validator in the
+            // short-lived positive cache.
+            let cache_ttl =
+                (cache_ttl_secs > 0).then(|| std::time::Duration::from_secs(cache_ttl_secs));
+            let auth = toolkit_k8s_auth::build_cached_k8s_authenticator(audiences, cache_ttl)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("failed to init Kubernetes TokenReview authenticator: {e}")
+                })?;
+            return Ok(Some(auth));
+        }
+    }
+    #[cfg(not(feature = "k8s-auth"))]
+    {
+        if cfg.is_kube() {
+            anyhow::bail!("grpc-hub internal_auth provider=kube requires the `k8s-auth` feature");
+        }
+    }
+
+    anyhow::bail!(
+        "internal_auth is configured but no authenticator could be built for the selected provider"
+    )
+}
+
+/// Assemble the [`InternalAuthGrpcLayer`] from a built `authenticator` and the
+/// configured enforcement mode / exempt-method override.
+///
+/// `authenticator` being `None` is a deliberate, explicit
+/// [`InternalAuthGrpcLayer::disabled`] — never the fully-open configuration
+/// reached merely by *forgetting* to supply one
+/// (`cpt-cf-adr-platform-plane-auth`).
+fn assemble_auth_layer(
+    authenticator: Option<DynInternalAuthenticator>,
+    enforcement: InternalAuthEnforcement,
+    exempt_methods: Option<Vec<String>>,
+) -> InternalAuthGrpcLayer {
+    let mut layer = match authenticator {
+        Some(authenticator) => InternalAuthGrpcLayer::new(authenticator),
+        None => InternalAuthGrpcLayer::disabled(),
+    }
+    .with_enforcement(enforcement);
+    if let Some(prefixes) = exempt_methods {
+        layer = layer.with_exempt_prefixes(prefixes);
+    }
+    layer
+}
+
+/// Reject an exempt-method entry that could never match a gRPC method path:
+/// an empty string matches every path via `starts_with`, and a prefix
+/// missing the leading `/` can never match one at all.
+///
+/// # Errors
+/// Returns an error naming the offending entry.
+fn validate_exempt_method(entry: &str) -> anyhow::Result<()> {
+    if entry.is_empty() || !entry.starts_with('/') {
+        anyhow::bail!(
+            "grpc-hub internal_auth_exempt_methods entry {entry:?} is invalid: must be \
+             non-empty and start with '/'"
+        );
+    }
+    Ok(())
+}
+
 /// The gRPC Hub gear.
 /// This gear is responsible for hosting the gRPC server and managing the gRPC services.
 #[toolkit::gear(
@@ -108,6 +255,9 @@ pub struct GrpcHub {
     pub(crate) client_hub: OnceLock<Arc<ClientHub>>,
     pub(crate) instance_id: OnceLock<String>,
     pub(crate) bound_endpoint: RwLock<Option<String>>,
+    /// Platform-plane middleware applied to every served gRPC RPC; a
+    /// pass-through layer when `internal_auth` is unset.
+    pub(crate) auth_layer: OnceLock<InternalAuthGrpcLayer>,
 }
 
 impl Default for GrpcHub {
@@ -119,6 +269,7 @@ impl Default for GrpcHub {
             client_hub: OnceLock::new(),
             instance_id: OnceLock::new(),
             bound_endpoint: RwLock::new(None),
+            auth_layer: OnceLock::new(),
         }
     }
 }
@@ -158,6 +309,26 @@ impl GrpcHub {
     /// Set the bound endpoint after the server has started listening.
     fn set_bound_endpoint(&self, endpoint: String) {
         *self.bound_endpoint.write() = Some(endpoint);
+    }
+
+    /// The platform-plane middleware to install on the server.
+    ///
+    /// `init` always populates `auth_layer` — with an explicit
+    /// [`InternalAuthGrpcLayer::disabled`] when `internal_auth` is unset, never
+    /// a bare absence. An unset `auth_layer` here means `init` never ran, a
+    /// startup-ordering bug: this refuses to serve rather than silently
+    /// downgrading to a pass-through layer (this is the *only* inbound
+    /// enforcement point, `cpt-cf-adr-platform-plane-auth`).
+    ///
+    /// # Errors
+    /// Returns an error if `init` has not run.
+    fn effective_auth_layer(&self) -> anyhow::Result<InternalAuthGrpcLayer> {
+        self.auth_layer.get().cloned().ok_or_else(|| {
+            anyhow::anyhow!(
+                "GrpcHub auth_layer not initialized: Gear::init must run before serving \
+                 (refusing to serve with platform-plane enforcement undetermined)"
+            )
+        })
     }
 
     /// Pick the endpoint to register with Directory for a TCP listener.
@@ -427,6 +598,7 @@ impl GrpcHub {
 
         let incoming = TcpListenerStream::new(listener);
         Server::builder()
+            .layer(self.effective_auth_layer()?)
             .add_routes(routes)
             .serve_with_incoming_shutdown(incoming, async move {
                 cancel.cancelled().await;
@@ -466,6 +638,7 @@ impl GrpcHub {
 
         let incoming = UnixListenerStream::new(uds);
         Server::builder()
+            .layer(self.effective_auth_layer()?)
             .add_routes(routes)
             .serve_with_incoming_shutdown(incoming, async move {
                 cancel.cancelled().await;
@@ -493,6 +666,7 @@ impl GrpcHub {
 
         let incoming = create_named_pipe_incoming(pipe_name, cancel.clone());
         Server::builder()
+            .layer(self.effective_auth_layer()?)
             .add_routes(routes)
             .serve_with_incoming_shutdown(incoming, async move {
                 cancel.cancelled().await;
@@ -600,6 +774,65 @@ impl Gear for GrpcHub {
         // Parse listen_addr into appropriate transport type
         self.apply_listen_config(&cfg.listen_addr)?;
 
+        // Fail loud at init on an out-of-bound cache TTL rather than silently
+        // running with a dangerously wide token-revocation window.
+        if cfg.internal_auth_cache_ttl_secs > MAX_INTERNAL_AUTH_CACHE_TTL_SECS {
+            anyhow::bail!(
+                "grpc-hub internal_auth_cache_ttl_secs ({}) exceeds the maximum of {}s",
+                cfg.internal_auth_cache_ttl_secs,
+                MAX_INTERNAL_AUTH_CACHE_TTL_SECS
+            );
+        }
+
+        // Fail loud on an exempt-method entry that could never match a path.
+        if let Some(exempt_methods) = &cfg.internal_auth_exempt_methods {
+            for entry in exempt_methods {
+                validate_exempt_method(entry)?;
+            }
+        }
+
+        // Build the inbound platform-plane middleware; an unset `internal_auth`
+        // yields an explicit `InternalAuthGrpcLayer::disabled()` (Profile 1 /
+        // in-process).
+        let authenticator = build_internal_authenticator(
+            cfg.internal_auth.as_ref(),
+            cfg.internal_auth_cache_ttl_secs,
+        )
+        .await?;
+        match (&authenticator, &cfg.internal_auth) {
+            (Some(_), Some(internal_auth)) => {
+                let provider = if internal_auth.is_kube() {
+                    "kube"
+                } else {
+                    "shared_secret"
+                };
+                tracing::info!(
+                    provider,
+                    enforcement = ?cfg.internal_auth_enforcement,
+                    cache_ttl_secs = cfg.internal_auth_cache_ttl_secs,
+                    exempt_prefixes = ?cfg
+                        .internal_auth_exempt_methods
+                        .as_deref()
+                        .unwrap_or(&[]),
+                    "inbound gRPC platform-plane enforcement enabled"
+                );
+            }
+            _ => {
+                tracing::warn!(
+                    "grpc-hub internal_auth is unset; every inbound gRPC RPC on this hub is \
+                     UNAUTHENTICATED (expected only for Profile 1 / in-process deployments)"
+                );
+            }
+        }
+        let auth_layer = assemble_auth_layer(
+            authenticator,
+            cfg.internal_auth_enforcement,
+            cfg.internal_auth_exempt_methods.clone(),
+        );
+        self.auth_layer
+            .set(auth_layer)
+            .map_err(|_| anyhow::anyhow!("auth_layer already set (init called twice?)"))?;
+
         if let Some(advertise_addr) = cfg.advertise_addr {
             let parsed = parse_advertise_addr(&advertise_addr)?;
 
@@ -701,6 +934,70 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn build_internal_authenticator_passes_through_when_unconfigured() {
+        let auth = build_internal_authenticator(None, 30).await.unwrap();
+        assert!(auth.is_none());
+    }
+
+    #[tokio::test]
+    async fn build_internal_authenticator_builds_shared_secret() {
+        let cfg = InternalAuthConfig::SharedSecret {
+            secret: "test-secret".to_owned(),
+            peer_name: "test-peer".to_owned(),
+        };
+        let auth = build_internal_authenticator(Some(&cfg), 30).await.unwrap();
+        assert!(auth.is_some());
+    }
+
+    #[tokio::test]
+    #[cfg(not(feature = "k8s-auth"))]
+    async fn build_internal_authenticator_rejects_kube_without_feature() {
+        let cfg = InternalAuthConfig::Kube {
+            audiences: vec!["toolkit-internal".to_owned()],
+            token_path: None,
+        };
+        let err = build_internal_authenticator(Some(&cfg), 30)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("k8s-auth"),
+            "error should mention missing k8s-auth feature: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_exempt_method_accepts_a_well_formed_prefix() {
+        assert!(validate_exempt_method("/pkg.Svc/Method").is_ok());
+    }
+
+    #[test]
+    fn assemble_auth_layer_applies_custom_exempt_prefixes() {
+        // With a custom exempt list, the built-in health/reflection default
+        // must no longer apply.
+        let layer = assemble_auth_layer(
+            None,
+            InternalAuthEnforcement::Required,
+            Some(vec!["/my.Svc/".to_owned()]),
+        );
+        let rendered = format!("{layer:?}");
+        assert!(rendered.contains("my.Svc"));
+        assert!(!rendered.contains("grpc.health"));
+    }
+
+    #[test]
+    fn effective_auth_layer_errors_when_init_never_ran() {
+        // `init` unconditionally populates `auth_layer`, so finding it unset
+        // here means `init` never ran — a startup-ordering bug that must
+        // refuse to serve rather than silently pass every RPC through.
+        let hub = GrpcHub::default();
+        let err = hub.effective_auth_layer().unwrap_err();
+        assert!(
+            err.to_string().contains("auth_layer not initialized"),
+            "expected an initialization error, got {err}"
+        );
+    }
+
     #[test]
     fn test_advertise_addr_parse_and_resolve_substitutes_ephemeral_port() {
         // `:0` means "use the bound port" at serve time.
@@ -758,6 +1055,11 @@ mod tests {
     async fn test_run_with_installers_starts_server() {
         let hub = Arc::new(GrpcHub::default());
         hub.set_listen_addr_tcp("127.0.0.1:0".parse().unwrap());
+        // `serve_tcp` requires an `auth_layer`; this test only exercises
+        // listener/registration plumbing, so wire the disabled layer directly.
+        hub.auth_layer
+            .set(InternalAuthGrpcLayer::disabled())
+            .unwrap();
         let data = GrpcInstallerData {
             gears: vec![GearInstallers {
                 gear_name: "test".to_owned(),
@@ -815,6 +1117,10 @@ mod tests {
 
         hub.pre_init(&sys_ctx)
             .expect("pre_init should set installer_store and instance_id");
+        // `serve` requires `auth_layer` to be set (normally by `init`).
+        hub.auth_layer
+            .set(InternalAuthGrpcLayer::disabled())
+            .unwrap();
 
         let cancel = CancellationToken::new();
         let cancel_clone = cancel.clone();
@@ -845,6 +1151,18 @@ mod tests {
         assert!(
             installer_store.is_empty(),
             "installers should be consumed after serve completes"
+        );
+    }
+
+    #[test]
+    fn omitted_cache_ttl_inherits_struct_default() {
+        let cfg: GrpcHubConfig = serde_json::from_value(serde_json::json!({
+            "internal_auth": { "provider": "shared_secret", "secret": "x" }
+        }))
+        .expect("partial config should deserialize via container default");
+        assert_eq!(
+            cfg.internal_auth_cache_ttl_secs, DEFAULT_INTERNAL_AUTH_CACHE_TTL_SECS,
+            "omitted TTL must inherit the struct Default, not u64::default()"
         );
     }
 
@@ -1205,5 +1523,223 @@ mod tests {
             hub.resolve_directory_client().is_some(),
             "should resolve DirectoryClient registered after init()"
         );
+    }
+
+    fn config_provider_with(config: serde_json::Value) -> impl ConfigProvider {
+        struct Provider(serde_json::Value);
+        impl ConfigProvider for Provider {
+            fn get_gear_config(&self, gear_name: &str) -> Option<&serde_json::Value> {
+                (gear_name == "grpc-hub").then_some(&self.0)
+            }
+        }
+        let mut wrapped = serde_json::Map::new();
+        wrapped.insert("config".to_owned(), config);
+        Provider(serde_json::Value::Object(wrapped))
+    }
+
+    #[tokio::test]
+    async fn init_rejects_cache_ttl_over_max() {
+        let hub = GrpcHub::default();
+        let ctx = GearCtx::new(
+            "grpc-hub",
+            Uuid::new_v4(),
+            Arc::new(config_provider_with(serde_json::json!({
+                "internal_auth_cache_ttl_secs": MAX_INTERNAL_AUTH_CACHE_TTL_SECS + 1
+            }))),
+            Arc::new(ClientHub::default()),
+            CancellationToken::new(),
+        );
+        let err = hub.init(&ctx).await.unwrap_err();
+        assert!(
+            err.to_string().contains("exceeds the maximum"),
+            "expected a maximum-TTL error, got {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn init_accepts_cache_ttl_at_max() {
+        let hub = GrpcHub::default();
+        let ctx = GearCtx::new(
+            "grpc-hub",
+            Uuid::new_v4(),
+            Arc::new(config_provider_with(serde_json::json!({
+                "internal_auth_cache_ttl_secs": MAX_INTERNAL_AUTH_CACHE_TTL_SECS
+            }))),
+            Arc::new(ClientHub::default()),
+            CancellationToken::new(),
+        );
+        hub.init(&ctx)
+            .await
+            .expect("TTL exactly at the max must be accepted");
+    }
+
+    #[tokio::test]
+    async fn init_rejects_invalid_exempt_method_entries() {
+        for bad_entry in ["", "no-leading-slash"] {
+            let hub = GrpcHub::default();
+            let ctx = GearCtx::new(
+                "grpc-hub",
+                Uuid::new_v4(),
+                Arc::new(config_provider_with(serde_json::json!({
+                    "internal_auth_exempt_methods": [bad_entry]
+                }))),
+                Arc::new(ClientHub::default()),
+                CancellationToken::new(),
+            );
+            let err = hub.init(&ctx).await.unwrap_err();
+            assert!(
+                err.to_string().contains("invalid"),
+                "expected {bad_entry:?} to be rejected, got {err}"
+            );
+        }
+    }
+
+    /// `cpt-cf-adr-platform-plane-auth` acceptance over the real `init()` +
+    /// `serve_tcp` path: a `shared_secret` `internal_auth` config gets
+    /// installed on the server that actually gets served, and an inbound RPC
+    /// is enforced end to end over a real TCP listener.
+    #[tokio::test]
+    async fn shared_secret_config_enforces_internal_token_over_real_tcp_listener() {
+        use secrecy::SecretString;
+        use tonic::Request;
+        use tonic::client::Grpc;
+        use tonic::codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder};
+        use tonic::service::interceptor::InterceptedService;
+        use tonic::transport::Channel;
+        use toolkit_transport_grpc::InternalAuthInterceptor;
+
+        const SECRET: &str = "dev-internal-token";
+
+        // A codec that passes message bytes through untouched.
+        // `ServiceAImpl` ignores request/response body content entirely, so
+        // no protobuf message type is needed to drive a real gRPC round trip
+        // through the layered server.
+        #[derive(Clone, Default)]
+        struct RawBytesCodec;
+
+        impl Encoder for RawBytesCodec {
+            type Item = Vec<u8>;
+            type Error = tonic::Status;
+            fn encode(
+                &mut self,
+                item: Self::Item,
+                dst: &mut EncodeBuf<'_>,
+            ) -> Result<(), Self::Error> {
+                use bytes::BufMut;
+                dst.put_slice(&item);
+                Ok(())
+            }
+        }
+
+        impl Decoder for RawBytesCodec {
+            type Item = Vec<u8>;
+            type Error = tonic::Status;
+            fn decode(
+                &mut self,
+                src: &mut DecodeBuf<'_>,
+            ) -> Result<Option<Self::Item>, Self::Error> {
+                use bytes::Buf;
+                let mut buf = vec![0u8; src.remaining()];
+                src.copy_to_slice(&mut buf);
+                Ok(Some(buf))
+            }
+        }
+
+        impl Codec for RawBytesCodec {
+            type Encode = Vec<u8>;
+            type Decode = Vec<u8>;
+            type Encoder = RawBytesCodec;
+            type Decoder = RawBytesCodec;
+            fn encoder(&mut self) -> Self::Encoder {
+                RawBytesCodec
+            }
+            fn decoder(&mut self) -> Self::Decoder {
+                RawBytesCodec
+            }
+        }
+
+        let hub = Arc::new(GrpcHub::default());
+        let cancel = CancellationToken::new();
+        let ctx = GearCtx::new(
+            "grpc-hub",
+            Uuid::new_v4(),
+            Arc::new(config_provider_with(serde_json::json!({
+                "listen_addr": "127.0.0.1:0",
+                "internal_auth": { "provider": "shared_secret", "secret": SECRET },
+            }))),
+            Arc::new(ClientHub::default()),
+            cancel.clone(),
+        );
+        hub.init(&ctx).await.expect("init should succeed");
+
+        let data = GrpcInstallerData {
+            gears: vec![GearInstallers {
+                gear_name: "test".to_owned(),
+                installers: vec![installer_a()],
+            }],
+        };
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let ready = ReadySignal::from_sender(tx);
+        let hub_task = {
+            let hub = Arc::clone(&hub);
+            let cancel = cancel.clone();
+            tokio::spawn(async move { hub.run_with_installers(data, cancel, ready).await })
+        };
+
+        tokio::time::timeout(Duration::from_secs(2), rx)
+            .await
+            .expect("ready signal should fire")
+            .expect("ready channel should complete");
+
+        let uri = hub
+            .get_bound_endpoint()
+            .expect("hub should have bound and recorded its TCP endpoint");
+        let path = http::uri::PathAndQuery::from_static("/grpc_hub.test.ServiceA/Method");
+
+        // (1) No credential -> Unauthenticated, over the real served listener.
+        let channel = Channel::from_shared(uri.clone())
+            .unwrap()
+            .connect()
+            .await
+            .unwrap();
+        let mut anon = Grpc::new(channel);
+        anon.ready().await.unwrap();
+        let err = anon
+            .unary(Request::new(Vec::new()), path.clone(), RawBytesCodec)
+            .await
+            .expect_err("a call without an internal token must be rejected");
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+
+        // (2) The matching shared secret -> accepted.
+        let channel = Channel::from_shared(uri).unwrap().connect().await.unwrap();
+        let intercepted = InterceptedService::new(
+            channel,
+            InternalAuthInterceptor::from_token(SecretString::from(SECRET)),
+        );
+        let mut authed = Grpc::new(intercepted);
+        authed.ready().await.unwrap();
+        // `ServiceAImpl` returns a body with no gRPC-framed message at all
+        // (it exists only to prove routing/auth, not to speak a real
+        // protocol), so tonic's client reports "missing response message"
+        // even on a successful call. What this test asserts is that the
+        // request got *past* the auth layer to reach the service at all —
+        // i.e. it must never be rejected as unauthenticated.
+        if let Err(status) = authed
+            .unary(Request::new(Vec::new()), path, RawBytesCodec)
+            .await
+        {
+            assert_ne!(
+                status.code(),
+                tonic::Code::Unauthenticated,
+                "a call with a valid internal token must not be rejected as unauthenticated, \
+                 got {status:?}"
+            );
+        }
+
+        cancel.cancel();
+        hub_task
+            .await
+            .expect("task should join")
+            .expect("server should exit cleanly");
     }
 }

--- a/libs/toolkit-k8s-auth/Cargo.toml
+++ b/libs/toolkit-k8s-auth/Cargo.toml
@@ -19,8 +19,7 @@ name = "toolkit_k8s_auth"
 workspace = true
 
 [dependencies]
-# Platform-plane authentication trait + identity/error types.
-toolkit-security = { workspace = true }
+toolkit-security = { workspace = true, features = ["internal-auth-cache"] }
 
 kube = { workspace = true, features = ["client", "rustls-tls", "aws-lc-rs"] }
 k8s-openapi = { workspace = true, features = ["latest"] }
@@ -30,4 +29,4 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/libs/toolkit-k8s-auth/src/lib.rs
+++ b/libs/toolkit-k8s-auth/src/lib.rs
@@ -26,9 +26,19 @@
 //! # }
 //! ```
 
+// The short-lived positive/negative validation cache is generic over any
+// `InternalAuthenticator` and lives in `toolkit-security`, so a caller
+// wanting to cache a non-Kubernetes provider does not have to depend on this
+// crate's `kube`/`k8s-openapi` stack. Re-exported here for convenience.
+pub use toolkit_security::{
+    CachingInternalAuthenticator, DEFAULT_TOKEN_REVIEW_CACHE_TTL, MAX_TOKEN_REVIEW_CACHE_TTL,
+};
+
 use k8s_openapi::api::authentication::v1::{TokenReview, TokenReviewSpec};
 use kube::api::{Api, PostParams};
-use toolkit_security::{InternalAuthNError, InternalAuthenticator, PlatformIdentity};
+use toolkit_security::{
+    DynInternalAuthenticator, InternalAuthNError, InternalAuthenticator, PlatformIdentity,
+};
 
 /// Prefix of the `user.username` returned by `TokenReview` for a
 /// `ServiceAccount`: `system:serviceaccount:<namespace>:<name>`.
@@ -40,13 +50,17 @@ const POD_NAME_EXTRA_KEY: &str = "authentication.kubernetes.io/pod-name";
 /// Per-request timeout for the Kubernetes `TokenReview` API call.
 const TOKEN_REVIEW_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
-/// Error constructing a [`K8sTokenReviewAuthenticator`].
+/// Error constructing a [`K8sTokenReviewAuthenticator`] (optionally wrapped in
+/// the cache, via [`build_cached_k8s_authenticator`]).
 #[derive(Debug, thiserror::Error)]
 pub enum K8sAuthError {
     /// The Kubernetes client could not be constructed (no in-cluster config or
     /// kubeconfig, or the config was invalid).
     #[error("failed to construct Kubernetes client: {0}")]
     Client(#[from] kube::Error),
+    /// The requested cache TTL was out of bounds.
+    #[error("invalid internal-auth cache TTL: {0}")]
+    InvalidCacheTtl(#[from] toolkit_security::InvalidCacheTtl),
 }
 
 /// A platform-plane authenticator backed by the Kubernetes `TokenReview` API.
@@ -190,6 +204,32 @@ impl K8sTokenReviewAuthenticator {
 impl InternalAuthenticator for K8sTokenReviewAuthenticator {
     async fn authenticate(&self, token: &str) -> Result<PlatformIdentity, InternalAuthNError> {
         self.review(token).await
+    }
+}
+
+/// Build a Kubernetes `TokenReview` platform-plane authenticator, optionally
+/// wrapped in [`CachingInternalAuthenticator`].
+///
+/// This is the **one** place `provider: kube` is constructed. Every caller
+/// that wires it (the gRPC hub, the `OoP` HTTP bootstrap) goes through this
+/// function so they cannot drift on caching behavior or on what a
+/// construction failure means.
+///
+/// # Errors
+/// Returns [`K8sAuthError`] if the Kubernetes client cannot be constructed,
+/// or a caching-TTL error (via [`InvalidCacheTtl`](toolkit_security::InvalidCacheTtl),
+/// converted with its `Display`) if `cache_ttl` is `Some` and out of bounds.
+pub async fn build_cached_k8s_authenticator(
+    audiences: Vec<String>,
+    cache_ttl: Option<std::time::Duration>,
+) -> Result<DynInternalAuthenticator, K8sAuthError> {
+    let validator = K8sTokenReviewAuthenticator::try_default(audiences).await?;
+    match cache_ttl {
+        Some(ttl) => {
+            let cached = CachingInternalAuthenticator::new(validator, ttl)?;
+            Ok(DynInternalAuthenticator::new(cached))
+        }
+        None => Ok(DynInternalAuthenticator::new(validator)),
     }
 }
 

--- a/libs/toolkit-security/Cargo.toml
+++ b/libs/toolkit-security/Cargo.toml
@@ -18,14 +18,22 @@ name = "toolkit_security"
 [lints]
 workspace = true
 
+[features]
+# Enables `internal_auth_cache::CachingInternalAuthenticator`.
+internal-auth-cache = ["dep:tokio", "dep:base64", "dep:serde_json", "dep:parking_lot"]
+
 [dependencies]
 uuid = { workspace = true, features = ["v4"] }
 serde = { workspace = true }
 postcard = { workspace = true }
 secrecy = { workspace = true }
 thiserror = { workspace = true }
+parking_lot = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["sync"], optional = true }
+serde_json = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
 trybuild = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/libs/toolkit-security/src/internal_auth_cache.rs
+++ b/libs/toolkit-security/src/internal_auth_cache.rs
@@ -1,0 +1,885 @@
+//! Short-lived positive (and brief negative) caching for platform-plane
+//! authentication.
+//!
+//! [`CachingInternalAuthenticator`] wraps any [`InternalAuthenticator`] with
+//! an in-memory, TTL-bounded cache. It exists because a remote validation
+//! backend (e.g. the Kubernetes `TokenReview` API) performs a live round-trip
+//! on every call — untenable on a hot gRPC/HTTP path where the same projected
+//! credential is presented on back-to-back requests
+//! (`cpt-cf-adr-platform-plane-auth`, decision 5).
+//!
+//! # Semantics
+//!
+//! - **Successful** validations are cached for up to `ttl`, clamped to the
+//!   credential's own remaining validity when it is a JWT carrying an `exp`
+//!   claim (see [`jwt_exp_claim`]) — a token with two seconds left is never
+//!   cached for the full configured `ttl`.
+//! - **Rejections** ([`InternalAuthNError::InvalidToken`]) are cached for a
+//!   short, fixed [`NEGATIVE_CACHE_TTL`] so a caller presenting no valid
+//!   credential cannot drive one backend round-trip per request, while a
+//!   token that becomes valid moments later is re-checked quickly.
+//! - Backend failures ([`InternalAuthNError::Unavailable`], `Other`) are
+//!   **never** cached: a transient outage is re-evaluated on the next call.
+//! - Concurrent misses for the **same** token are serialized behind a
+//!   per-token lock (single-flight), so a burst of calls carrying the same
+//!   credential collapses into one backend round-trip instead of N.
+//! - The cache key is the token itself, matched exactly. Exact matching
+//!   avoids the collision risk of a non-cryptographic hash (two distinct
+//!   tokens resolving to one cached identity) without pulling in a
+//!   cryptographic digest — the workspace's validated crypto provider is
+//!   platform-dependent, so this crate stays free of any direct crypto
+//!   dependency. The token is already resident in process memory (request
+//!   headers, the outbound credential), and entries are in-process and
+//!   TTL-bounded.
+//! - The cache holds at most [`MAX_CACHE_ENTRIES`] distinct tokens. When full,
+//!   a single sweep reclaims any expired entries first (amortizing across the
+//!   inserts it makes room for); only if nothing is reclaimable — a burst of
+//!   distinct, individually-valid credentials — does it evict the entry
+//!   expiring soonest, rather than growing unbounded.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use base64::Engine as _;
+use parking_lot::Mutex;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::internal_auth::{InternalAuthNError, InternalAuthenticator, PlatformIdentity};
+
+/// Default time-to-live for a cached successful validation.
+///
+/// A conservative few seconds: long enough to collapse a burst of calls
+/// carrying the same token, short enough to keep the post-revocation
+/// acceptance window small.
+pub const DEFAULT_TOKEN_REVIEW_CACHE_TTL: Duration = Duration::from_secs(30);
+
+/// Upper bound accepted by [`CachingInternalAuthenticator::new`]. Caps how
+/// long a revoked or expired token can keep validating from cache, so a
+/// misconfiguration cannot widen the revocation window unboundedly.
+pub const MAX_TOKEN_REVIEW_CACHE_TTL: Duration = Duration::from_mins(5);
+
+/// Fixed TTL for a cached **rejection**. Deliberately short and
+/// non-configurable: it exists only to blunt a hot loop of fresh invalid
+/// tokens, not to widen any acceptance window.
+const NEGATIVE_CACHE_TTL: Duration = Duration::from_secs(1);
+
+/// Amortizes the expired-entry sweep: a full scan of the cache runs only
+/// every `SWEEP_INTERVAL`-th insert rather than on every single one.
+const SWEEP_INTERVAL: u32 = 32;
+
+/// Maximum number of distinct tokens held at once, bounding memory even
+/// under a sustained burst of distinct, individually-valid credentials
+/// (which TTL expiry alone never reclaims). Generous enough for realistic
+/// fleets of Kubernetes `ServiceAccount`s calling through a single
+/// authenticator instance.
+pub const MAX_CACHE_ENTRIES: usize = 10_000;
+
+/// `ttl` passed to [`CachingInternalAuthenticator::new`] was zero or exceeded
+/// [`MAX_TOKEN_REVIEW_CACHE_TTL`].
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "internal-auth cache TTL must be > 0 and <= {MAX_TOKEN_REVIEW_CACHE_TTL:?}, got {actual:?}"
+)]
+pub struct InvalidCacheTtl {
+    actual: Duration,
+}
+
+/// A cached validation outcome and the instant it stops applying.
+enum CacheEntry {
+    Valid {
+        identity: PlatformIdentity,
+        expires_at: Instant,
+    },
+    Rejected {
+        expires_at: Instant,
+    },
+}
+
+impl CacheEntry {
+    fn expires_at(&self) -> Instant {
+        match self {
+            Self::Valid { expires_at, .. } | Self::Rejected { expires_at } => *expires_at,
+        }
+    }
+}
+
+/// Outcome of a cache lookup.
+enum CacheLookup {
+    Valid(PlatformIdentity),
+    Rejected,
+    Miss,
+}
+
+/// Best-effort extraction of the `exp` (seconds since the Unix epoch) claim
+/// from a JWT, without verifying the signature.
+///
+/// The caller has already had the token's signature verified by the
+/// authentication backend (e.g. Kubernetes `TokenReview`); this is a plain
+/// base64 decode of the already-trusted payload, used only to avoid caching a
+/// validation past the credential's own expiry. Returns `None` for a
+/// non-JWT credential (e.g. a shared secret), which simply skips the clamp.
+fn jwt_exp_claim(token: &str) -> Option<u64> {
+    let payload_b64 = token.split('.').nth(1)?;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload_b64)
+        .ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&payload).ok()?;
+    value.get("exp")?.as_u64()
+}
+
+/// The instant a freshly validated `token` should stop being trusted from
+/// cache: whichever is sooner of `now + ttl` and the token's own `exp` claim
+/// (when present).
+fn clamped_expiry(token: &str, now: Instant, ttl: Duration) -> Instant {
+    let ttl_expiry = now + ttl;
+    let Some(exp_secs) = jwt_exp_claim(token) else {
+        return ttl_expiry;
+    };
+    let exp_at = UNIX_EPOCH + Duration::from_secs(exp_secs);
+    let Ok(remaining) = exp_at.duration_since(SystemTime::now()) else {
+        // The token's own claim says it is already expired; do not extend
+        // trust in it at all.
+        return now;
+    };
+    ttl_expiry.min(now + remaining)
+}
+
+/// Wraps an [`InternalAuthenticator`] with a short-lived cache of both
+/// successful and rejected validations.
+///
+/// Construct it around the concrete validator and hand the wrapper to the
+/// transport layer as the `InternalAuthenticator`:
+///
+/// ```rust
+/// use std::time::Duration;
+/// use toolkit_security::{CachingInternalAuthenticator, InternalAuthNError, PlatformIdentity};
+///
+/// struct AlwaysOk;
+/// impl toolkit_security::InternalAuthenticator for AlwaysOk {
+///     async fn authenticate(&self, token: &str) -> Result<PlatformIdentity, InternalAuthNError> {
+///         Ok(PlatformIdentity::Shared { name: token.to_owned() })
+///     }
+/// }
+///
+/// # fn wire() -> Result<(), Box<dyn std::error::Error>> {
+/// let cached = CachingInternalAuthenticator::new(AlwaysOk, Duration::from_secs(30))?;
+/// # let _ = cached;
+/// # Ok(())
+/// # }
+/// ```
+pub struct CachingInternalAuthenticator<A> {
+    inner: A,
+    ttl: Duration,
+    cache: Mutex<HashMap<String, CacheEntry>>,
+    /// Per-token single-flight locks: concurrent misses for the same token
+    /// serialize here instead of each issuing a backend call.
+    inflight: Mutex<HashMap<String, Arc<AsyncMutex<()>>>>,
+    sweep_counter: AtomicU32,
+}
+
+impl<A> std::fmt::Debug for CachingInternalAuthenticator<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CachingInternalAuthenticator")
+            .field("ttl", &self.ttl)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<A> CachingInternalAuthenticator<A> {
+    /// Wrap `inner`, caching successful validations for up to `ttl` (clamped
+    /// to the credential's own expiry when it is a JWT) and rejections for a
+    /// short fixed window.
+    ///
+    /// # Errors
+    /// Returns [`InvalidCacheTtl`] if `ttl` is zero or exceeds
+    /// [`MAX_TOKEN_REVIEW_CACHE_TTL`].
+    pub fn new(inner: A, ttl: Duration) -> Result<Self, InvalidCacheTtl> {
+        if ttl == Duration::ZERO || ttl > MAX_TOKEN_REVIEW_CACHE_TTL {
+            return Err(InvalidCacheTtl { actual: ttl });
+        }
+        Ok(Self {
+            inner,
+            ttl,
+            cache: Mutex::new(HashMap::new()),
+            inflight: Mutex::new(HashMap::new()),
+            sweep_counter: AtomicU32::new(0),
+        })
+    }
+
+    /// Wrap `inner` with the [`DEFAULT_TOKEN_REVIEW_CACHE_TTL`].
+    #[must_use]
+    pub fn with_default_ttl(inner: A) -> Self {
+        Self {
+            inner,
+            ttl: DEFAULT_TOKEN_REVIEW_CACHE_TTL,
+            cache: Mutex::new(HashMap::new()),
+            inflight: Mutex::new(HashMap::new()),
+            sweep_counter: AtomicU32::new(0),
+        }
+    }
+
+    /// Look up a still-applicable cached outcome for `token`, evicting it
+    /// immediately if found stale (rather than waiting for the next sweep).
+    ///
+    /// Holds the lock only for the duration of the map access (never across
+    /// an `await`), so the returned future stays `Send`.
+    fn lookup(&self, token: &str, now: Instant) -> CacheLookup {
+        let mut cache = self.cache.lock();
+        let Some(entry) = cache.get(token) else {
+            return CacheLookup::Miss;
+        };
+        if entry.expires_at() <= now {
+            cache.remove(token);
+            return CacheLookup::Miss;
+        }
+        match entry {
+            CacheEntry::Valid { identity, .. } => CacheLookup::Valid(identity.clone()),
+            CacheEntry::Rejected { .. } => CacheLookup::Rejected,
+        }
+    }
+
+    /// Insert `entry` under `token`, amortizing the expired-entry sweep over
+    /// [`SWEEP_INTERVAL`] inserts instead of scanning the whole map every
+    /// time, and enforcing [`MAX_CACHE_ENTRIES`] when a new token would
+    /// exceed it.
+    ///
+    /// When full, expired entries are reclaimed with a single `retain` sweep
+    /// first — one scan typically frees room for many subsequent inserts, so
+    /// the following misses take the cheap path. Only if that sweep frees
+    /// nothing (a fleet of simultaneously-valid tokens) does it fall back to
+    /// the O(n) soonest-to-expire scan, so the whole-map scan is no longer
+    /// paid on every miss while the cache stays full.
+    fn insert(&self, token: String, entry: CacheEntry, now: Instant) {
+        let mut cache = self.cache.lock();
+        let count = self.sweep_counter.fetch_add(1, Ordering::Relaxed) + 1;
+        let swept = count.is_multiple_of(SWEEP_INTERVAL);
+        if swept {
+            cache.retain(|_, e| e.expires_at() > now);
+        }
+        if cache.len() >= MAX_CACHE_ENTRIES && !cache.contains_key(&token) {
+            // Reclaim expired entries before scanning for a victim: a single
+            // sweep amortizes across the many inserts it makes room for,
+            // whereas the min_by_key scan below would otherwise run on every
+            // miss for as long as the cache stayed full.
+            if !swept {
+                cache.retain(|_, e| e.expires_at() > now);
+            }
+            if cache.len() >= MAX_CACHE_ENTRIES {
+                // Sweep freed nothing (every entry still valid): fall back to
+                // evicting the soonest-to-expire, which needs re-validation
+                // soonest regardless. No extra bookkeeping for real LRU order.
+                if let Some(victim) = cache
+                    .iter()
+                    .min_by_key(|(_, e)| e.expires_at())
+                    .map(|(k, _)| k.clone())
+                {
+                    cache.remove(&victim);
+                }
+            }
+        }
+        cache.insert(token, entry);
+    }
+
+    /// Get-or-create the per-token single-flight lock.
+    fn token_lock(&self, token: &str) -> Arc<AsyncMutex<()>> {
+        let mut inflight = self.inflight.lock();
+        Arc::clone(
+            inflight
+                .entry(token.to_owned())
+                .or_insert_with(|| Arc::new(AsyncMutex::new(()))),
+        )
+    }
+
+    /// Drop the per-token lock from the map once nothing else references it,
+    /// so `inflight` does not grow unboundedly over the process lifetime.
+    fn release_token_lock(&self, token: &str, lock: &Arc<AsyncMutex<()>>) {
+        let mut inflight = self.inflight.lock();
+        // 2 = the map's own clone + `lock` here; anything higher means
+        // another waiter still holds a clone.
+        if Arc::strong_count(lock) <= 2 {
+            inflight.remove(token);
+        }
+    }
+}
+
+/// Releases the `inflight` entry on drop, so cancellation (not just a normal
+/// return) still cleans it up. Borrows `lock` rather than cloning it, so it
+/// doesn't skew `release_token_lock`'s `Arc::strong_count` check.
+struct ReleaseTokenLockOnDrop<'a, A> {
+    owner: &'a CachingInternalAuthenticator<A>,
+    token: &'a str,
+    lock: &'a Arc<AsyncMutex<()>>,
+}
+
+impl<A> Drop for ReleaseTokenLockOnDrop<'_, A> {
+    fn drop(&mut self) {
+        self.owner.release_token_lock(self.token, self.lock);
+    }
+}
+
+impl<A: InternalAuthenticator> CachingInternalAuthenticator<A> {
+    /// The implementation behind [`InternalAuthenticator::authenticate`],
+    /// parameterized on the "current" instant used for the lookup / miss
+    /// phases.
+    ///
+    /// Split out so a test can drive a deterministic TTL-expiry check (e.g.
+    /// `now + ttl + 1ms`) instead of a real `tokio::time::sleep` — this
+    /// crate's `Instant`-based cache cannot be virtualized by
+    /// `tokio::time::pause`. `authenticate` is simply the
+    /// `Instant::now()`-sampling production wrapper.
+    ///
+    /// The instant used to timestamp a freshly-stored entry is still
+    /// re-sampled internally *after* the backend round-trip (never derived
+    /// from `now`) so a slow backend call never erodes the effective TTL.
+    ///
+    /// cancel-safe: dropping this future early loses only a would-be cache
+    /// insert or single-flight slot — the lock and its `inflight` entry are
+    /// still released, via `AsyncMutex`'s guard and [`ReleaseTokenLockOnDrop`].
+    async fn authenticate_at(
+        &self,
+        token: &str,
+        now: Instant,
+    ) -> Result<PlatformIdentity, InternalAuthNError> {
+        match self.lookup(token, now) {
+            CacheLookup::Valid(identity) => return Ok(identity),
+            CacheLookup::Rejected => return Err(InternalAuthNError::InvalidToken),
+            CacheLookup::Miss => {}
+        }
+
+        // Single-flight: serialize concurrent misses for the same token so a
+        // burst of calls collapses into one backend round-trip.
+        let lock = self.token_lock(token);
+        let _guard = lock.lock().await;
+        // Cleans up `inflight` on drop too, so cancellation doesn't leak it.
+        let _release = ReleaseTokenLockOnDrop {
+            owner: self,
+            token,
+            lock: &lock,
+        };
+
+        // Another caller may have populated the cache while this one waited.
+        // Refresh the cutoff: `now` predates the lock wait, so a stale value
+        // could serve an entry that expired during it. Later of the injected
+        // instant and real time keeps a test's deterministic `now` dominant.
+        let now = now.max(Instant::now());
+        match self.lookup(token, now) {
+            CacheLookup::Valid(identity) => return Ok(identity),
+            CacheLookup::Rejected => return Err(InternalAuthNError::InvalidToken),
+            CacheLookup::Miss => {}
+        }
+
+        let result = self.inner.authenticate(token).await;
+        // Re-sampled *after* the backend round-trip: sampling before it would
+        // shrink the effective TTL by however long the call took.
+        let stored_at = Instant::now();
+
+        match result {
+            Ok(identity) => {
+                let expires_at = clamped_expiry(token, stored_at, self.ttl);
+                self.insert(
+                    token.to_owned(),
+                    CacheEntry::Valid {
+                        identity: identity.clone(),
+                        expires_at,
+                    },
+                    stored_at,
+                );
+                Ok(identity)
+            }
+            Err(InternalAuthNError::InvalidToken) => {
+                self.insert(
+                    token.to_owned(),
+                    CacheEntry::Rejected {
+                        expires_at: stored_at + NEGATIVE_CACHE_TTL,
+                    },
+                    stored_at,
+                );
+                Err(InternalAuthNError::InvalidToken)
+            }
+            // Backend outage / unexpected failure: never cached, so a
+            // recovery or a later attempt is re-evaluated immediately.
+            Err(err) => Err(err),
+        }
+    }
+}
+
+impl<A: InternalAuthenticator> InternalAuthenticator for CachingInternalAuthenticator<A> {
+    async fn authenticate(&self, token: &str) -> Result<PlatformIdentity, InternalAuthNError> {
+        self.authenticate_at(token, Instant::now()).await
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    /// Counts backend calls and can be flipped between success and one of two
+    /// failure modes so tests can assert exactly when the wrapped
+    /// authenticator is consulted.
+    struct CountingAuth {
+        calls: AtomicUsize,
+        mode: Mutex<Mode>,
+        /// Artificial delay before returning, to widen the single-flight
+        /// window so a concurrent waiter genuinely blocks on the per-token
+        /// lock instead of finding the cache already populated at its first
+        /// (pre-lock) check.
+        delay: Mutex<Duration>,
+    }
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Mode {
+        Succeed,
+        Unavailable,
+        Invalid,
+    }
+
+    impl CountingAuth {
+        fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                mode: Mutex::new(Mode::Succeed),
+                delay: Mutex::new(Duration::ZERO),
+            }
+        }
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+        fn set_mode(&self, mode: Mode) {
+            *self.mode.lock() = mode;
+        }
+        fn set_delay(&self, delay: Duration) {
+            *self.delay.lock() = delay;
+        }
+    }
+
+    impl InternalAuthenticator for CountingAuth {
+        async fn authenticate(&self, token: &str) -> Result<PlatformIdentity, InternalAuthNError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let delay = *self.delay.lock();
+            if !delay.is_zero() {
+                tokio::time::sleep(delay).await;
+            }
+            match *self.mode.lock() {
+                Mode::Succeed => Ok(PlatformIdentity::Shared {
+                    name: token.to_owned(),
+                }),
+                Mode::Unavailable => Err(InternalAuthNError::Unavailable),
+                Mode::Invalid => Err(InternalAuthNError::InvalidToken),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn second_call_within_ttl_hits_cache() {
+        let cached =
+            CachingInternalAuthenticator::new(CountingAuth::new(), Duration::from_mins(1)).unwrap();
+
+        let a = cached.authenticate("tok").await.unwrap();
+        let b = cached.authenticate("tok").await.unwrap();
+        assert_eq!(a, b);
+        assert_eq!(
+            cached.inner.calls(),
+            1,
+            "second call must be served from cache"
+        );
+        assert_eq!(
+            a.peer_name(),
+            "tok",
+            "cached identity must match the token it was issued for"
+        );
+    }
+
+    #[tokio::test]
+    async fn distinct_tokens_are_cached_independently() {
+        let cached =
+            CachingInternalAuthenticator::new(CountingAuth::new(), Duration::from_mins(1)).unwrap();
+
+        let a = cached.authenticate("a").await.unwrap();
+        let b = cached.authenticate("b").await.unwrap();
+        let a2 = cached.authenticate("a").await.unwrap();
+        assert_eq!(
+            cached.inner.calls(),
+            2,
+            "each distinct token validated once"
+        );
+        assert_eq!(a.peer_name(), "a");
+        assert_eq!(b.peer_name(), "b");
+        assert_eq!(
+            a2.peer_name(),
+            "a",
+            "cache must not confuse token identities"
+        );
+    }
+
+    #[tokio::test]
+    async fn entry_expires_after_ttl() {
+        // Deterministic via `authenticate_at`, not a real sleep: this crate's
+        // cache samples `Instant::now()` internally, which `tokio::time::pause`
+        // cannot virtualize, so a real-time sleep would be both wall-clock
+        // dependent and slow.
+        let cached =
+            CachingInternalAuthenticator::new(CountingAuth::new(), Duration::from_millis(20))
+                .unwrap();
+        let t0 = Instant::now();
+
+        cached.authenticate_at("tok", t0).await.unwrap();
+        assert_eq!(cached.inner.calls(), 1);
+
+        cached
+            .authenticate_at("tok", t0 + Duration::from_millis(21))
+            .await
+            .unwrap();
+        assert_eq!(
+            cached.inner.calls(),
+            2,
+            "expired entry must be re-validated"
+        );
+    }
+
+    #[tokio::test]
+    async fn unavailable_errors_are_not_cached() {
+        let cached =
+            CachingInternalAuthenticator::new(CountingAuth::new(), Duration::from_mins(1)).unwrap();
+        cached.inner.set_mode(Mode::Unavailable);
+
+        assert!(cached.authenticate("tok").await.is_err());
+        assert!(cached.authenticate("tok").await.is_err());
+        assert_eq!(
+            cached.inner.calls(),
+            2,
+            "backend outages must not be cached"
+        );
+
+        // Once the backend recovers, the next call succeeds and is then cached.
+        cached.inner.set_mode(Mode::Succeed);
+        cached.authenticate("tok").await.unwrap();
+        cached.authenticate("tok").await.unwrap();
+        assert_eq!(
+            cached.inner.calls(),
+            3,
+            "recovery validated once, then cached"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_token_rejections_are_briefly_negative_cached() {
+        let cached =
+            CachingInternalAuthenticator::new(CountingAuth::new(), Duration::from_mins(1)).unwrap();
+        cached.inner.set_mode(Mode::Invalid);
+
+        let err = cached.authenticate("bad").await.unwrap_err();
+        assert!(matches!(err, InternalAuthNError::InvalidToken));
+        // A second rejection within the negative-cache window is served
+        // without a second backend call.
+        let err = cached.authenticate("bad").await.unwrap_err();
+        assert!(matches!(err, InternalAuthNError::InvalidToken));
+        assert_eq!(
+            cached.inner.calls(),
+            1,
+            "a cached rejection must not re-hit the backend"
+        );
+
+        tokio::time::sleep(NEGATIVE_CACHE_TTL + Duration::from_millis(50)).await;
+        cached.inner.set_mode(Mode::Succeed);
+        let identity = cached.authenticate("bad").await.unwrap();
+        assert_eq!(
+            identity.peer_name(),
+            "bad",
+            "the token validates once the backend accepts it"
+        );
+        assert_eq!(cached.inner.calls(), 2);
+    }
+
+    #[test]
+    fn new_rejects_zero_and_over_max_ttl() {
+        assert!(CachingInternalAuthenticator::new(CountingAuth::new(), Duration::ZERO).is_err());
+        assert!(
+            CachingInternalAuthenticator::new(
+                CountingAuth::new(),
+                MAX_TOKEN_REVIEW_CACHE_TTL + Duration::from_secs(1)
+            )
+            .is_err()
+        );
+        assert!(
+            CachingInternalAuthenticator::new(CountingAuth::new(), MAX_TOKEN_REVIEW_CACHE_TTL)
+                .is_ok()
+        );
+    }
+
+    fn valid_entry(name: &str, expires_at: Instant) -> CacheEntry {
+        CacheEntry::Valid {
+            identity: PlatformIdentity::Shared {
+                name: name.to_owned(),
+            },
+            expires_at,
+        }
+    }
+
+    #[test]
+    fn capacity_bound_evicts_soonest_to_expire_when_full() {
+        let cached =
+            CachingInternalAuthenticator::new(CountingAuth::new(), Duration::from_mins(1)).unwrap();
+        let now = Instant::now();
+
+        for i in 0..MAX_CACHE_ENTRIES {
+            let name = format!("tok-{i}");
+            // Ascending expiry: `tok-0` expires soonest.
+            let expires_at = now + Duration::from_mins(1) + Duration::from_micros(i as u64);
+            cached.insert(name.clone(), valid_entry(&name, expires_at), now);
+        }
+        assert_eq!(cached.cache.lock().len(), MAX_CACHE_ENTRIES);
+
+        cached.insert(
+            "overflow".to_owned(),
+            valid_entry("overflow", now + Duration::from_mins(2)),
+            now,
+        );
+
+        let cache = cached.cache.lock();
+        assert_eq!(
+            cache.len(),
+            MAX_CACHE_ENTRIES,
+            "cache must never grow past MAX_CACHE_ENTRIES"
+        );
+        assert!(
+            cache.contains_key("overflow"),
+            "the newly inserted token must be present"
+        );
+        assert!(
+            !cache.contains_key("tok-0"),
+            "the soonest-to-expire entry must be evicted to make room"
+        );
+    }
+
+    #[test]
+    fn full_cache_reclaims_expired_before_scanning_for_a_victim() {
+        let cached =
+            CachingInternalAuthenticator::new(CountingAuth::new(), Duration::from_mins(1)).unwrap();
+        let now = Instant::now();
+
+        // Fill one short of capacity with valid, far-future entries: the
+        // soonest-to-expire scan would pick one of these if an expired entry
+        // were not reclaimed first.
+        for i in 1..MAX_CACHE_ENTRIES {
+            let name = format!("tok-{i}");
+            let expires_at = now + Duration::from_mins(5) + Duration::from_micros(i as u64);
+            cached.insert(name.clone(), valid_entry(&name, expires_at), now);
+        }
+        // Insert the already-expired entry last so a periodic sweep during the
+        // fill loop above cannot reclaim it before the capacity path runs.
+        cached.insert(
+            "expired".to_owned(),
+            valid_entry("expired", now.checked_sub(Duration::from_secs(1)).unwrap()),
+            now,
+        );
+        assert_eq!(cached.cache.lock().len(), MAX_CACHE_ENTRIES);
+
+        cached.insert(
+            "overflow".to_owned(),
+            valid_entry("overflow", now + Duration::from_mins(10)),
+            now,
+        );
+
+        let cache = cached.cache.lock();
+        assert_eq!(cache.len(), MAX_CACHE_ENTRIES);
+        assert!(cache.contains_key("overflow"));
+        assert!(
+            !cache.contains_key("expired"),
+            "the expired entry must be reclaimed by the sweep, making room"
+        );
+        assert!(
+            cache.contains_key("tok-1"),
+            "a still-valid entry must not be evicted while an expired one exists"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_misses_for_the_same_token_single_flight() {
+        let cached = Arc::new(
+            CachingInternalAuthenticator::new(CountingAuth::new(), Duration::from_mins(1)).unwrap(),
+        );
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let cached = Arc::clone(&cached);
+            handles.push(tokio::spawn(
+                async move { cached.authenticate("burst").await },
+            ));
+        }
+        for handle in handles {
+            handle.await.unwrap().unwrap();
+        }
+
+        assert_eq!(
+            cached.inner.calls(),
+            1,
+            "a burst of concurrent misses for the same token must collapse to one backend call"
+        );
+    }
+
+    #[tokio::test]
+    async fn aborting_an_inflight_call_still_releases_the_single_flight_slot() {
+        let auth = CountingAuth::new();
+        auth.set_delay(Duration::from_millis(200));
+        let cached =
+            Arc::new(CachingInternalAuthenticator::new(auth, Duration::from_mins(1)).unwrap());
+
+        let handle = {
+            let cached = Arc::clone(&cached);
+            tokio::spawn(async move { cached.authenticate("burst").await })
+        };
+        // Give the task time to take the single-flight lock and start
+        // blocking on the (delayed) backend call before aborting it.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        handle.abort();
+        let result = handle.await;
+        assert!(
+            result.unwrap_err().is_cancelled(),
+            "the task must actually have been aborted mid-flight for this test to be meaningful"
+        );
+
+        assert!(
+            cached.inflight.lock().is_empty(),
+            "aborting an in-flight call must not leak its single-flight slot"
+        );
+
+        // The slot must also be fully usable afterwards: a fresh call for the
+        // same token must not deadlock on a lock nobody will ever release.
+        let identity = tokio::time::timeout(Duration::from_secs(1), cached.authenticate("burst"))
+            .await
+            .expect("post-abort call must not hang")
+            .unwrap();
+        assert_eq!(identity.peer_name(), "burst");
+    }
+
+    #[test]
+    fn clamped_expiry_never_extends_trust_past_an_expired_jwt() {
+        let now = Instant::now();
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"exp":1}"#);
+        let expired_token = format!("h.{payload}.s");
+        assert_eq!(
+            clamped_expiry(&expired_token, now, Duration::from_mins(1)),
+            now,
+            "a JWT already expired per its own claim must not be trusted at all"
+        );
+    }
+
+    #[test]
+    fn clamped_expiry_uses_jwt_remaining_life_when_shorter_than_ttl() {
+        let now = Instant::now();
+        let exp = (SystemTime::now() + Duration::from_secs(2))
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{exp}}}"#));
+        let token = format!("h.{payload}.s");
+        let expiry = clamped_expiry(&token, now, Duration::from_mins(5));
+        assert!(
+            expiry < now + Duration::from_mins(5),
+            "a JWT with less remaining life than the configured ttl must clamp to the JWT's expiry"
+        );
+    }
+
+    #[tokio::test]
+    async fn second_waiter_reuses_result_populated_while_it_waited() {
+        let auth = CountingAuth::new();
+        auth.set_delay(Duration::from_millis(50));
+        let cached =
+            Arc::new(CachingInternalAuthenticator::new(auth, Duration::from_mins(1)).unwrap());
+
+        let first = {
+            let cached = Arc::clone(&cached);
+            tokio::spawn(async move { cached.authenticate("burst").await })
+        };
+        // Give the first call time to take the single-flight lock and start
+        // its (delayed) backend call, so this call genuinely blocks on the
+        // lock instead of racing it.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let second = cached.authenticate("burst").await.unwrap();
+        let first = first.await.unwrap().unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(
+            cached.inner.calls(),
+            1,
+            "a waiter that blocked on the single-flight lock must reuse the result the winner stored"
+        );
+    }
+
+    #[tokio::test]
+    async fn second_waiter_reuses_rejection_populated_while_it_waited() {
+        let auth = CountingAuth::new();
+        auth.set_delay(Duration::from_millis(50));
+        auth.set_mode(Mode::Invalid);
+        let cached =
+            Arc::new(CachingInternalAuthenticator::new(auth, Duration::from_mins(1)).unwrap());
+
+        let first = {
+            let cached = Arc::clone(&cached);
+            tokio::spawn(async move { cached.authenticate("burst").await })
+        };
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let second = cached.authenticate("burst").await;
+        let first = first.await.unwrap();
+
+        assert!(matches!(first, Err(InternalAuthNError::InvalidToken)));
+        assert!(matches!(second, Err(InternalAuthNError::InvalidToken)));
+        assert_eq!(
+            cached.inner.calls(),
+            1,
+            "a waiter that blocked on the single-flight lock must reuse the cached rejection"
+        );
+    }
+
+    #[tokio::test]
+    async fn lock_waiter_revalidates_an_entry_that_expired_during_the_wait() {
+        let auth = CountingAuth::new();
+        // Widen the single-flight window so the second caller genuinely blocks
+        // on the per-token lock across the winner's backend round-trip.
+        auth.set_delay(Duration::from_millis(50));
+        let cached =
+            Arc::new(CachingInternalAuthenticator::new(auth, Duration::from_mins(1)).unwrap());
+
+        // An already-expired JWT: the backend accepts it, but `clamped_expiry`
+        // stores it with `expires_at == stored_at` — expired the instant it
+        // lands. A waiter that re-checked with its pre-wait `now` (sampled
+        // before `stored_at`) would wrongly serve it; the refreshed cutoff must
+        // treat it as a miss and re-validate.
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"exp":1}"#);
+        let token = format!("h.{payload}.s");
+
+        let first = {
+            let cached = Arc::clone(&cached);
+            let token = token.clone();
+            tokio::spawn(async move { cached.authenticate(&token).await })
+        };
+        // Let the winner take the lock and start its (delayed) backend call so
+        // this caller blocks on the lock rather than racing it.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        cached.authenticate(&token).await.unwrap();
+        first.await.unwrap().unwrap();
+
+        assert_eq!(
+            cached.inner.calls(),
+            2,
+            "a waiter must re-validate an entry that expired during its wait, not serve it stale"
+        );
+    }
+
+    #[test]
+    fn jwt_exp_claim_extracts_and_ignores_non_jwt() {
+        // header.payload.signature, payload = {"exp":123} base64url (no padding).
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"exp":123}"#);
+        let token = format!("h.{payload}.s");
+        assert_eq!(jwt_exp_claim(&token), Some(123));
+
+        assert_eq!(jwt_exp_claim("not-a-jwt"), None);
+        assert_eq!(jwt_exp_claim("shared-secret-token"), None);
+    }
+}

--- a/libs/toolkit-security/src/lib.rs
+++ b/libs/toolkit-security/src/lib.rs
@@ -5,6 +5,8 @@ pub mod bin_codec;
 pub mod constants;
 pub mod context;
 pub mod internal_auth;
+#[cfg(feature = "internal-auth-cache")]
+pub mod internal_auth_cache;
 pub mod internal_auth_config;
 pub mod prelude;
 pub mod shared_secret;
@@ -21,6 +23,11 @@ pub use context::{SecurityContext, SecurityContextBuildError};
 pub use internal_auth::{
     InternalAuthNError, InternalAuthenticator, InternalCredential, PeerAuthenticated,
     PlatformIdentity, PlatformSecurityContext,
+};
+#[cfg(feature = "internal-auth-cache")]
+pub use internal_auth_cache::{
+    CachingInternalAuthenticator, DEFAULT_TOKEN_REVIEW_CACHE_TTL, InvalidCacheTtl,
+    MAX_TOKEN_REVIEW_CACHE_TTL,
 };
 pub use internal_auth_config::{DEFAULT_INTERNAL_PEER_NAME, InternalAuthConfig};
 pub use shared_secret::SharedSecretInternalAuthenticator;

--- a/libs/toolkit-transport-grpc/Cargo.toml
+++ b/libs/toolkit-transport-grpc/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 tonic = { workspace = true }
 toolkit-security = { workspace = true }
 
+futures-util = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
@@ -34,6 +35,8 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 secrecy = { workspace = true }
 parking_lot = { workspace = true }
+tower = { workspace = true }
+http = { workspace = true }
 
 [dev-dependencies]
-http = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/libs/toolkit-transport-grpc/src/internal_auth.rs
+++ b/libs/toolkit-transport-grpc/src/internal_auth.rs
@@ -14,10 +14,10 @@
 //!
 //! Inbound server-side validation (e.g. protecting `DirectoryService`
 //! register/resolve RPCs) is **async** — it cannot use tonic's synchronous
-//! `Interceptor` trait — and its enforcement is installed at the bootstrap /
-//! orchestrator wiring layer, reusing
-//! [`extract_internal_token_grpc`] together with the
-//! `toolkit_security::InternalAuthenticator` trait.
+//! `Interceptor` trait — and is provided as a Tower layer,
+//! [`InternalAuthGrpcLayer`](crate::internal_auth_server::InternalAuthGrpcLayer),
+//! installed on the tonic `Server`. It reuses the same
+//! `toolkit_security::InternalAuthenticator` trait as the outbound path.
 
 use std::sync::Arc;
 

--- a/libs/toolkit-transport-grpc/src/internal_auth_server.rs
+++ b/libs/toolkit-transport-grpc/src/internal_auth_server.rs
@@ -1,0 +1,686 @@
+//! Inbound (server-side) platform-plane authentication for gRPC.
+//!
+//! [`InternalAuthGrpcLayer`] is the gRPC counterpart of the HTTP
+//! `internal_auth_middleware`: a Tower [`Layer`] installed on a tonic
+//! `Server` that validates the `x-toolkit-internal-token` metadata on every
+//! inbound RPC and, on success, inserts a
+//! [`PlatformSecurityContext`] and a [`PeerAuthenticated`] marker into the
+//! request extensions so downstream handlers can read them
+//! (`cpt-cf-adr-platform-plane-auth`).
+//!
+//! Validation is **async** (the K8s `TokenReview` backend is an out-of-process
+//! call), so this cannot use tonic's synchronous `Interceptor` trait — it is a
+//! Tower service operating at the `http::Request`/`http::Response` layer, which
+//! tonic propagates into the handler's [`tonic::Request`] extensions.
+//!
+//! # Enforcement
+//!
+//! - [`InternalAuthEnforcement::Required`] (default) — a non-exempt RPC without
+//!   a valid token is rejected. This is the mode a platform-plane-only listener
+//!   uses.
+//! - [`InternalAuthEnforcement::Permissive`] — an **absent** token passes
+//!   through unauthenticated (mirroring the HTTP middleware), for listeners that
+//!   also serve tenant-plane / anonymous RPCs. A **present-but-invalid** token
+//!   is always rejected regardless of mode.
+//!
+//! Disabling enforcement entirely (Profile 1 / in-process: the process
+//! boundary is the trust root) is a deliberate call —
+//! [`InternalAuthGrpcLayer::disabled`] — distinct from "no authenticator was
+//! supplied", so a caller cannot reach the fully-open configuration by
+//! accident (e.g. by forgetting to wire a configured authenticator through).
+//!
+//! # Exempt methods
+//!
+//! Infrastructure RPCs (gRPC health checking, server reflection) are exempt by
+//! path prefix — see [`DEFAULT_EXEMPT_PREFIXES`]. The allowlist is configurable
+//! via [`InternalAuthGrpcLayer::with_exempt_prefixes`]. A prefix only matches on
+//! a method-path segment boundary (see [`prefix_matches_boundary`]) so e.g. the
+//! reflection prefix cannot be satisfied by an unrelated package that merely
+//! shares the string prefix.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use futures_util::future::Either;
+use secrecy::{ExposeSecret, SecretString};
+use tonic::Status;
+use toolkit_security::constants::INTERNAL_TOKEN_HEADER;
+use toolkit_security::{
+    DynInternalAuthenticator, InternalAuthNError, InternalAuthenticator, PeerAuthenticated,
+    PlatformSecurityContext,
+};
+use tower::{Layer, Service};
+
+/// gRPC method path prefixes exempt from platform-plane enforcement by default.
+///
+/// These are the infrastructure services a client or load balancer probes
+/// before (or independently of) authenticating: the standard health-checking
+/// service and both versions of the reflection service, spelled out in full
+/// (not a bare `grpc.reflection.` prefix) so an unrelated package that merely
+/// shares the string prefix (e.g. `grpc.reflection.evil.Svc`) is never
+/// accidentally exempted.
+pub const DEFAULT_EXEMPT_PREFIXES: &[&str] = &[
+    "/grpc.health.v1.Health/",
+    "/grpc.reflection.v1.ServerReflection/",
+    "/grpc.reflection.v1alpha.ServerReflection/",
+];
+
+/// Whether an **absent** platform-plane credential is rejected or allowed.
+///
+/// A present-but-invalid credential is always rejected, in either mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InternalAuthEnforcement {
+    /// Reject a non-exempt RPC that does not present a valid token. The mode a
+    /// dedicated platform-plane listener uses.
+    #[default]
+    Required,
+    /// Let an RPC that presents **no** token through unauthenticated (the tenant
+    /// plane, if any, is enforced separately). Mirrors the HTTP middleware.
+    Permissive,
+}
+
+/// Whether the layer validates inbound requests or passes every request
+/// through untouched.
+///
+/// Kept as its own type (rather than `Option<DynInternalAuthenticator>`
+/// inline) so "authentication deliberately disabled" is a distinct,
+/// explicitly-constructed state from "no authenticator value was passed"
+/// (`cpt-cf-adr-platform-plane-auth`).
+#[derive(Clone)]
+enum AuthMode {
+    /// Profile 1 / in-process: every request passes through untouched.
+    Disabled,
+    /// Every non-exempt request is validated against this authenticator.
+    Enforced(DynInternalAuthenticator),
+}
+
+/// Immutable, shared configuration behind a [`InternalAuthGrpcLayer`].
+#[derive(Clone)]
+struct Config {
+    mode: AuthMode,
+    /// How an absent credential is treated.
+    enforcement: InternalAuthEnforcement,
+    /// gRPC method path prefixes exempt from enforcement.
+    exempt_prefixes: Vec<String>,
+}
+
+/// Tower [`Layer`] that enforces the platform plane on inbound gRPC requests.
+///
+/// Install it on a tonic server with `Server::builder().layer(layer)`. The
+/// layer is server-wide: it applies to every service mounted on that server
+/// (tonic cannot layer an async middleware onto a single service without losing
+/// `NamedService`).
+#[derive(Clone)]
+pub struct InternalAuthGrpcLayer {
+    config: Arc<Config>,
+}
+
+impl std::fmt::Debug for InternalAuthGrpcLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InternalAuthGrpcLayer")
+            .field(
+                "enforced",
+                &matches!(self.config.mode, AuthMode::Enforced(_)),
+            )
+            .field("enforcement", &self.config.enforcement)
+            .field("exempt_prefixes", &self.config.exempt_prefixes)
+            .finish()
+    }
+}
+
+impl InternalAuthGrpcLayer {
+    fn with_mode(mode: AuthMode) -> Self {
+        Self {
+            config: Arc::new(Config {
+                mode,
+                enforcement: InternalAuthEnforcement::Required,
+                exempt_prefixes: DEFAULT_EXEMPT_PREFIXES
+                    .iter()
+                    .map(|p| (*p).to_owned())
+                    .collect(),
+            }),
+        }
+    }
+
+    /// Build a layer that validates every non-exempt request against
+    /// `authenticator`.
+    ///
+    /// Enforcement defaults to [`InternalAuthEnforcement::Required`] with the
+    /// [`DEFAULT_EXEMPT_PREFIXES`] allowlist.
+    #[must_use]
+    pub fn new(authenticator: DynInternalAuthenticator) -> Self {
+        Self::with_mode(AuthMode::Enforced(authenticator))
+    }
+
+    /// Build a layer that passes every request through untouched.
+    ///
+    /// This is the explicit, deliberate way to disable platform-plane
+    /// enforcement (Profile 1 / in-process, where the process boundary is the
+    /// trust root) — distinct from "no authenticator was configured", which
+    /// this type cannot represent.
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self::with_mode(AuthMode::Disabled)
+    }
+
+    /// Override how an absent credential is treated (default:
+    /// [`InternalAuthEnforcement::Required`]).
+    #[must_use]
+    pub fn with_enforcement(mut self, enforcement: InternalAuthEnforcement) -> Self {
+        Arc::make_mut(&mut self.config).enforcement = enforcement;
+        self
+    }
+
+    /// Replace the exempt method-path allowlist (default:
+    /// [`DEFAULT_EXEMPT_PREFIXES`]).
+    ///
+    /// Each entry is matched against the gRPC method path
+    /// (`/<package>.<Service>/<Method>`) on a segment boundary (see
+    /// [`prefix_matches_boundary`]) — an empty string or a prefix lacking a
+    /// leading `/` can never match, so a config typo cannot silently exempt
+    /// every method. Pass an empty vector to enforce on every method.
+    #[must_use]
+    pub fn with_exempt_prefixes(mut self, prefixes: Vec<String>) -> Self {
+        let prefixes = prefixes
+            .into_iter()
+            .filter(|p| !p.is_empty() && p.starts_with('/'))
+            .collect();
+        Arc::make_mut(&mut self.config).exempt_prefixes = prefixes;
+        self
+    }
+}
+
+impl<S> Layer<S> for InternalAuthGrpcLayer {
+    type Service = InternalAuthGrpcService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        InternalAuthGrpcService {
+            inner,
+            config: Arc::clone(&self.config),
+        }
+    }
+}
+
+/// The [`Service`] produced by [`InternalAuthGrpcLayer`].
+#[derive(Clone)]
+pub struct InternalAuthGrpcService<S> {
+    inner: S,
+    config: Arc<Config>,
+}
+
+/// Outcome of reading the internal-token header off an inbound request.
+enum TokenOutcome {
+    /// A single, non-empty token was present.
+    Present(SecretString),
+    /// No internal-token header was present.
+    Missing,
+    /// The header was present but malformed (non-ASCII, empty, or repeated).
+    Invalid,
+}
+
+/// Read (and, on a definitive outcome, consume) the
+/// `x-toolkit-internal-token` header from an inbound request.
+///
+/// A header repeated more than once is rejected outright rather than silently
+/// validating the first occurrence and forwarding the rest untouched.
+fn read_token(headers: &mut http::HeaderMap) -> TokenOutcome {
+    let mut values = headers.get_all(INTERNAL_TOKEN_HEADER).iter();
+    let Some(first) = values.next() else {
+        return TokenOutcome::Missing;
+    };
+    if values.next().is_some() {
+        return TokenOutcome::Invalid;
+    }
+    let Ok(raw) = first.to_str() else {
+        return TokenOutcome::Invalid;
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        TokenOutcome::Invalid
+    } else {
+        TokenOutcome::Present(SecretString::from(trimmed))
+    }
+}
+
+/// Map a neutral [`InternalAuthNError`] onto a gRPC [`Status`].
+///
+/// The token and any provider-specific detail are never surfaced on the wire.
+fn authn_error_to_status(err: &InternalAuthNError) -> Status {
+    match err {
+        InternalAuthNError::InvalidToken => Status::unauthenticated("invalid internal token"),
+        InternalAuthNError::Unavailable => Status::unavailable("internal-auth backend unavailable"),
+        // `Other` (and, defensively, any future neutral variant) is an
+        // unexpected infrastructure failure. `InternalAuthNError` is
+        // `#[non_exhaustive]`, so the wildcard is required.
+        _ => Status::internal("internal authentication failure"),
+    }
+}
+
+/// Whether `path` matches `prefix` on a method-path segment boundary: either
+/// `prefix` already ends with `/`, or `path` continues past `prefix` with a
+/// `/` (or ends exactly at `prefix`).
+///
+/// Prevents a prefix like `/pkg.Svc/List` from also matching
+/// `/pkg.Svc/ListSecrets`, and (for the built-in defaults) a bare
+/// `grpc.reflection.` prefix from matching an unrelated
+/// `grpc.reflection.evil.Svc` package.
+fn prefix_matches_boundary(path: &str, prefix: &str) -> bool {
+    let Some(rest) = path.strip_prefix(prefix) else {
+        return false;
+    };
+    prefix.ends_with('/') || rest.is_empty() || rest.starts_with('/')
+}
+
+impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for InternalAuthGrpcService<S>
+where
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Default + Send + 'static,
+{
+    type Response = http::Response<ResBody>;
+    type Error = S::Error;
+    // `Either::Left` (pass-through/exempt) skips the `Box::pin` allocation;
+    // only `Right` (enforced) needs it.
+    type Future = Either<
+        S::Future,
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    // cancel-safe: dropping this future before it resolves simply drops the
+    // in-flight authentication (or inner-service) call; no state is mutated
+    // by this layer outside the request/response it is handling, so a
+    // cancellation leaves nothing partially applied.
+    fn call(&mut self, mut req: http::Request<ReqBody>) -> Self::Future {
+        // Tower readiness contract: `poll_ready` was called on `self.inner`, so
+        // the readiness reservation belongs to it. Move that instance into the
+        // future and leave a fresh clone behind for the next call.
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        // Disabled layer (Profile 1 / in-process): straight pass-through.
+        let AuthMode::Enforced(authenticator) = &self.config.mode else {
+            return Either::Left(inner.call(req));
+        };
+
+        // Infrastructure methods (health, reflection) bypass enforcement.
+        let path = req.uri().path();
+        if self
+            .config
+            .exempt_prefixes
+            .iter()
+            .any(|prefix| prefix_matches_boundary(path, prefix))
+        {
+            return Either::Left(inner.call(req));
+        }
+
+        let config = Arc::clone(&self.config);
+        let authenticator = authenticator.clone();
+        let path = path.to_owned();
+
+        Either::Right(Box::pin(async move {
+            match read_token(req.headers_mut()) {
+                TokenOutcome::Present(token) => {
+                    match authenticator.authenticate(token.expose_secret()).await {
+                        Ok(identity) => {
+                            // The layer has consumed the credential; never
+                            // forward it to the handler.
+                            req.headers_mut().remove(INTERNAL_TOKEN_HEADER);
+                            let name = identity.peer_name().to_owned();
+                            tracing::debug!(
+                                peer = %name,
+                                method = %path,
+                                "platform-plane gRPC call authenticated"
+                            );
+                            req.extensions_mut().insert(PeerAuthenticated { name });
+                            req.extensions_mut()
+                                .insert(PlatformSecurityContext::new(identity));
+                            inner.call(req).await
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                error = %err,
+                                method = %path,
+                                "platform-plane gRPC authentication failed"
+                            );
+                            Ok(authn_error_to_status(&err).into_http())
+                        }
+                    }
+                }
+                // A malformed / empty / repeated credential is rejected in
+                // either mode.
+                TokenOutcome::Invalid => {
+                    tracing::warn!(
+                        method = %path,
+                        "platform-plane gRPC call rejected: malformed internal token"
+                    );
+                    Ok(Status::unauthenticated("invalid internal token").into_http())
+                }
+                TokenOutcome::Missing => match config.enforcement {
+                    InternalAuthEnforcement::Permissive => inner.call(req).await,
+                    InternalAuthEnforcement::Required => {
+                        tracing::warn!(
+                            method = %path,
+                            "platform-plane gRPC call rejected: missing internal token"
+                        );
+                        Ok(Status::unauthenticated("missing internal token").into_http())
+                    }
+                },
+            }
+        }))
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::convert::Infallible;
+    use std::future::{Ready, ready};
+
+    use toolkit_security::PlatformIdentity;
+
+    /// Header the [`Echo`] inner service sets to report whether the request
+    /// carried a validated [`PlatformSecurityContext`] extension by the time it
+    /// was called.
+    const HAD_CTX_HEADER: &str = "x-test-had-ctx";
+    /// Header reporting the [`PeerAuthenticated`] name the inner service saw.
+    const PEER_HEADER: &str = "x-test-peer";
+    /// Header reporting whether the inner service still saw the raw internal
+    /// token header (it must not, once the layer has consumed it).
+    const SAW_TOKEN_HEADER: &str = "x-test-saw-token";
+
+    /// Terminal inner service: records what extensions the request carried into
+    /// response headers so tests can assert the middleware populated them.
+    #[derive(Clone)]
+    struct Echo;
+
+    impl Service<http::Request<()>> for Echo {
+        type Response = http::Response<()>;
+        type Error = Infallible;
+        type Future = Ready<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: http::Request<()>) -> Self::Future {
+            let had_ctx = req.extensions().get::<PlatformSecurityContext>().is_some();
+            let peer = req
+                .extensions()
+                .get::<PeerAuthenticated>()
+                .map(|p| p.name.clone())
+                .unwrap_or_default();
+            let saw_token = req.headers().get(INTERNAL_TOKEN_HEADER).is_some();
+            let mut resp = http::Response::new(());
+            resp.headers_mut().insert(
+                HAD_CTX_HEADER,
+                if had_ctx { "1" } else { "0" }.parse().unwrap(),
+            );
+            resp.headers_mut().insert(
+                PEER_HEADER,
+                peer.parse().unwrap_or_else(|_| "".parse().unwrap()),
+            );
+            resp.headers_mut().insert(
+                SAW_TOKEN_HEADER,
+                if saw_token { "1" } else { "0" }.parse().unwrap(),
+            );
+            ready(Ok(resp))
+        }
+    }
+
+    /// A fake platform-plane validator: `"good"` authenticates as `peer-x`,
+    /// `"down"` is a backend outage, `"broken"` is an unexpected
+    /// infrastructure failure, anything else is an invalid token.
+    struct FakeAuth;
+
+    impl InternalAuthenticator for FakeAuth {
+        async fn authenticate(&self, token: &str) -> Result<PlatformIdentity, InternalAuthNError> {
+            match token {
+                "good" => Ok(PlatformIdentity::Shared {
+                    name: "peer-x".to_owned(),
+                }),
+                "down" => Err(InternalAuthNError::Unavailable),
+                "broken" => Err(InternalAuthNError::Other("boom".to_owned())),
+                _ => Err(InternalAuthNError::InvalidToken),
+            }
+        }
+    }
+
+    fn authed_layer() -> InternalAuthGrpcLayer {
+        InternalAuthGrpcLayer::new(DynInternalAuthenticator::new(FakeAuth))
+    }
+
+    fn request(path: &str, token: Option<&str>) -> http::Request<()> {
+        let mut builder = http::Request::builder().uri(path);
+        if let Some(token) = token {
+            builder = builder.header(INTERNAL_TOKEN_HEADER, token);
+        }
+        builder.body(()).unwrap()
+    }
+
+    /// Drive one request through the layered service, going through the
+    /// Tower `poll_ready`/`call` contract (rather than calling `call`
+    /// directly) to also exercise `InternalAuthGrpcService::poll_ready` and
+    /// the inner `Echo::poll_ready`.
+    async fn call(layer: &InternalAuthGrpcLayer, req: http::Request<()>) -> http::Response<()> {
+        let mut svc = layer.clone().layer(Echo);
+        tower::ServiceExt::ready(&mut svc).await.unwrap();
+        svc.call(req).await.unwrap()
+    }
+
+    fn grpc_status(resp: &http::Response<()>) -> Option<i32> {
+        resp.headers()
+            .get("grpc-status")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse().ok())
+    }
+
+    #[tokio::test]
+    async fn disabled_layer_passes_through() {
+        let layer = InternalAuthGrpcLayer::disabled();
+        // No token, Required-by-default — but disabled is a no-op.
+        let resp = call(&layer, request("/pkg.Svc/Method", None)).await;
+        assert!(grpc_status(&resp).is_none(), "must not reject");
+        assert_eq!(resp.headers().get(HAD_CTX_HEADER).unwrap(), "0");
+    }
+
+    #[tokio::test]
+    async fn required_rejects_missing_token() {
+        let resp = call(&authed_layer(), request("/pkg.Svc/Method", None)).await;
+        // gRPC Unauthenticated == 16.
+        assert_eq!(grpc_status(&resp), Some(16));
+    }
+
+    #[tokio::test]
+    async fn valid_token_populates_extensions_and_is_stripped() {
+        let resp = call(&authed_layer(), request("/pkg.Svc/Method", Some("good"))).await;
+        assert!(grpc_status(&resp).is_none(), "valid token must not reject");
+        assert_eq!(resp.headers().get(HAD_CTX_HEADER).unwrap(), "1");
+        assert_eq!(resp.headers().get(PEER_HEADER).unwrap(), "peer-x");
+        assert_eq!(
+            resp.headers().get(SAW_TOKEN_HEADER).unwrap(),
+            "0",
+            "the handler must never see the raw internal token"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_token_is_rejected() {
+        let resp = call(&authed_layer(), request("/pkg.Svc/Method", Some("nope"))).await;
+        assert_eq!(grpc_status(&resp), Some(16));
+    }
+
+    #[tokio::test]
+    async fn empty_token_is_rejected_even_when_permissive() {
+        let layer = authed_layer().with_enforcement(InternalAuthEnforcement::Permissive);
+        let resp = call(&layer, request("/pkg.Svc/Method", Some("   "))).await;
+        assert_eq!(grpc_status(&resp), Some(16));
+    }
+
+    #[tokio::test]
+    async fn permissive_still_rejects_invalid_token() {
+        // The module doc's central claim: a present-but-invalid token is
+        // rejected regardless of mode, not just an empty/malformed one.
+        let layer = authed_layer().with_enforcement(InternalAuthEnforcement::Permissive);
+        let resp = call(&layer, request("/pkg.Svc/Method", Some("nope"))).await;
+        assert_eq!(grpc_status(&resp), Some(16));
+    }
+
+    #[tokio::test]
+    async fn permissive_still_maps_backend_outage_to_unavailable() {
+        let layer = authed_layer().with_enforcement(InternalAuthEnforcement::Permissive);
+        let resp = call(&layer, request("/pkg.Svc/Method", Some("down"))).await;
+        // gRPC Unavailable == 14.
+        assert_eq!(grpc_status(&resp), Some(14));
+    }
+
+    #[tokio::test]
+    async fn duplicate_token_header_is_rejected() {
+        let mut req = request("/pkg.Svc/Method", Some("good"));
+        req.headers_mut()
+            .append(INTERNAL_TOKEN_HEADER, "good".parse().unwrap());
+        let resp = call(&authed_layer(), req).await;
+        assert_eq!(
+            grpc_status(&resp),
+            Some(16),
+            "a repeated internal-token header must be rejected, not validated on the first value"
+        );
+    }
+
+    #[tokio::test]
+    async fn backend_unavailable_maps_to_unavailable() {
+        let resp = call(&authed_layer(), request("/pkg.Svc/Method", Some("down"))).await;
+        // gRPC Unavailable == 14.
+        assert_eq!(grpc_status(&resp), Some(14));
+    }
+
+    #[tokio::test]
+    async fn permissive_allows_missing_token() {
+        let layer = authed_layer().with_enforcement(InternalAuthEnforcement::Permissive);
+        let resp = call(&layer, request("/pkg.Svc/Method", None)).await;
+        assert!(
+            grpc_status(&resp).is_none(),
+            "permissive must allow anonymous"
+        );
+        assert_eq!(resp.headers().get(HAD_CTX_HEADER).unwrap(), "0");
+    }
+
+    #[tokio::test]
+    async fn exempt_path_bypasses_enforcement() {
+        // Health check with no token is allowed even under Required.
+        let resp = call(
+            &authed_layer(),
+            request("/grpc.health.v1.Health/Check", None),
+        )
+        .await;
+        assert!(
+            grpc_status(&resp).is_none(),
+            "exempt method must pass through"
+        );
+        assert_eq!(resp.headers().get(HAD_CTX_HEADER).unwrap(), "0");
+    }
+
+    #[tokio::test]
+    async fn reflection_boundary_does_not_leak_to_unrelated_package() {
+        // A package that merely shares the `grpc.reflection.` string prefix
+        // (but is neither of the two real reflection services) must not be
+        // exempted.
+        let resp = call(
+            &authed_layer(),
+            request("/grpc.reflection.evil.Svc/Method", None),
+        )
+        .await;
+        assert_eq!(
+            grpc_status(&resp),
+            Some(16),
+            "a look-alike package must not inherit the reflection exemption"
+        );
+    }
+
+    #[tokio::test]
+    async fn custom_exempt_prefixes_replace_defaults() {
+        let layer = authed_layer().with_exempt_prefixes(vec!["/my.Svc/".to_owned()]);
+        // The custom prefix is now exempt.
+        let resp = call(&layer, request("/my.Svc/Ping", None)).await;
+        assert!(grpc_status(&resp).is_none());
+        // The former default (health) is no longer exempt.
+        let resp = call(&layer, request("/grpc.health.v1.Health/Check", None)).await;
+        assert_eq!(grpc_status(&resp), Some(16));
+    }
+
+    #[tokio::test]
+    async fn malformed_exempt_prefixes_are_dropped() {
+        // An empty string or a prefix without a leading '/' can never match a
+        // gRPC method path, so keeping it in the allowlist would either do
+        // nothing or (for an empty string) match every path via `starts_with`.
+        // `with_exempt_prefixes` filters both out rather than accepting a
+        // config typo that silently disables enforcement server-wide.
+        let layer = authed_layer().with_exempt_prefixes(vec![
+            String::new(),
+            "no-leading-slash".to_owned(),
+            "/my.Svc/".to_owned(),
+        ]);
+        let resp = call(&layer, request("/pkg.Svc/Method", None)).await;
+        assert_eq!(
+            grpc_status(&resp),
+            Some(16),
+            "an empty exempt entry must not exempt every path"
+        );
+        let resp = call(&layer, request("/my.Svc/Ping", None)).await;
+        assert!(
+            grpc_status(&resp).is_none(),
+            "the valid entry still applies"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_ascii_token_header_is_rejected() {
+        let mut req = request("/pkg.Svc/Method", None);
+        req.headers_mut().insert(
+            INTERNAL_TOKEN_HEADER,
+            http::HeaderValue::from_bytes(b"\xff\xfe").unwrap(),
+        );
+        let resp = call(&authed_layer(), req).await;
+        assert_eq!(
+            grpc_status(&resp),
+            Some(16),
+            "a non-UTF-8 token header must be rejected, not silently ignored"
+        );
+    }
+
+    #[tokio::test]
+    async fn unexpected_backend_error_maps_to_internal() {
+        // `InternalAuthNError::Other` (and, defensively, any future
+        // non-exhaustive neutral variant) must never leak provider detail on
+        // the wire; it maps to gRPC `Internal`, not a token-shaped rejection.
+        let resp = call(&authed_layer(), request("/pkg.Svc/Method", Some("broken"))).await;
+        // gRPC Internal == 13.
+        assert_eq!(grpc_status(&resp), Some(13));
+    }
+
+    #[test]
+    fn prefix_boundary_examples() {
+        assert!(prefix_matches_boundary(
+            "/grpc.health.v1.Health/Check",
+            "/grpc.health.v1.Health/"
+        ));
+        assert!(!prefix_matches_boundary(
+            "/pkg.Svc/ListSecrets",
+            "/pkg.Svc/List"
+        ));
+        assert!(prefix_matches_boundary("/pkg.Svc/List", "/pkg.Svc/List"));
+        assert!(prefix_matches_boundary(
+            "/pkg.Svc/List/sub",
+            "/pkg.Svc/List"
+        ));
+    }
+}

--- a/libs/toolkit-transport-grpc/src/lib.rs
+++ b/libs/toolkit-transport-grpc/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 pub mod client;
 pub mod internal_auth;
+pub mod internal_auth_server;
 pub mod rpc_retry;
 pub mod sa_token;
 
@@ -13,6 +14,10 @@ pub use windows_named_pipe::{NamedPipeConnection, NamedPipeIncoming, create_name
 pub use internal_auth::{
     InternalAuthInterceptor, attach_internal_token_grpc, build_internal_auth_interceptor,
     extract_internal_token_grpc,
+};
+pub use internal_auth_server::{
+    DEFAULT_EXEMPT_PREFIXES, InternalAuthEnforcement, InternalAuthGrpcLayer,
+    InternalAuthGrpcService,
 };
 pub use sa_token::{DEFAULT_REFRESH_INTERVAL, ServiceAccountTokenReader};
 

--- a/libs/toolkit/src/bootstrap/oop.rs
+++ b/libs/toolkit/src/bootstrap/oop.rs
@@ -713,10 +713,14 @@ async fn build_oop_serve_options(
 /// Construct the inbound platform-plane authenticator from configuration.
 ///
 /// The `shared_secret` provider is built here directly (no external backend).
-/// The `kube` provider initializes the Kubernetes `TokenReview` authenticator
-/// and requires the `k8s-auth` feature; without it, `provider: kube` is an
-/// error rather than a silent enforcement downgrade. `Ok(None)` is returned
-/// only when no `internal_auth` is configured.
+/// The `kube` provider is built (with the default positive/negative
+/// validation cache) by the single shared
+/// `toolkit_k8s_auth::build_cached_k8s_authenticator` helper also used by
+/// `grpc-hub`, so the two never drift on what `provider: kube` means or how
+/// it is cached. The `kube` provider requires the `k8s-auth` feature; without
+/// it, `provider: kube` is an error rather than a silent enforcement
+/// downgrade, as is any other unrecognized provider value. `Ok(None)` is
+/// returned only when no `internal_auth` is configured at all (Profile 1).
 #[cfg_attr(not(feature = "k8s-auth"), allow(clippy::unused_async))]
 async fn build_internal_authenticator(
     cfg: Option<&toolkit_security::InternalAuthConfig>,
@@ -736,13 +740,13 @@ async fn build_internal_authenticator(
         if cfg.is_kube() {
             info!("Initializing Kubernetes TokenReview platform-plane authenticator");
             let audiences = cfg.kube_audiences().unwrap_or_default().to_vec();
-            let authenticator =
-                toolkit_k8s_auth::K8sTokenReviewAuthenticator::try_default(audiences)
-                    .await
-                    .context("failed to initialize Kubernetes TokenReview authenticator")?;
-            return Ok(Some(toolkit_security::DynInternalAuthenticator::new(
-                authenticator,
-            )));
+            let authenticator = toolkit_k8s_auth::build_cached_k8s_authenticator(
+                audiences,
+                Some(toolkit_security::DEFAULT_TOKEN_REVIEW_CACHE_TTL),
+            )
+            .await
+            .context("failed to initialize Kubernetes TokenReview authenticator")?;
+            return Ok(Some(authenticator));
         }
     }
     #[cfg(not(feature = "k8s-auth"))]
@@ -752,7 +756,9 @@ async fn build_internal_authenticator(
         }
     }
 
-    Ok(None)
+    anyhow::bail!(
+        "internal_auth is configured but no authenticator could be built for the selected provider"
+    )
 }
 
 /// Build the platform-plane credential material from config: the **outbound**


### PR DESCRIPTION
Closes #4576

Move `x-toolkit-internal-token` (platform-plane) enforcement out of per-service handler checks and into a single transport-level Tower layer applied by `grpc-hub` across every inbound RPC (`cpt-cf-adr-platform-plane-auth`). Previously, enforcement lived in `gear-orchestrator`'s `DirectoryService` and had to be re-implemented per handler; now it is enforced once, at the gRPC boundary, for all services mounted on the hub.
 
- `toolkit-transport-grpc`: new `InternalAuthGrpcLayer` - a Tower layer that validates the internal token on every inbound RPC (with configurable Required/Permissive enforcement and an exempt-method allowlist for health checks and reflection), and populates request extensions (`PlatformSecurityContext`, `PeerAuthenticated`) for downstream handlers.
- `toolkit-security`: new `CachingInternalAuthenticator` - a generic, TTL-bounded cache for any `InternalAuthenticator`, so a remote validation backend (e.g. Kubernetes `TokenReview`) isn't hit on every call.
- `toolkit-k8s-auth`: wires the kube `TokenReview` authenticator through the shared cache.
- `grpc-hub`: applies the layer to all three serve paths (TCP, Unix socket, named pipe); adds `internal_auth`, `internal_auth_enforcement`, `internal_auth_exempt_methods`, and `internal_auth_cache_ttl_secs` config; now owns the `k8s-auth` feature.
- `gear-orchestrator`: drops the old per-handler auth config and plumbing now that enforcement lives at the transport layer; fails `init` with a migration message if a deployment still has the old config set, so an upgrade can't silently drop enforcement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable platform authentication for gRPC Hub connections using shared secrets or Kubernetes tokens.
  * Added required or permissive enforcement, exempt method prefixes, and successful-authentication caching across supported gRPC transports.

* **Bug Fixes**
  * Invalid authentication settings and unsupported providers now produce clear startup errors.

* **Documentation**
  * Added configuration guidance for authentication providers, enforcement, exemptions, and caching.

* **Migration**
  * Legacy orchestrator authentication settings are rejected with guidance to configure authentication through gRPC Hub.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->