### PR TITLE
fix(api-gateway): seconds-scale bucket boundaries for http.server.request.duration

### DIFF
--- a/gears/system/api-gateway/src/middleware/http_metrics.rs
+++ b/gears/system/api-gateway/src/middleware/http_metrics.rs
@@ -21,6 +21,16 @@ use opentelemetry::{
     metrics::{Histogram, UpDownCounter},
 };
 
+/// [OTel semconv recommended boundaries][semconv] (seconds) for
+/// `http.server.request.duration`. Set explicitly because the SDK defaults
+/// are millisecond-scale and collapse seconds-valued observations into a
+/// single bucket, making percentiles meaningless.
+///
+/// [semconv]: https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration
+const DURATION_BOUNDARIES_SECS: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+];
+
 /// Holds the two OpenTelemetry instruments for HTTP server metrics.
 pub struct HttpMetrics {
     duration: Histogram<f64>,
@@ -56,6 +66,7 @@ impl HttpMetrics {
             .f64_histogram(duration_name)
             .with_description("Duration of HTTP server requests")
             .with_unit("s")
+            .with_boundaries(DURATION_BOUNDARIES_SECS.to_vec())
             .build();
 
         let active_requests = meter

--- a/gears/system/api-gateway/tests/http_metrics_tests.rs
+++ b/gears/system/api-gateway/tests/http_metrics_tests.rs
@@ -124,6 +124,24 @@ fn histogram_has_attributes(
     false
 }
 
+/// Extract the explicit bucket boundaries of the named histogram, if exported.
+fn histogram_bounds(exporter: &InMemoryMetricExporter, name: &str) -> Option<Vec<f64>> {
+    let metrics = exporter.get_finished_metrics().unwrap();
+    for resource_metrics in &metrics {
+        for scope_metrics in resource_metrics.scope_metrics() {
+            for metric in scope_metrics.metrics() {
+                if metric.name() == name
+                    && let AggregatedMetrics::F64(MetricData::Histogram(hist)) = metric.data()
+                    && let Some(dp) = hist.data_points().next()
+                {
+                    return Some(dp.bounds().collect());
+                }
+            }
+        }
+    }
+    None
+}
+
 async fn ok_handler() -> impl IntoResponse {
     StatusCode::OK
 }
@@ -437,6 +455,53 @@ async fn metrics_unmatched_route() -> Result<()> {
             ]
         ),
         "unmatched route should have http.route='unmatched' and status 404"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn metrics_duration_uses_second_scale_bucket_boundaries() -> Result<()> {
+    let _lock = METER_LOCK.lock().await;
+    let (provider, exporter) = install_test_meter_provider();
+    let ctx = create_api_gateway_ctx(base_config());
+    let api = api_gateway::ApiGateway::default();
+    api.init(&ctx).await?;
+
+    let router = OperationBuilder::get("/tests/v1/items")
+        .operation_id("test:list-items")
+        .summary("List items")
+        .anonymous()
+        .json_response(StatusCode::OK, "OK")
+        .handler(axum::routing::get(ok_handler))
+        .register(Router::new(), &api);
+    let app = api.rest_finalize(
+        &ctx,
+        router,
+        Arc::new(toolkit::RestHealthcheckRegistry::new()),
+    )?;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/tests/v1/items")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    provider.force_flush().unwrap();
+
+    let bounds = histogram_bounds(&exporter, "http.server.request.duration")
+        .expect("duration histogram should be exported with at least one data point");
+    assert_eq!(
+        bounds,
+        vec![
+            0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0
+        ],
+        "http.server.request.duration must use semconv seconds-scale bucket \
+         boundaries, not the SDK's millisecond-scale defaults"
     );
 
     Ok(())


### PR DESCRIPTION
The duration histogram records seconds (semconv unit "s") but never set explicit boundaries, so the OTel SDK applied its legacy default set (5, 10, 25, ... 10000) designed for milliseconds. The first finite boundary le="5" means <= 5 SECONDS, so effectively all real traffic lands in a single bucket: on a live stand 99.998% of 173k observations fell into (0, 5], histogram_quantile(0.95, ...) returned a constant 4.75 s (pure interpolation, 0.95 x 5) while the true mean was 0.208 s — p95/p99 of the platform API were unmeasurable.

Set the OTel semconv recommended boundaries for
http.server.request.duration, matching the recorded unit. The client-side layer (toolkit-http MetricsLayer) already sets explicit seconds-scale boundaries for the same reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP request-duration metrics by using meaningful second-based histogram buckets, enabling more accurate latency measurements and percentiles.

* **Tests**
  * Added coverage to verify that request-duration metrics use the expected histogram boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->