### PR TITLE
docs(oagw): reference required-headers-guard-plugin ADR in Architecture Drivers

### DIFF
--- a/gears/system/oagw/docs/DESIGN.md
+++ b/gears/system/oagw/docs/DESIGN.md
@@ -75,6 +75,7 @@ This design satisfies the requirements for centralized outbound traffic manageme
 - `cpt-cf-oagw-adr-grpc-support` — HTTP/2 multiplexing with protocol detection
 - `cpt-cf-oagw-adr-rust-abi-client-library` — Rust ABI client for internal gear routing
 - `cpt-cf-oagw-adr-oauth2-client-credentials-auth-plugin` — OAuth2 Client Credentials auth plugin with internal token cache
+- `cpt-cf-oagw-adr-required-headers-guard-plugin` — Stateless builtin `GuardPlugin` enforcing required request/response headers, fail-open when unconfigured
 
 ### 1.3 Architecture Layers
 


### PR DESCRIPTION
- ADR 0017 was never linked from DESIGN.md's Architecture Drivers section, which cfs validate flags as a missing cross-reference on every PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an architecture reference for a Required Headers Guard Plugin.
  * Documented enforcement of required request and response headers, including fail-open behavior when unconfigured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->