### PR TITLE
feat(keycloak-idp-plugin): implement tenant-scoped user updates

### DIFF
--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
@@ -59,7 +59,7 @@ The plugin talks to the Keycloak Admin REST and OAuth token endpoints directly o
 
 Three realm bindings are supported: `shared` (default; tenants share an operator-provisioned realm), `adopted` (an existing empty operator realm bound to one tenant), and `created` (the plugin creates and lifecycle-manages a dedicated realm — generated as `realm-{tenant_id}` for child tenants, while a root-target created realm requires an explicit operator-supplied name). Keycloak remains the user source of truth; the plugin persists nothing locally and returns a versioned opaque metadata envelope that Account Management stores and replays.
 
-`update_user` is intentionally not implemented in this revision: the plugin inherits the SDK default, which returns `IdpUserOperationFailure::UnsupportedOperation`.
+User updates are provider pass-through operations: the plugin verifies the stored tenant binding, applies only touched Keycloak profile or credential fields, and returns a fresh provider projection without persisting user state locally.
 
 ### 1.2 Architecture Drivers
 
@@ -67,10 +67,11 @@ Three realm bindings are supported: `shared` (default; tenants share an operator
 |---|---|
 | Provider-neutral publication and selection | `PluginV1<IdpPluginSpecV1>` published to types-registry (instance segment `cf.builtin.keycloak_idp.plugin.v1`; full catalogue id in §3.2, vendor `keycloak`, priority 50); scoped ClientHub registration keyed on the instance id; AM resolves via `choose_plugin_instance` against `idp.vendor` |
 | Fail-fast configuration errors | Init validates typed config (`deny_unknown_fields`), the `secret_ref_template`, and the service-account section, then pre-warms the bootstrap admin token with a bounded retry budget; exhausting the budget fails `Gear::init` |
-| Shared-realm tenant isolation | Per-tenant Keycloak group under `/tenants`, immutable `tenant_id` user attribute (ADR-0006), and an ownership marker attribute (`cf.provisioning.tenant_id`) on created realms and service-account clients |
+| Shared-realm tenant isolation | Per-tenant Keycloak group under `/tenants`, immutable `tenant_id` user attribute checked before user update/deprovision (ADR-0006), and an ownership marker attribute (`cf.provisioning.tenant_id`) on created realms and service-account clients |
 | Safe external mutation | Parse-then-probe saga ordering, per-step reactive-401 wrapping, idempotent replay paths (probe-adopt realm ensure, 409 group reuse), and stage-attributed `AmbiguousCreated` classification with an `ambig:` prefix contract for reconciliation tooling |
 | Secret custody | `SecretFromEnv`/`SecretString` wrappers with redacted `Debug`, token cache redaction, `redact_secrets` on every error body, and Credential Store writes only for plugin-created realm-admin secrets |
 | Credential rotation without restart | Token cache keyed `(realm, client_id)` with single-flight refresh and an exactly-once reactive-401 retry that re-resolves the secret from its source (env or Credential Store) |
+| User update safety | Pre-write tenant-binding and Keycloak profile-metadata checks, touched-field-only profile PUT, dedicated password reset, and provider re-read; foreign users are indistinguishable from absent users |
 | User query correctness | Full tenant-group member drain (hard cap 10,000) sorted client-side on the caller's effective `order` (Account-Management default `username ASC, id ASC`), client-side typed filters, `CursorV1` continuation with an FNV-1a filter hash |
 | Observability | Segregated metric ports over one OTel adapter (`keycloak_idp_plugin_*` instruments), realm-label cardinality cap, and structured audit events on the `keycloak_idp_plugin.events` tracing target |
 
@@ -78,11 +79,11 @@ Three realm bindings are supported: `shared` (default; tenants share an operator
 
 | NFR | Architectural response | Release verification |
 |---|---|---|
-| Tenant isolation | Tenant group membership scopes listing; the `tenant_id` user attribute guards user deprovision; `cf.provisioning.tenant_id` markers guard realm and service-account ownership | Negative-isolation unit and integration tests |
+| Tenant isolation | Tenant group membership scopes listing; the `tenant_id` user attribute guards user update and deprovision; `cf.provisioning.tenant_id` markers guard realm and service-account ownership | Negative-isolation unit and integration tests |
 | Secret non-disclosure | Typed secret wrappers, redacted token cache, `redact_secrets` + 2 KiB truncation on every provider error body before it crosses the AM boundary | Redaction unit tests; log/metric scanning |
 | Failure classification | Closed `PluginError` taxonomy translated at the SDK boundary per fixed tables; `debug_assert` that provisioning never surfaces `MetadataDecode` | Exhaustive translation unit tests and failure injection |
 | Availability recovery | Per-call pre-saga health probe; reactive-401 secret re-resolution; no cached provider state besides tokens; recovery needs no restart once init has succeeded | Dependency loss/recovery tests |
-| Personal-data lifecycle | No local user directory; user deprovision deletes the provider identity; audit events carry provider IDs plus `username` only on `user.provisioned` | Hard-delete and output-minimization tests |
+| Personal-data lifecycle | No local user directory; user deprovision deletes the provider identity; audit events carry provider IDs, `username` only on `user.provisioned`, and changed field names only on `user.updated` | Hard-delete and output-minimization tests |
 | Lifecycle latency | Bounded per-request HTTP timeout (5 s default), bounded retry policy, 30 s provision/deprovision saga timeout, list drain cap | Release qualification profile per PRD §6.1 |
 
 #### Decision Provenance
@@ -182,7 +183,7 @@ DTOs, cursors, and failure vocabularies all come from `account-management-sdk`, 
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-principle-no-silent-success`
 
-Unsupported operations (`update_user`, unsupported filters) return typed `UnsupportedOperation` failures. Truncated list drains are logged loudly. Already-absent resources are explicit success-equivalents, not silent no-ops.
+Unsupported filter shapes return typed `UnsupportedOperation` failures. User updates reject derived or provider-managed fields explicitly rather than silently dropping them, and return a fresh provider projection rather than echoing the request. Truncated list drains are logged loudly. Already-absent resources are explicit success-equivalents, not silent no-ops.
 
 #### Least privilege by tier
 
@@ -298,7 +299,7 @@ Provider ownership is split as follows:
 | Created realms (child tenants: generated `realm-{tenant_id}`; root target: operator-named; all marked `cf.provisioning.tenant_id`) | Plugin | Create, administer, and delete on last-tenant deprovisioning |
 | Realm-admin client and its 7 `realm-management` roles in created realms | Plugin | Create and grant during created-mode provisioning |
 | Per-tenant group under `/tenants` and the `tenant_id`/`user_type` user attributes | Plugin | Create, inspect, delete for the owning tenant |
-| Human identities and sessions in the tenant boundary | Plugin through Account Management | Create, delete, revoke, and query after boundary verification; updates are unsupported in this revision |
+| Human identities and sessions in the tenant boundary | Plugin through Account Management | Create, partially update, delete, revoke, and query after boundary verification |
 | Service-account clients `svc-{tenant_id}-{name}` and their service-account users | Plugin through the service-account half of `IdpPluginClient` | Create, rotate, revoke, list, and purge on tenant deprovisioning |
 | Created-realm admin secret in the Credential Store | Plugin (system actor) | Write on provisioning, read on later calls, delete on realm teardown |
 | Shared/adopted realm-admin secrets | Platform operator | Read only (env expansion or Credential Store reference) |
@@ -318,7 +319,7 @@ The plugin is one logical architecture component. The following entries are resp
 | Module wiring | Enabled probe, typed config expansion, static validation, bootstrap pre-warm, DI, catalogue publish, ClientHub registration |
 | Plugin root | SDK trait surface; failure translation tables |
 | Tenant lifecycle coordinator | Provision/deprovision sagas for all three bindings, saga timeout, idempotent replay, ambiguity staging, service-account purge hook |
-| User lifecycle coordinator | User provision/deprovision/list, tenant boundary guard, orphan compensation, cursor pagination |
+| User lifecycle coordinator | User provision/update/deprovision/list, tenant boundary guard, merge-patch translation, read-only-field preflight, orphan compensation, cursor pagination |
 | Service-account facade | Machine-identity lifecycle against the configured service-account realm (`service_account.realm`, default `platform`); ownership markers; quota and scope allowlist |
 | Metadata codec | Versioned fail-closed envelope encode/decode |
 | KC admin client factory | `client_credentials` token acquisition, `(realm, client_id)` token cache with single-flight refresh, reactive-401, health probe |
@@ -354,7 +355,7 @@ Contract invariants implemented at the plugin's SDK boundary:
 - provider 5xx, transport/timeout, saga timeout, and staged `AmbiguousCreated` map to `IdpProvisionFailure::Ambiguous` for the provisioning reaper **once a mutation has been attempted and follow-up evidence cannot rule out retained state**; realm creation is the explicit reconciliation case: a post-failure 404 proves the realm was not retained and maps to `CleanFailure`, while an unsuccessful re-probe preserves `Ambiguous` — retained-state evidence, not the error class alone, separates this row from the one above;
 - missing bootstrap permissions (`BootstrapPermsMissing`) map to `UnsupportedOperation` with an operator-runbook detail;
 - tenant deprovisioning maps `DeprovisionNotFound` → `NotFound` (success-equivalent), `DeprovisionRetryable` → `Retryable`, and everything else — including metadata decode failures — → `Terminal`;
-- user failures use only `IdpUserOperationFailure` variants: KC 409 on create is `DuplicateUser` with the field refined from the provider message (`Username`/`Email`/`UsernameOrEmail`), password-policy rejections are `PasswordPolicy`, unsupported filters and the unimplemented `update_user` are `UnsupportedOperation`, provider/transport trouble is `Unavailable`;
+- user failures use only `IdpUserOperationFailure` variants: KC 409 on create or rename is `DuplicateUser` with the field refined from provider evidence (`Username`/`Email`/`UsernameOrEmail`), absent and foreign update targets are the same `NotFound`, provider-managed fields are `FieldNotWritable`, password-policy rejections are `PasswordPolicy`, unsupported filters are `UnsupportedOperation`, and provider/transport trouble is `Unavailable`;
 - service-account failures use the `IdpServiceAccountFailure` set: `InvalidInput` (bad name, disallowed scope, quota, taken client id), `NotFound` (absent or foreign account — indistinguishable by design), `Ambiguous` (stage-attributed transport uncertainty; stage tokens tabulated in §3.6), `CleanFailure` (pre-mutation failures). The taxonomy also carries `UnsupportedOperation`, which this plugin never returns for these methods because it implements them - it is the category an adapter that ships only the tenant and user halves surfaces through the contract's default implementations;
 - every mutating return carries redacted, truncated, grep-friendly detail: provider failures use `kc:{METHOD} {path_template} -> {status}: {body≤2KiB}`, internal component failures `internal:{component}: …`, and classified domain rejections a stable variant prefix (`ambig:{stage}: …`, `deprovision retryable: …`, `sa invalid input: …`, and so on).
 
@@ -436,7 +437,7 @@ Success returns the metadata envelope, records `provision_tenant_duration` and `
 
 **ID**: `cpt-cf-keycloak-idp-plugin-seq-user-mutation`
 
-**Use cases**: user provisioning/deprovisioning are exercised through the parent Account Management use cases; `cpt-cf-keycloak-idp-plugin-usecase-update-user` is p2 — **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
+**Use cases**: user provisioning/deprovisioning are exercised through the parent Account Management use cases; updates implement `cpt-cf-keycloak-idp-plugin-usecase-update-user` — **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-keycloak`
 
 User operations resolve realm, admin client, and tenant group from replayed metadata and run each Keycloak step under an exactly-once reactive-401 wrapper.
 
@@ -444,7 +445,7 @@ User operations resolve realm, admin client, and tenant group from replayed meta
 
 *Deprovisioning* first reads the target user's stored `tenant_id` attribute; a mismatch against the request tenant performs no mutation and returns success-equivalently (non-disclosing, per ADR-0006 — this attribute check is the cross-tenant deletion guard). It then best-effort revokes sessions (configurable, default on) and deletes the identity; 404/410 are success-equivalent.
 
-*Updates* are not implemented: the SDK default returns `UnsupportedOperation`.
+*Updates* reject `display_name` before provider access because Keycloak derives it from `firstName` and `lastName` and has no corresponding writable property. For other patches, the plugin reads `GET /users/{id}?userProfileMetadata=true`, verifies `attributes.tenant_id`, and gathers every touched field Keycloak marks `readOnly`; absence and a foreign tenant binding both become non-disclosing `NotFound`, while known locked fields become `FieldNotWritable` before any write. It then sends only touched profile fields through `PUT /users/{id}` (`Some(None)` becomes Keycloak's empty-string clear, omitted fields are absent), resets a supplied password through `PUT /users/{id}/reset-password`, and finally re-reads `GET /users/{id}` so the result reflects provider normalization. A profile-and-password patch spans two Keycloak calls and cannot be atomic; preflight removes known deterministic failures before either write, but a credential or transport failure after the profile PUT can leave a partial provider update, so `Unavailable` never asserts that fields remained unchanged.
 
 #### Tenant Deprovisioning
 
@@ -527,7 +528,7 @@ sequenceDiagram
   AM->>A: Durably correlate terminal outcome
 ```
 
-The plugin emits structured events on the `keycloak_idp_plugin.events` tracing target — `tenant.bound`, `realm.created`, `admin_user.bound`, `tenant.unbound`, `realm.removed`, `service_accounts.purged`, `user.provisioned` (includes `username`), `user.deprovisioned` — each carrying the acting subject (id, closed-set type, raw type, tenant). `user.deprovisioned` is emitted on every successful `deprovision_user` return, including the non-mutating cross-tenant-guard and already-absent paths, and its `already_absent` field is currently always `false`. This is an explicit development stand-in until the platform audit sink lands; durable one-outcome-per-call correlation is owned by Account Management and the platform audit owner. `list_users` and the service-account read/mutate paths emit no plugin audit events of their own; the only service-account audit signal is `service_accounts.purged` on tenant deprovisioning.
+The plugin emits structured events on the `keycloak_idp_plugin.events` tracing target — `tenant.bound`, `realm.created`, `admin_user.bound`, `tenant.unbound`, `realm.removed`, `service_accounts.purged`, `user.provisioned` (includes `username`), `user.updated` (changed field names only), `user.deprovisioned` — each carrying the acting subject (id, closed-set type, raw type, tenant). `user.deprovisioned` is emitted on every successful `deprovision_user` return, including the non-mutating cross-tenant-guard and already-absent paths, and its `already_absent` field is currently always `false`. This is an explicit development stand-in until the platform audit sink lands; durable one-outcome-per-call correlation is owned by Account Management and the platform audit owner. `list_users` and the service-account read/mutate paths emit no plugin audit events of their own; the only service-account audit signal is `service_accounts.purged` on tenant deprovisioning.
 
 Metrics: `keycloak_idp_plugin_provision_tenant_duration_seconds`, `user_op_duration_seconds`, `sa_op_duration_seconds`, `kc_admin_request_duration_seconds` (declared, not yet wired), `failure_total{op,failure_variant}`, `kc_admin_token_refresh_total` and `credential_refresh_total` (`{outcome,tier,realm}`), `credstore_write_total`, `metadata_decode_failure_total{version_observed}`, `deprovision_missing_metadata_total`, `orphan_user_compensation_total`, `realms_bound{realm_binding,realm_name}`. Every label is a closed enum except `version_observed` (an uncapped observed version string) and `realm`/`realm_name`, which share a cardinality budget (default 500 distinct realms) after which the label is dropped and a warning is logged on every observation of an over-cap realm.
 
@@ -557,7 +558,7 @@ Not applicable: the plugin owns no database schema, table, migration, audit stor
 | Service-account consumer to plugin | Trusted platform modules only (in-process ClientHub); caller RBAC/PDP authorizes before delegation; `ctx` is audit-only |
 | Plugin to Keycloak | HTTPS with optional operator CA bundle; bearer tokens minted per admin tier; bounded bodies on error paths; no caller-controlled URL — paths are built from configuration and validated identifiers |
 | Plugin to Credential Store | Plugin-owned system actor (stable service-account UUID, platform tenant, wildcard token scopes) authorized through ordinary RBAC grants — no PEP bypass; reader and writer are separate types so read-only sites cannot mutate |
-| Tenant A to tenant B | Group-scoped listing; `tenant_id`-attribute guard on user deletion; ownership-marker guard on realms and service-account clients; foreign resources are reported as absent, not as denied |
+| Tenant A to tenant B | Group-scoped listing; `tenant_id`-attribute guard on user update and deletion; ownership-marker guard on realms and service-account clients; foreign resources are reported as absent, not as denied |
 | Plugin to metrics/logs | Closed-enum labels, capped realm label, `redact_secrets` (bearer and key-value secret patterns) plus 2 KiB truncation on every provider body |
 
 Secret custody: the bootstrap and shared-realm admin secrets enter the process through `${VAR}` config expansion into redacted wrapper types; adopted/created realm secrets and the optional CA bundle live in the Credential Store; created-realm secrets are generated by Keycloak, read back once per provisioning, and stored under the templated reference with tenant sharing. Cached tokens are `SecretString`s with redacted debug output. Metadata envelopes carry reference names, never values.
@@ -572,7 +573,7 @@ Keycloak is the sole user directory. The plugin holds request data only for the 
 |---|---|
 | Unit (in-crate, 300+ tests) | Config parsing/defaults/validation, metadata codec compatibility, error classification and translation tables, redaction, cursor encode/decode incl. legacy fallback and order-token round-trip, filter lowering, order-key projection/comparison (per-key direction, absent-field placement, unsupported order key rejection), boundary predicates, token cache/single-flight/reactive-401 (wiremock), transport retry/backoff/Retry-After (wiremock), metrics label and cardinality behavior, saga step ordering via configurable stubs |
 | SDK contract | Conformance to the `IdpPluginClient` failure enums and semantics across all three halves; the crate carries a placeholder awaiting the upstream AM-SDK conformance harness |
-| Real-Keycloak integration | Realm ensure idempotency, group lifecycle, role grants, user replay, cross-tenant denial, deletion ordering, provider failures, query behavior (owned by the deployment repository's E2E stacks) |
+| Real-Keycloak integration | Realm ensure idempotency, group lifecycle, role grants, user replay, update set/clear/read-only behavior, cross-tenant denial, deletion ordering, provider failures, query behavior (owned by the deployment repository's E2E stacks) |
 | Lifecycle integration | Enabled/disabled init paths, pre-warm retry/fast-bail budgets, catalogue re-registration drift detection |
 | Cross-system audit contract | Account Management and the platform audit owner prove durable terminal outcomes; external production gate |
 
@@ -593,7 +594,7 @@ The release-qualification query matrix for the PRD latency NFR covers unfiltered
 | Audit ownership | Parent Account Management and platform audit designs assign persistence, recovery, delivery, and retention; the plugin's tracing stand-in is not a production substitute |
 | Reconciliation | Operator runbook exists and consumes `ambig:{stage}` evidence without secret inspection |
 | Init dependency | Deployment ordering tolerates the pre-warm budget (Keycloak/Credential Store reachable within ≈37 s of plugin init) or explicitly disables the plugin |
-| User updates | `update_user` support requires implementing the SDK contract (JSON Merge Patch semantics, duplicate/password-policy classification) before any product surface promises profile editing through this provider |
+| Multi-step user updates | Release tests cover profile-only, password-only, and combined patches; callers treat a failed combined patch as potentially partial and re-read provider state before corrective retry |
 | Service-account contract | Implemented against the contract as shipped in `account-management-sdk` (PRD §5.4). The published trait is authoritative wherever it differs from the design below. Tenant and user lifecycle carry no dependency on it and gate independently, so a service-account regression cannot block them |
 | Host wiring | The crate is deliberately landed **unwired**: no host in this repository links it, so its `inventory`-based gear registration never fires, and the repository carries no worked configuration sample. Enabling it requires a host that links the crate, a `keycloak:` configuration tree satisfying `Gear::init` (`base_url`, `realm_admin.secret_ref_template`, `bootstrap_pre_warm.*`, `service_account.*`, `security_context.platform_tenant_id`, the metrics cap, `vendor`/`priority`), and `account-management.idp.vendor` aligned to this plugin's vendor. Until then the code is compiled and unit-tested but never initialized, which is why the gates below are stated as deployment obligations rather than satisfied conditions |
 
@@ -610,7 +611,7 @@ The wire-side suffix is baked into the name (`_total` for monotonic counters, a 
 | `keycloak_idp_plugin_provision_tenant_duration_seconds` | Histogram, seconds | `realm_binding` ∈ {`shared`, `adopted`, `created`} | `TenantLifecycleMetricsPort` | Live |
 | `keycloak_idp_plugin_realms_bound` | UpDownCounter (no suffix) | `realm_binding` × `realm_name` (capped) | `TenantLifecycleMetricsPort` | Live |
 | `keycloak_idp_plugin_deprovision_missing_metadata_total` | Counter | none — `realm_name` is unknowable by definition on this path, metadata was its only source | `TenantLifecycleMetricsPort` | Live |
-| `keycloak_idp_plugin_user_op_duration_seconds` | Histogram, seconds | `op` ∈ {`provision_user`, `deprovision_user`, `list_users`} | `UserOpMetricsPort` | Live |
+| `keycloak_idp_plugin_user_op_duration_seconds` | Histogram, seconds | `op` ∈ {`provision_user`, `update_user`, `deprovision_user`, `list_users`} | `UserOpMetricsPort` | Live |
 | `keycloak_idp_plugin_orphan_user_compensation_total` | Counter | `outcome` ∈ {`ok`, `failed`} | `UserOpMetricsPort` | Live |
 | `keycloak_idp_plugin_sa_op_duration_seconds` | Histogram, seconds | `op` ∈ {`sa_create`, `sa_rotate_secret`, `sa_revoke`, `sa_list`, `sa_purge`} | `SaOpMetricsPort` | Live |
 | `keycloak_idp_plugin_credstore_write_total` | Counter | `op` ∈ {`put`, `delete`} × `outcome` ∈ {`ok`, `error`} | `CredstoreMetricsPort` | Live |
@@ -628,9 +629,9 @@ Both refresh counters are emitted from the token-acquisition slow path in `src/d
 
 Both labels are closed sets, but the `failure_variant` vocabulary is **not** the `FailureVariant` constant list: every emit site converts through `From<&PluginError>`, so the wire values are whatever `failure_variant_label` in `src/domain/error.rs` produces. That is the authoritative list.
 
-`op` is a superset of every plugin-level operation: `provision_tenant`, `deprovision_tenant`, `provision_user`, `deprovision_user`, `list_users`, `sa_create`, `sa_rotate_secret`, `sa_revoke`, `sa_list`, `sa_purge`.
+`op` is a superset of every plugin-level operation: `provision_tenant`, `deprovision_tenant`, `provision_user`, `update_user`, `deprovision_user`, `list_users`, `sa_create`, `sa_rotate_secret`, `sa_revoke`, `sa_list`, `sa_purge`.
 
-`failure_variant` classifies the failure, not its text — 18 values: `config`, `credstore_read`, `metadata_decode`, `kc_rest`, `provision_input_rejected`, `ambiguous_created`, `created_realm_exists`, `bootstrap_perms_missing`, `deprovision_not_found`, `deprovision_retryable`, `deprovision_terminal`, `user_op_rejected`, `user_op_unavailable`, `user_op_unsupported`, `user_op_duplicate`, `user_op_password_policy`, `sa_invalid_input`, `sa_not_found`. A provider body never reaches a label — the counter is the metric-side counterpart of the redaction posture in §4.1.
+`failure_variant` classifies the failure, not its text — 21 values: `config`, `credstore_read`, `metadata_decode`, `kc_rest`, `provision_input_rejected`, `ambiguous_created`, `created_realm_exists`, `realm_create_not_retained`, `bootstrap_perms_missing`, `deprovision_not_found`, `deprovision_retryable`, `deprovision_terminal`, `user_op_rejected`, `user_op_unavailable`, `user_op_unsupported`, `user_op_duplicate`, `user_op_password_policy`, `user_op_not_found`, `user_op_field_not_writable`, `sa_invalid_input`, `sa_not_found`. A provider body never reaches a label — the counter is the metric-side counterpart of the redaction posture in §4.1.
 
 #### Instrument prefix
 
@@ -668,7 +669,7 @@ All three realm-keyed instruments share one cap and one observed-realm set, whic
 | `cpt-cf-keycloak-idp-plugin-fr-provider-metadata` | §§3.1, 3.3 |
 | `cpt-cf-keycloak-idp-plugin-fr-tenant-deprovision`, `cpt-cf-keycloak-idp-plugin-fr-tenant-service-account-cleanup`, `cpt-cf-keycloak-idp-plugin-fr-tenant-user-access-termination`, `cpt-cf-keycloak-idp-plugin-usecase-retire-tenant` | §§3.6, 4.1 |
 | `cpt-cf-keycloak-idp-plugin-fr-tenant-failure-contract`, `cpt-cf-keycloak-idp-plugin-fr-external-mutation-resilience`, `cpt-cf-keycloak-idp-plugin-nfr-failure-classification` | §§3.3, 3.6 |
-| `cpt-cf-keycloak-idp-plugin-fr-user-provision`, `cpt-cf-keycloak-idp-plugin-fr-user-deprovision` | §3.6 |
+| `cpt-cf-keycloak-idp-plugin-fr-user-provision`, `cpt-cf-keycloak-idp-plugin-fr-user-update`, `cpt-cf-keycloak-idp-plugin-fr-user-update-outcomes`, `cpt-cf-keycloak-idp-plugin-fr-user-deprovision`, `cpt-cf-keycloak-idp-plugin-usecase-update-user` | §§3.3, 3.6 |
 | `cpt-cf-keycloak-idp-plugin-fr-user-query` | §3.6 |
 | `cpt-cf-keycloak-idp-plugin-fr-user-source-of-truth` | §§3.1, 4.1 |
 | `cpt-cf-keycloak-idp-plugin-fr-service-account-lifecycle`, `cpt-cf-keycloak-idp-plugin-fr-service-account-state`, `cpt-cf-keycloak-idp-plugin-fr-service-account-safeguards`, `cpt-cf-keycloak-idp-plugin-fr-service-account-rotation`, `cpt-cf-keycloak-idp-plugin-fr-service-account-list`, `cpt-cf-keycloak-idp-plugin-fr-service-account-mutation-safety`, `cpt-cf-keycloak-idp-plugin-fr-service-account-secret-disclosure`, `cpt-cf-keycloak-idp-plugin-fr-service-account-recovery`, `cpt-cf-keycloak-idp-plugin-fr-service-account-failure-contract`, `cpt-cf-keycloak-idp-plugin-interface-service-account-client`, `cpt-cf-keycloak-idp-plugin-usecase-service-account-credentials`, `cpt-cf-keycloak-idp-plugin-usecase-list-revoke-service-accounts` | §§3.2–3.3, 3.6, 4.1 |
@@ -684,4 +685,4 @@ All three realm-keyed instruments share one cap and one observed-realm set, whic
 | `cpt-cf-keycloak-idp-plugin-nfr-provider-compatibility` | §4.3 |
 | `cpt-cf-keycloak-idp-plugin-interface-idp-plugin-client`, `cpt-cf-keycloak-idp-plugin-contract-account-management`, `cpt-cf-keycloak-idp-plugin-contract-keycloak-admin` | §§1.1, 2.1, 3.2–3.3 |
 
-P2 requirements (user update, realm profile verification, runtime provider-version gate) remain traceable in the PRD but are intentionally not allocated to implementation components in this DESIGN.
+The remaining p2 requirements (realm profile verification and a runtime provider-version gate) remain traceable in the PRD but are intentionally not allocated to implementation components in this DESIGN.

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
@@ -47,7 +47,7 @@ The Keycloak IdP Plugin (crate `cf-gears-keycloak-idp-plugin`) is a provider plu
 
 The plugin runs as a Gear in the host process. Account Management remains the public control-plane boundary. The plugin exposes no public REST API and does not authenticate requests, issue tokens, validate tokens, or make authorization decisions. It administers Keycloak directly over HTTPS using OAuth2 `client_credentials` administrator clients, with secret custody split between environment-expanded configuration and the platform Credential Store.
 
-In this revision, user provisioning, deprovisioning, and querying are supported; **user profile update is not implemented** and returns `UnsupportedOperation` (p2).
+User provisioning, profile update, deprovisioning, and querying are supported. Updates use provider-native JSON Merge Patch semantics while preserving Keycloak as the user source of truth.
 
 ### 1.2 Background / Problem Statement
 
@@ -175,7 +175,7 @@ flowchart LR
 - Selectable Keycloak provider registration for Account Management (types-registry catalogue instance plus scoped ClientHub client).
 - Tenant binding to shared (default, inherited by child tenants), adopted (single-tenant, operator-owned), and created (plugin-owned, per-tenant) realms.
 - Tenant identity-boundary creation, binding, and cleanup, including created-realm lifecycle and Credential Store custody of created-realm admin secrets.
-- Tenant-scoped user creation, deletion, provider-session revocation, listing, filtering, and cursor pagination.
+- Tenant-scoped user creation, partial profile and password update, deletion, provider-session revocation, listing, filtering, and cursor pagination.
 - Two-tier administrator credential handling (bootstrap admin, per-realm admin) with rotation convergence via reactive re-authentication, without process restart.
 - Tenant-scoped service-account creation, secret rotation, revocation, listing, and purge-on-tenant-deprovision through the service-account half of `IdpPluginClient`.
 - Deterministic failure classification, retry safety, and stage-attributed ambiguous-outcome reconciliation signals.
@@ -183,7 +183,7 @@ flowchart LR
 
 ### 4.2 Out of Scope
 
-The user-update, realm-profile-verification, and provider-version-gate bullets below are out of v1 scope but retained as p2 requirements. All other bullets are product-level exclusions.
+The realm-profile-verification and provider-version-gate bullets below are out of v1 scope but retained as p2 requirements. All other bullets are product-level exclusions.
 
 - Starting, deploying, upgrading, backing up, or scaling Keycloak.
 - Running code inside Keycloak or packaging Keycloak server extensions.
@@ -191,7 +191,6 @@ The user-update, realm-profile-verification, and provider-version-gate bullets b
 - Validating incoming JWTs; the OIDC AuthN Resolver Plugin owns validation.
 - Making authorization decisions; RBAC and the Policy Engine own authorization.
 - Exposing public REST endpoints; Account Management and other owning gears expose public APIs.
-- User profile updates through `IdpPluginClient::update_user`; the current implementation returns `UnsupportedOperation` (p2).
 - Runtime verification of the operator-provisioned realm authentication profile; operator realm bootstrap owns the profile (verification is p2).
 - A runtime Keycloak version gate; release qualification owns the compatibility matrix (a runtime gate is p2).
 - Moving a user between tenants or changing a user's tenant binding through any operation.
@@ -341,18 +340,18 @@ The plugin **MUST** create a user inside the resolved tenant identity boundary: 
 
 #### Tenant-Scoped User Update
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-update`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-update`
 
-User profile update is not implemented in this revision: `IdpPluginClient::update_user` returns `UnsupportedOperation`. When implemented, partial updates to `username`, `email`, `display_name`, `first_name`, `last_name`, and `password` **MUST** apply within the existing tenant binding, omitted fields **MUST** remain unchanged, nullable profile fields **MUST** support clearing, and the user identifier and tenant binding **MUST** remain immutable.
+The plugin **MUST** verify the target user's stored `tenant_id` before every update and **MUST** perform no write when the user is absent or belongs to another tenant. It **MUST** apply supplied changes to `username`, `email`, `first_name`, `last_name`, and `password`; omitted fields **MUST** remain unchanged, nullable profile fields **MUST** support clearing, and the user identifier and tenant binding **MUST** remain immutable. Because Keycloak has no independently writable display-name property, a supplied `display_name` **MUST** return `FieldNotWritable` rather than guessing how to split it or silently discarding it. The success result **MUST** be a fresh provider read so Keycloak normalization is reflected.
 
-- **Rationale**: A production provider eventually needs a complete administrative user lifecycle; until then callers receive a deterministic unsupported outcome rather than partial behavior.
+- **Rationale**: Tenant administrators need truthful partial updates without weakening tenant isolation or inventing a lossy mapping for provider-derived fields.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
 
 #### User Update Outcome Classification
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-update-outcomes`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-user-update-outcomes`
 
-When user update is implemented, the plugin **MUST** distinguish an absent user, duplicate username or email, password-policy rejection, unsupported behavior, invalid input, and provider unavailability. A missing user **MUST NOT** be treated as a successful update.
+The plugin **MUST** distinguish an absent or foreign user (`NotFound`, deliberately indistinguishable), duplicate username or email, password-policy rejection, provider-managed fields, invalid input, unsupported behavior, and provider unavailability. A missing user **MUST NOT** be treated as a successful update. A timeout after a profile or password write is ambiguous and **MUST** surface as provider unavailability without claiming that attributes remained unchanged.
 
 - **Rationale**: Tenant administrators need actionable and stable outcomes for corrective action.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`, `cpt-cf-keycloak-idp-plugin-actor-account-management`
@@ -515,7 +514,7 @@ The operator's v1 realm authentication profile **MUST** limit access-token lifet
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-fr-audit-metrics`
 
-The plugin **MUST** return a classified, redacted outcome for every supported call and **MUST** emit structured audit events on the dedicated `keycloak_idp.events` tracing target for every mutating tenant and user lifecycle transition: `tenant.bound`, `realm.created`, `admin_user.bound`, `tenant.unbound`, `realm.removed`, `service_accounts.purged`, `user.provisioned`, and `user.deprovisioned`, each carrying the acting subject (id, classified type, raw type, tenant) and provider identifiers. `user.provisioned` additionally records the username as operational evidence; no event carries secrets, passwords, tokens, or raw provider bodies. These emitters are a development stand-in: Account Management and the platform audit owner **MUST** create and durably deliver the terminal audit outcome for each mutating plugin call before production enablement.
+The plugin **MUST** return a classified, redacted outcome for every supported call and **MUST** emit structured audit events on the dedicated `keycloak_idp_plugin.events` tracing target for every mutating tenant and user lifecycle transition: `tenant.bound`, `realm.created`, `admin_user.bound`, `tenant.unbound`, `realm.removed`, `service_accounts.purged`, `user.provisioned`, `user.updated`, and `user.deprovisioned`, each carrying the acting subject (id, classified type, raw type, tenant) and provider identifiers. `user.provisioned` additionally records the username as operational evidence; `user.updated` records only the changed field names. No event carries update values, secrets, passwords, tokens, or raw provider bodies. These emitters are a development stand-in: Account Management and the platform audit owner **MUST** create and durably deliver the terminal audit outcome for each mutating plugin call before production enablement.
 
 - **Rationale**: A single owner for each durable record prevents duplicate or missing audit events while preserving plugin-level diagnostic evidence.
 - **Actors**: `cpt-cf-keycloak-idp-plugin-actor-account-management`, `cpt-cf-keycloak-idp-plugin-actor-platform-operator`
@@ -539,7 +538,7 @@ Global reliability, security, and observability baselines come from the [Archite
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-tenant-isolation`
 
-The plugin **MUST** prevent an operation resolved for one tenant from reading or mutating identities bound to another tenant: listing is scoped to the tenant group, user deletion is guarded by the stored `tenant_id` attribute, and realm/service-account mutations are guarded by ownership markers.
+The plugin **MUST** prevent an operation resolved for one tenant from reading or mutating identities bound to another tenant: listing is scoped to the tenant group, user update and deletion are guarded by the stored `tenant_id` attribute, and realm/service-account mutations are guarded by ownership markers.
 
 - **Threshold**: Zero successful cross-tenant operations across the automated negative-isolation suite.
 - **Rationale**: Identity administration is a security boundary for every tenant.
@@ -559,7 +558,7 @@ The plugin **MUST** prevent administrator tokens, administrator secrets, user pa
 
 - [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-nfr-lifecycle-latency`
 
-On the release qualification profile, shared-realm tenant provisioning **MUST** complete within 5 seconds at p95; created-realm provisioning within 10 seconds at p95. User creation, deprovisioning, and a full query page **MUST** each complete within 1 second at p95. The profile **MUST** use 20 concurrent operations, an operator-equivalent Keycloak 26.x node backed by PostgreSQL, at most 5 ms network round-trip time between the plugin and Keycloak, and up to 1,000 human identities, enabled or disabled, in one tenant group. The query run matrix (filter-selectivity mix and token-cache states) is defined in [DESIGN §4.2](./DESIGN.md#42-verification-architecture). Operational bounds enforced by the implementation and validated by the profile: per-request provider timeout, bounded retry policy, saga timeout, caller page size cap, and the membership-scan hard cap with loud truncation (values in [DESIGN §§2.2, 3.6](./DESIGN.md#22-constraints)).
+On the release qualification profile, shared-realm tenant provisioning **MUST** complete within 5 seconds at p95; created-realm provisioning within 10 seconds at p95. User creation, update, deprovisioning, and a full query page **MUST** each complete within 1 second at p95. The profile **MUST** use 20 concurrent operations, an operator-equivalent Keycloak 26.x node backed by PostgreSQL, at most 5 ms network round-trip time between the plugin and Keycloak, and up to 1,000 human identities, enabled or disabled, in one tenant group. The query run matrix (filter-selectivity mix and token-cache states) is defined in [DESIGN §4.2](./DESIGN.md#42-verification-architecture). Operational bounds enforced by the implementation and validated by the profile: per-request provider timeout, bounded retry policy, saga timeout, caller page size cap, and the membership-scan hard cap with loud truncation (values in [DESIGN §§2.2, 3.6](./DESIGN.md#22-constraints)).
 
 - **Threshold**: Shared provisioning p95 ≤ 5 s; created provisioning p95 ≤ 10 s; each named user operation p95 ≤ 1 s; 20 concurrent operations; scan cap 10,000 members per tenant group with observable truncation.
 - **Rationale**: A fixed population, topology, filter mix, and bound set make the linear-scan acceptance test reproducible.
@@ -643,7 +642,7 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 
 - **Type**: Rust SDK trait (`IdpPluginClient`)
 - **Stability**: stable
-- **Description**: Provides tenant provisioning, tenant deprovisioning, user provisioning, user deprovisioning, and user query behavior to Account Management. `update_user` is not implemented and returns `UnsupportedOperation` (p2).
+- **Description**: Provides tenant provisioning, tenant deprovisioning, user provisioning, tenant-scoped partial user update, user deprovisioning, and user query behavior to Account Management.
 - **Breaking Change Policy**: Incompatible request, result, or failure changes require a versioned contract and coordinated Account Management migration.
 
 #### Service-Account Lifecycle Contract
@@ -769,11 +768,30 @@ When required dependencies meet their objectives, the plugin **MUST** support th
 
 #### Update a Tenant User
 
-- [ ] `p2` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-update-user`
+- [ ] `p1` - **ID**: `cpt-cf-keycloak-idp-plugin-usecase-update-user`
 
 **Actor**: `cpt-cf-keycloak-idp-plugin-actor-tenant-admin`
 
-Not available in this revision: `update_user` returns `UnsupportedOperation`. When implemented, Account Management sends the tenant context, user identifier, and partial update; the plugin applies only the supplied mutable fields within the resolved tenant binding and returns the updated provider projection, distinguishing not-found, duplicate-attribute, and password-policy outcomes.
+**Preconditions**:
+- Account Management has authorized the caller and supplies an active tenant context, user identifier, and non-empty merge patch.
+- The tenant metadata resolves a Keycloak realm and realm administrator.
+
+**Main Flow**:
+1. The plugin rejects statically provider-managed fields before provider access.
+2. It reads the user with profile metadata, verifies `attributes.tenant_id`, and refuses every touched field Keycloak reports as read-only before writing.
+3. It applies only touched profile fields and uses the credential endpoint when a password is supplied.
+4. It re-reads and returns Keycloak's resulting user projection.
+5. It emits `user.updated` with changed field names only.
+
+**Postconditions**:
+- The user remains bound to the same tenant and keeps the same provider identifier.
+- Omitted fields are unchanged and no password or profile value is retained by the plugin.
+
+**Alternative Flows**:
+- **Absent or foreign user**: return indistinguishable `NotFound` and perform no mutation.
+- **Provider-managed field**: return `FieldNotWritable` naming every attributable field and perform no mutation when preflight can determine the lock.
+- **Rename collision or password-policy reject**: return the corresponding typed SDK outcome.
+- **Provider failure or timeout**: return `Unavailable`; after an attempted write the caller must not assume that provider state stayed unchanged.
 
 #### Create and Rotate a Service Account
 
@@ -883,7 +901,7 @@ Not available in this revision: `update_user` returns `UnsupportedOperation`. Wh
 - [ ] Created-mode provisioning is replay-safe: a marked realm is adopted idempotently, a foreign realm is rejected cleanly, a lost create reconciles by re-probe, and the realm-admin secret lands in the Credential Store before success is reported.
 - [ ] Hard deprovisioning deletes the tenant group, tears down created realms and their secrets on last-tenant retirement, and never deletes shared/adopted realms or other tenants' resources. (The service-account purge barrier that precedes boundary removal is p2, gated with §5.4.)
 - [ ] User provisioning binds `tenant_id`/`user_type` attributes and group membership, compensates orphans on group-join failure, and classifies duplicates with field refinement; user deprovisioning enforces the tenant-attribute guard, revokes sessions best-effort, and treats 404/410 as success-equivalent.
-- [ ] `update_user` deterministically returns `UnsupportedOperation`.
+- [ ] User updates enforce the stored-tenant binding before writing; apply merge-patch set/clear/omit semantics; reject derived or provider-managed fields explicitly; classify not-found, duplicate, password-policy, and provider failures; and return a fresh Keycloak projection.
 - [ ] User queries return only tenant-group members, honor the supported filter surface (rejecting unsupported shapes with `UnsupportedOperation` before provider access), sort on the requested order over the orderable field set (Account-Management default `username ASC, id ASC`), page via `CursorV1` with order- and filter-hash validation and the rolling-deploy legacy fallback, and truncate loudly at the scan hard cap.
 - [ ] Cross-tenant negative tests produce zero successful reads or mutations across the tenant and user surfaces.
 - [ ] Failure injection proves ambiguous tenant provisioning is never reported as clean, each user failure maps to an `IdpUserOperationFailure` outcome, and every variant carries its stable metric label.
@@ -900,7 +918,6 @@ Not available in this revision: `update_user` returns `UnsupportedOperation`. Wh
 - [ ] Hard deprovisioning purges the tenant's service accounts before boundary removal, and a purge failure aborts the saga with a retryable or terminal classification rather than a success-equivalent outcome.
 - [ ] Cross-tenant negative tests extend to the service-account surface with zero successful reads or mutations.
 - [ ] Failure injection maps each service-account failure to the `IdpServiceAccountFailure` set, with every variant carrying its stable metric label.
-- [ ] `update_user` implements the SDK contract (partial update semantics, immutable identity/tenant binding, duplicate/password-policy/not-found classification) and passes the provider contract suite.
 - [ ] A read-only realm authentication-profile verifier gates tenant binding on shared/adopted realms before promotion of profile verification.
 - [ ] A runtime provider-version gate fails affected operations deterministically on unsupported majors without preventing host startup.
 
@@ -935,7 +952,8 @@ Not available in this revision: `update_user` returns `UnsupportedOperation`. Wh
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| An external mutation completes after the caller loses the response. | Duplicate or orphaned identity resources or credentials. | Idempotent replay paths (realm ensure re-probe, group 409 reuse), stage-attributed ambiguous outcomes, no blind retry, reconciliation runbook. |
+| An external mutation completes after the caller loses the response. | Duplicate or orphaned identity resources or credentials, or an update whose final state is unknown. | Idempotent replay paths (realm ensure re-probe, group 409 reuse), stage-attributed tenant/service-account ambiguity, no blind retry, reconciliation runbook; user-update timeout returns `Unavailable` and never asserts fields were unchanged. |
+| A user-update request combines profile and password changes across separate Keycloak endpoints. | The profile write can succeed before the credential reset fails. | Preflight tenant ownership and every known field lock before either write; return the exact password/provider failure and document that a failed multi-step update may require a provider re-read before retry. |
 | Administrator credentials grant broader access than required. | Compromise can affect unrelated tenants or realms. | Two-tier admin model, exact least-privilege role grants on created realms, typed secret custody, rotation convergence, and secret non-disclosure tests. |
 | Provider metadata becomes unreadable after upgrade or rollback. | Existing tenants cannot be administered or retired safely. | Versioned fail-closed envelope, decode-failure metrics, and compatibility coverage for supported upgrade paths. |
 | The Credential Store write fails after created-realm Keycloak state exists. | Realm exists without retrievable admin credentials. | A dedicated ambiguity stage token for the post-provider secret-write window, the reconciliation runbook, and replay-safe provisioning that restores the stored secret. |
@@ -956,10 +974,9 @@ The following questions gate only p2 promotion:
 
 | # | Question | Impact | Owner | Target Date |
 |---|----------|--------|-------|-------------|
-| 1 | When is `update_user` promoted, and does it adopt JSON Merge Patch semantics end to end? | Determines profile-editing support through this provider. | Account Management Owner and Plugin Owner | Before user-update DESIGN |
-| 2 | Should realm authentication-profile verification become a plugin-side runtime gate, and what profile format does the operator publish for it? | Determines whether misconfigured realms fail binding deterministically. | Platform Architect and Plugin Owner | Before profile-verifier DESIGN |
-| 3 | Does a runtime Keycloak version gate replace release-time qualification as the compatibility guarantee? | Determines unsupported-version failure behavior. | Plugin Owner | Before compatibility-gate DESIGN |
-| 4 | Will a future authentication component enforce real-time token revocation? | Determines whether any future release can promise rejection before JWT expiry. | Security Architect and AuthN Owner | Before real-time revocation requirements are added |
+| 1 | Should realm authentication-profile verification become a plugin-side runtime gate, and what profile format does the operator publish for it? | Determines whether misconfigured realms fail binding deterministically. | Platform Architect and Plugin Owner | Before profile-verifier DESIGN |
+| 2 | Does a runtime Keycloak version gate replace release-time qualification as the compatibility guarantee? | Determines unsupported-version failure behavior. | Plugin Owner | Before compatibility-gate DESIGN |
+| 3 | Will a future authentication component enforce real-time token revocation? | Determines whether any future release can promise rejection before JWT expiry. | Security Architect and AuthN Owner | Before real-time revocation requirements are added |
 
 ## 14. Traceability
 

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/audit.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/audit.rs
@@ -236,6 +236,41 @@ pub fn emit_user_provisioned(
     );
 }
 
+/// `kind = "user.updated"` — fired on every `update_user` success.
+///
+/// `changed` lists the request properties the patch actually touched
+/// (`username`, `email`, `first_name`, `last_name`, `password`), never
+/// their values: the audit trail records *what* an actor changed on
+/// someone's identity without becoming a secondary store of profile
+/// data, and `password` in particular MUST never have its value reach a
+/// log sink.
+pub fn emit_user_updated(
+    actor: &SecurityContext,
+    tenant_id: Uuid,
+    realm_name: &str,
+    realm_binding: RealmBinding,
+    user_id: Uuid,
+    changed: &[&'static str],
+) {
+    let (actor_subject_id, actor_subject_type, actor_subject_type_raw, actor_tenant_id) =
+        common_fields(actor);
+    let realm_binding_str = realm_binding_str(realm_binding);
+    tracing::info!(
+        target: "keycloak_idp_plugin.events",
+        kind = "user.updated",
+        %actor_subject_id,
+        actor_subject_type,
+        actor_subject_type_raw,
+        %actor_tenant_id,
+        %tenant_id,
+        realm_name,
+        realm_binding = realm_binding_str,
+        %user_id,
+        changed = changed.join(","),
+        "user updated"
+    );
+}
+
 /// `kind = "user.deprovisioned"` — fired on every `deprovision_user`
 /// success (including the 404/410 idempotency branches; `already_absent`
 /// distinguishes them).

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/error.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/error.rs
@@ -214,6 +214,45 @@ pub enum PluginError {
     #[error("user op unsupported: {detail}")]
     UserOpUnsupported { detail: String },
 
+    /// The target user is absent from the bound realm, OR its stored
+    /// `tenant_id` attribute does not match the requesting tenant. The
+    /// two collapse deliberately: `update_user` must not let a caller
+    /// distinguish "exists in another tenant" from "does not exist", or
+    /// the endpoint becomes a cross-tenant existence oracle. Boundary
+    /// maps this to [`IdpUserOperationFailure::NotFound`] (HTTP 404).
+    ///
+    /// Unlike the deprovision path — which folds absence into
+    /// `Ok(())` for idempotency — an update against a missing user is a
+    /// genuine 404: there is no state in which the patch was applied.
+    #[error("user op not found: {detail}")]
+    UserOpNotFound { detail: String },
+
+    /// KC refused to write one or more attributes because they are
+    /// provider-managed and not overridable (read-only user-profile
+    /// attribute, or an attribute federated from a read-only mapper).
+    /// Boundary maps this to [`IdpUserOperationFailure::FieldNotWritable`]
+    /// so AM emits a 400 carrying one `field_violations[]` entry per
+    /// refused attribute, each with `reason=IDP_MANAGED_FIELD`.
+    ///
+    /// `fields` is a set, not a single attribute: a merge patch can touch
+    /// several attributes at once and a locked realm typically refuses more
+    /// than one of them, so callers collect the full refused set before
+    /// returning this variant rather than reporting one attribute per round
+    /// trip. It must be non-empty; an attribution-less refusal belongs on
+    /// [`Self::UserOpRejected`] instead.
+    ///
+    /// Distinct from [`Self::UserOpUnsupported`] (the provider implements no
+    /// update at all) and from [`Self::UserOpRejected`] (the value was bad,
+    /// not the field).
+    #[error(
+        "user op fields not writable ({}): {detail}",
+        fields.iter().map(|f| f.as_field_token()).collect::<Vec<_>>().join(", ")
+    )]
+    UserOpFieldNotWritable {
+        fields: Vec<account_management_sdk::IdpUserAttribute>,
+        detail: String,
+    },
+
     /// Service-account request rejected before any KC call
     /// (name/scope/quota/conflict). Permanent client error.
     /// Boundary maps this to service-account-sdk's `InvalidInput`.
@@ -253,6 +292,8 @@ pub fn failure_variant_label(e: &PluginError) -> &'static str {
         PluginError::UserOpPasswordPolicy { .. } => "user_op_password_policy",
         PluginError::UserOpUnavailable { .. } => "user_op_unavailable",
         PluginError::UserOpUnsupported { .. } => "user_op_unsupported",
+        PluginError::UserOpNotFound { .. } => "user_op_not_found",
+        PluginError::UserOpFieldNotWritable { .. } => "user_op_field_not_writable",
         PluginError::SaInvalidInput { .. } => "sa_invalid_input",
         PluginError::SaNotFound { .. } => "sa_not_found",
     }

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/error_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/error_tests.rs
@@ -180,6 +180,34 @@ fn user_op_unsupported_detail_format() {
 }
 
 #[test]
+fn user_op_not_found_detail_format_and_label_are_stable() {
+    let e = PluginError::UserOpNotFound {
+        detail: "user absent from tenant scope".into(),
+    };
+    assert_eq!(
+        format!("{e}"),
+        "user op not found: user absent from tenant scope"
+    );
+    assert_eq!(failure_variant_label(&e), "user_op_not_found");
+}
+
+#[test]
+fn user_op_field_not_writable_detail_format_and_label_are_stable() {
+    let e = PluginError::UserOpFieldNotWritable {
+        fields: vec![
+            account_management_sdk::IdpUserAttribute::Email,
+            account_management_sdk::IdpUserAttribute::FirstName,
+        ],
+        detail: "provider-managed profile".into(),
+    };
+    assert_eq!(
+        format!("{e}"),
+        "user op fields not writable (email, first_name): provider-managed profile"
+    );
+    assert_eq!(failure_variant_label(&e), "user_op_field_not_writable");
+}
+
+#[test]
 fn redact_secrets_masks_client_secret_kv() {
     let body = r#"{"error":"invalid_request","client_secret":"sensitive-value-123"}"#;
     let out = crate::domain::error::redact_secrets(body);

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/ports/metrics.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/ports/metrics.rs
@@ -44,6 +44,7 @@ use crate::domain::metadata_codec::{DecodeError, RealmBinding, version_observed_
 pub enum UserOp {
     ProvisionUser,
     DeprovisionUser,
+    UpdateUser,
     ListUsers,
 }
 
@@ -53,6 +54,7 @@ impl UserOp {
         match self {
             Self::ProvisionUser => "provision_user",
             Self::DeprovisionUser => "deprovision_user",
+            Self::UpdateUser => "update_user",
             Self::ListUsers => "list_users",
         }
     }
@@ -165,6 +167,7 @@ pub enum PluginOp {
     DeprovisionTenant,
     ProvisionUser,
     DeprovisionUser,
+    UpdateUser,
     ListUsers,
     SaCreate,
     SaRotateSecret,
@@ -181,6 +184,7 @@ impl PluginOp {
             Self::DeprovisionTenant => "deprovision_tenant",
             Self::ProvisionUser => "provision_user",
             Self::DeprovisionUser => "deprovision_user",
+            Self::UpdateUser => "update_user",
             Self::ListUsers => "list_users",
             Self::SaCreate => "sa_create",
             Self::SaRotateSecret => "sa_rotate_secret",
@@ -222,6 +226,8 @@ impl FailureVariant {
     pub const USER_OP_REJECTED: Self = Self("user_op_rejected");
     pub const USER_OP_UNAVAILABLE: Self = Self("user_op_unavailable");
     pub const USER_OP_UNSUPPORTED: Self = Self("user_op_unsupported");
+    pub const USER_OP_NOT_FOUND: Self = Self("user_op_not_found");
+    pub const USER_OP_FIELD_NOT_WRITABLE: Self = Self("user_op_field_not_writable");
     pub const SA_INVALID_INPUT: Self = Self("sa_invalid_input");
     pub const SA_NOT_FOUND: Self = Self("sa_not_found");
 

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/ports/metrics_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/ports/metrics_tests.rs
@@ -22,6 +22,7 @@ fn sa_op_as_str_stable() {
 fn user_op_as_str_stable() {
     assert_eq!(UserOp::ProvisionUser.as_str(), "provision_user");
     assert_eq!(UserOp::DeprovisionUser.as_str(), "deprovision_user");
+    assert_eq!(UserOp::UpdateUser.as_str(), "update_user");
     assert_eq!(UserOp::ListUsers.as_str(), "list_users");
 }
 
@@ -35,6 +36,7 @@ fn token_tier_as_str_stable() {
 fn plugin_op_as_str_stable() {
     assert_eq!(PluginOp::ProvisionTenant.as_str(), "provision_tenant");
     assert_eq!(PluginOp::DeprovisionTenant.as_str(), "deprovision_tenant");
+    assert_eq!(PluginOp::UpdateUser.as_str(), "update_user");
     assert_eq!(PluginOp::ListUsers.as_str(), "list_users");
     assert_eq!(PluginOp::SaCreate.as_str(), "sa_create");
     assert_eq!(PluginOp::SaRotateSecret.as_str(), "sa_rotate_secret");
@@ -140,6 +142,19 @@ fn failure_variant_constants_match_failure_variant_label() {
             "user_op_unsupported",
         ),
         (
+            PluginError::UserOpNotFound {
+                detail: String::new(),
+            },
+            "user_op_not_found",
+        ),
+        (
+            PluginError::UserOpFieldNotWritable {
+                fields: vec![account_management_sdk::IdpUserAttribute::Email],
+                detail: String::new(),
+            },
+            "user_op_field_not_writable",
+        ),
+        (
             PluginError::SaInvalidInput {
                 detail: String::new(),
                 field: None,
@@ -202,6 +217,14 @@ fn failure_variant_constants_match_their_literal() {
     assert_eq!(
         FailureVariant::USER_OP_UNSUPPORTED.as_str(),
         "user_op_unsupported"
+    );
+    assert_eq!(
+        FailureVariant::USER_OP_NOT_FOUND.as_str(),
+        "user_op_not_found"
+    );
+    assert_eq!(
+        FailureVariant::USER_OP_FIELD_NOT_WRITABLE.as_str(),
+        "user_op_field_not_writable"
     );
     assert_eq!(
         FailureVariant::SA_INVALID_INPUT.as_str(),

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/user_facade.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/user_facade.rs
@@ -1,12 +1,18 @@
-//! `UserFacade` — provision/deprovision/list users against Keycloak per DESIGN "Interactions & Sequences".
+//! `UserFacade` — provision/update/deprovision/list users against Keycloak per
+//! DESIGN "Interactions & Sequences".
 //!
-//! Implements `provision_user_inner`, `deprovision_user_inner`, and
-//! `list_users_inner` across all three [`RealmBinding`] modes (Shared /
-//! Adopted / Created). Metadata decode, secret-source selection (DESIGN "Domain Model"),
-//! and user-operation audit events are handled within this facade; the SDK
-//! boundary in `idp_impl.rs` translates [`PluginError`] into the typed
-//! `IdpUserOperationFailure` variants (`Rejected` / `Unavailable` /
-//! `UnsupportedOperation`).
+//! Implements `provision_user_inner`, `update_user_inner`,
+//! `deprovision_user_inner`, and `list_users_inner` across all three
+//! [`RealmBinding`] modes (Shared / Adopted / Created). Metadata decode,
+//! secret-source selection (DESIGN "Domain Model"), and user-operation audit
+//! events are handled within this facade; the SDK boundary in `idp_impl.rs`
+//! translates [`PluginError`] into the typed `IdpUserOperationFailure`
+//! variants.
+//!
+//! Both mutating paths that take a caller-supplied user ID verify the user's
+//! stored `tenant_id` attribute before writing. Users live in Keycloak rather
+//! than AM's database, so that provider-side ownership check is the protection
+//! against cross-tenant user mutation.
 //!
 //! [`TenantFacade`]: crate::domain::tenant_facade::TenantFacade
 
@@ -14,8 +20,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use account_management_sdk::idp_user::{
-    IdpDeprovisionUserRequest, IdpListUsersRequest, IdpProvisionUserRequest, IdpUser,
-    IdpUserFilterField,
+    IdpDeprovisionUserRequest, IdpListUsersRequest, IdpProvisionUserRequest, IdpUpdateUserRequest,
+    IdpUser, IdpUserAttribute, IdpUserFilterField, IdpUserPatch,
 };
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use credstore_sdk::SecretRef;
@@ -134,15 +140,174 @@ fn is_kc_password_policy_reject(body_text: &str) -> bool {
         || error.starts_with("invalidpassword")
 }
 
+/// Map a Keycloak `UserRepresentation` property name onto the SDK
+/// attribute token AM attributes field violations to.
+///
+/// `display_name` is absent by design: it is not a KC property at all
+/// (see [`UserFacade::user_rep_to_idp_user`] — AM's `display_name` is
+/// *derived* from `firstName`/`lastName`), so KC can never name it in a
+/// validation error. The un-writability of `display_name` is a static
+/// fact about this plugin's mapping, rejected before any KC call by
+/// [`UserFacade::preflight_unwritable_attribute`].
+fn kc_field_to_attribute(kc_field: &str) -> Option<IdpUserAttribute> {
+    match kc_field {
+        "username" => Some(IdpUserAttribute::Username),
+        "email" => Some(IdpUserAttribute::Email),
+        "firstName" => Some(IdpUserAttribute::FirstName),
+        "lastName" => Some(IdpUserAttribute::LastName),
+        _ => None,
+    }
+}
+
+/// Detect a KC read-only-attribute reject on user-update and localise it
+/// to every refused attribute the body names.
+///
+/// This is the SAFETY NET, not the primary mechanism: `update_user` decides
+/// writability up front from the structured
+/// `userProfileMetadata.attributes[].readOnly` flags
+/// ([`UserFacade::read_user_for_update`]), so a well-behaved patch never
+/// reaches here. This path catches what pre-flight cannot: a KC that does not
+/// serve profile metadata, a lock introduced between the read and the write,
+/// or a lock the metadata does not model.
+///
+/// # Signal precedence
+///
+/// 1. **`errorMessage` equals a known read-only message KEY.** KC returns a
+///    message key, not localized prose — verified against KC 26.5.3, where the
+///    body is byte-identical under `Accept-Language: de`:
+///    `{"field":"username","errorMessage":"error-user-attribute-read-only","params":["username"]}`.
+///    Exact comparison only, over keys observed in real response bodies — see
+///    the list's own notes on what is excluded and why. There is deliberately
+///    NO substring fallback: a phrase test over the message could only add
+///    false positives on unrelated 400s (`"cannot link read-only federated
+///    store"` is not a locked field). KC does define
+///    `updateReadOnlyAttributesRejectedMessage` for the legacy
+///    read-only-attributes rejection, so that path is not keyless as such — it
+///    is merely unproven on the admin API, and unreachable for the five profile
+///    fields AM patches.
+/// 2. **`field` from the body**, whether the body is that flat object or the
+///    `{"errors":[…]}` array some validation paths emit. KC names the refused
+///    property itself, so it is always preferred over inference, and EVERY
+///    named entry is collected -- a multi-field patch can draw one `errors[]`
+///    entry per locked attribute, and the caller needs the whole set in one
+///    round trip, not just the first.
+/// 3. **Single-touched-attribute inference**, only once (1) has already
+///    established this IS a read-only reject and no entry named a modelled
+///    field. Bounded by construction: it chooses *which* field, never
+///    *whether*, so it cannot manufacture a locked-field error out of an
+///    unrelated failure.
+///
+/// Returns an empty `Vec` for any 400 that is not a read-only reject, and for
+/// a read-only reject that cannot be attributed to a modelled request
+/// property — the caller then uses the generic rejection lane rather than
+/// blaming an arbitrary field.
+///
+/// Several unrelated Keycloak features land here, which is why detection is not
+/// tied to one config source:
+///
+/// * **Realm flag** — `editUsernameAllowed=false` locks `username`. This is
+///   Keycloak's DEFAULT and needs no federation, so on a stock platform it is
+///   the most likely trigger of this whole code path. Verified against the
+///   `platform` realm: renaming a login is refused there out of the box.
+/// * **Declarative user profile** (default since KC 24) — an attribute whose
+///   `permissions.edit` excludes the caller. Produces the per-field
+///   `errors[]` shape handled first below.
+/// * **Federated read-only attributes** — an LDAP/User-Storage provider in
+///   `editMode=READ_ONLY`, or an individual `user-attribute-ldap-mapper` with
+///   `read.only=true`. The external directory owns the value, so Keycloak
+///   refuses to write it.
+/// * **Keycloak's internal attribute guard** — over system attributes
+///   (`LDAP_ID`, `LDAP_ENTRY_DN`, `KERBEROS_PRINCIPAL`, `CREATED_TIMESTAMP`,
+///   …). AM patches none of these — [`IdpUserAttribute`] models only the five
+///   profile fields — so this cannot fire from here. Listed for completeness,
+///   NOT handled: it surfaces as a generic `UserOpRejected` 400 if a future
+///   field mapping ever reaches it, which is the correct conservative outcome
+///   for a request AM should never have sent.
+///
+/// AM does not need to distinguish them: from a caller's perspective all four
+/// mean "this provider will not let you write this field", which is exactly
+/// what `IDP_MANAGED_FIELD` says.
+fn classify_kc_read_only_reject(
+    body_text: &str,
+    touched: &[IdpUserAttribute],
+) -> Vec<IdpUserAttribute> {
+    /// The one message key KC is known to return for a read-only-attribute
+    /// refusal. Compared for equality, not searched for: it is a stable
+    /// identifier, byte-identical from KC 26.5.3 under `Accept-Language: de`.
+    ///
+    /// Observed verbatim:
+    /// `{"field":"username","errorMessage":"error-user-attribute-read-only","params":["username"]}`
+    ///
+    /// Should a second key ever need adding, it MUST come with an observed
+    /// admin-API body. Two earlier guesses did not: `error-user-read-only`
+    /// turned out not to exist in KC 26.5.3's bundles at all, and a substring
+    /// test over the message could only ever add false positives (an unrelated
+    /// 400 reading `"cannot link read-only federated store"` is not a locked
+    /// field). Real keys that remain excluded for want of evidence that the
+    /// admin API returns them as `errorMessage` rather than rendering them as
+    /// themed display text: `updateReadOnlyAttributesRejectedMessage` (the
+    /// legacy read-only-attributes rejection), `readOnlyUserMessage`,
+    /// `readOnlyUsernameMessage`, `readOnlyPasswordMessage`.
+    const READ_ONLY_MESSAGE_KEY: &str = "error-user-attribute-read-only";
+
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(body_text) else {
+        return Vec::new();
+    };
+
+    // KC states the refusal either as a flat object or as an `errors[]` array,
+    // so treat the body as a list of candidate entries: the array's members
+    // when present (most specific), then the root object itself.
+    let nested: &[serde_json::Value] = v
+        .get("errors")
+        .and_then(serde_json::Value::as_array)
+        .map_or(&[], Vec::as_slice);
+
+    let mut read_only_signalled = false;
+    let mut fields = Vec::new();
+    for entry in nested.iter().chain(std::iter::once(&v)) {
+        if entry
+            .get("errorMessage")
+            .and_then(serde_json::Value::as_str)
+            != Some(READ_ONLY_MESSAGE_KEY)
+        {
+            continue;
+        }
+        read_only_signalled = true;
+        // KC named the property — collected rather than returned
+        // immediately, because a multi-field patch can draw one entry per
+        // locked attribute and the caller needs the whole set. A field AM
+        // does not model (a custom realm attribute) still signals a
+        // read-only reject even though it contributes nothing to `fields`.
+        if let Some(attribute) = entry
+            .get("field")
+            .and_then(serde_json::Value::as_str)
+            .and_then(kc_field_to_attribute)
+            && !fields.contains(&attribute)
+        {
+            fields.push(attribute);
+        }
+    }
+    // No entry named a modelled field. A single-attribute patch is still
+    // unambiguous: the refusal can only be about that one.
+    if fields.is_empty()
+        && read_only_signalled
+        && let [only] = touched
+    {
+        fields.push(*only);
+    }
+    fields
+}
+
 /// Subset of Keycloak's `UserRepresentation` the facade needs:
 ///
 /// * UUID discovery after `provision_user` — only `id` is required.
 /// * `list_users` group-members listing — `id` + profile fields the
 ///   facade projects into [`IdpUser`].
 ///
-/// `firstName` / `lastName` are concatenated into [`IdpUser::display_name`]
-/// per DESIGN "Interactions & Sequences" (KC `firstName + lastName` is the canonical KC profile
-/// shape; OIDC `name` claim is not surfaced by the admin REST endpoint).
+/// `firstName` / `lastName` are projected directly and concatenated into
+/// [`IdpUser::display_name`] per DESIGN "Interactions & Sequences" (KC
+/// `firstName + lastName` is the canonical KC profile shape; OIDC `name` claim
+/// is not surfaced by the admin REST endpoint).
 ///
 /// `createdTimestamp` is used by the `list_users` cursor sort key
 /// `(createdTimestamp ASC, id ASC)` per DESIGN "Interactions & Sequences".
@@ -1152,6 +1317,615 @@ impl UserFacade {
         Ok((metadata.realm_name, metadata.realm_binding))
     }
 
+    /// Apply AM's merge patch to a user in the tenant's bound realm and
+    /// return the post-update projection.
+    ///
+    /// Emits `user.updated` on success and records a failure metric
+    /// otherwise, mirroring [`Self::provision_user_inner`].
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::update_user_impl`].
+    pub async fn update_user_inner(
+        &self,
+        ctx: &SecurityContext,
+        req: &IdpUpdateUserRequest,
+    ) -> Result<IdpUser, PluginError> {
+        let started = Instant::now();
+        let result = self.update_user_impl(req).await;
+        let elapsed = started.elapsed().as_secs_f64();
+        self.user_metrics
+            .user_op_duration(UserOp::UpdateUser, elapsed);
+        match &result {
+            Ok((user, realm_name, realm_binding)) => {
+                audit::emit_user_updated(
+                    ctx,
+                    req.tenant_context.tenant_id,
+                    realm_name,
+                    *realm_binding,
+                    user.id,
+                    &Self::changed_labels(&req.patch),
+                );
+            }
+            Err(e) => {
+                self.record_user_op_failure(PluginOp::UpdateUser, e);
+            }
+        }
+        result.map(|(user, _, _)| user)
+    }
+
+    /// Inner implementation returning the [`IdpUser`] plus the bound realm
+    /// name / binding so the wrapper can label the audit event without
+    /// re-decoding the metadata.
+    ///
+    /// Ordering (each step gated on the previous):
+    ///
+    /// 1. Decode tenant metadata; resolve the realm-admin secret source.
+    /// 2. Pre-flight the statically-unwritable attributes
+    ///    ([`Self::preflight_unwritable_attribute`]) — refused before any
+    ///    KC call, so a `display_name` patch costs no round trip.
+    /// 3. **Binding check** — the user's stored `tenant_id` attribute MUST
+    ///    equal the requesting tenant. This is the only defence against
+    ///    cross-tenant user mutation: users live in KC, so the `AuthZ` SQL
+    ///    clamp that protects AM-DB writes never sees this path. Same
+    ///    guard as [`Self::deprovision_user_impl`] step 2.5, but a
+    ///    mismatch here returns [`PluginError::UserOpNotFound`] rather
+    ///    than folding into success — an update must not silently no-op.
+    /// 4. `PUT /users/{id}` with only the touched profile fields.
+    /// 5. `PUT /users/{id}/reset-password` when the patch carries one.
+    /// 6. Re-read the user and project it.
+    ///
+    /// Step 6 is a real GET rather than echoing the request: KC normalises
+    /// what it stores (lower-cases `username`, may trim or reformat
+    /// profile fields), so the only truthful 200 body is the one read back
+    /// from the provider.
+    ///
+    /// # Errors
+    ///
+    /// * [`PluginError::UserOpFieldNotWritable`] — an attribute is
+    ///   provider-managed (`display_name` always; any attribute KC
+    ///   reports read-only).
+    /// * [`PluginError::UserOpNotFound`] — user absent from the realm, or
+    ///   bound to a different tenant.
+    /// * [`PluginError::UserOpDuplicate`] — a `username` rename collided.
+    /// * [`PluginError::UserOpPasswordPolicy`] — KC rejected the password.
+    /// * [`PluginError::UserOpRejected`] — any other terminal 400/422.
+    /// * [`PluginError::UserOpUnavailable`] — 5xx / transport / timeout.
+    async fn update_user_impl(
+        &self,
+        req: &IdpUpdateUserRequest,
+    ) -> Result<(IdpUser, String, RealmBinding), PluginError> {
+        // ---- Step 1: metadata + secret source. ----
+        let metadata = self.decode_tenant_metadata(req.tenant_context.metadata.as_ref())?;
+        let secret_source = self.build_secret_source(&metadata)?;
+
+        // ---- Step 2: statically-unwritable attributes. ----
+        if let Some(attribute) = Self::preflight_unwritable_attribute(&req.patch) {
+            return Err(PluginError::UserOpFieldNotWritable {
+                fields: vec![attribute],
+                detail: format!(
+                    "{} is derived from the Keycloak firstName/lastName pair and is not a \
+                     writable provider attribute; patch first_name / last_name instead",
+                    attribute.as_field_token()
+                ),
+            });
+        }
+
+        // ---- Step 3: single pre-write read — binding + writability. ----
+        let expected_tid = req.tenant_context.tenant_id;
+        let (actual_tid, read_only) = self
+            .kc_factory
+            .with_reactive_401(
+                &metadata.realm_name,
+                &metadata.admin_client_id,
+                &secret_source,
+                |realm_admin| {
+                    let realm_name = metadata.realm_name.clone();
+                    async move {
+                        self.read_user_for_update(&realm_admin, &realm_name, req.user_id)
+                            .await
+                    }
+                },
+            )
+            .await
+            .map_err(user_translate_kc)?;
+        if actual_tid != Some(expected_tid) {
+            tracing::warn!(
+                target: "keycloak_idp_plugin.user_binding",
+                user_id = %req.user_id,
+                expected_tenant_id = %expected_tid,
+                actual_tenant_id = ?actual_tid,
+                realm_name = %metadata.realm_name,
+                "user update refused: stored tenant_id attribute does not match request; cross-tenant PATCH prevented"
+            );
+            // Deliberately indistinguishable from a genuine absence: a
+            // caller must not be able to probe for users in other
+            // tenants by comparing 403 against 404.
+            return Err(PluginError::UserOpNotFound {
+                detail: format!("user {} not found in this tenant scope", req.user_id),
+            });
+        }
+
+        // ---- Step 3b: refuse attributes KC reports as non-writable. ----
+        //
+        // Decided from the structured `readOnly` flags rather than from a
+        // rejected write, which buys three things: the refusal names the exact
+        // field even when the patch touched several, no write is attempted for
+        // a patch that cannot fully apply (so a multi-field patch cannot land
+        // half-applied), and the classification does not depend on KC's error
+        // wording. `classify_kc_read_only_reject` still guards the PUT for
+        // locks this read cannot see.
+        //
+        // Ordering is deliberate where both could apply: a locked `username` is
+        // reported even when the requested login would ALSO collide with an
+        // existing one. The two answers are not equally useful —
+        // `already_exists` invites a retry with a different login, which is
+        // false when no login would be accepted. Refusing on the unconditional
+        // fact beats reporting the incidental one, and it means uniqueness is
+        // never probed for a field the caller cannot write.
+        let touched = Self::touched_attributes(&req.patch);
+        let locked_touched: Vec<IdpUserAttribute> = touched
+            .iter()
+            .copied()
+            .filter(|a| read_only.contains(a))
+            .collect();
+        if !locked_touched.is_empty() {
+            return Err(PluginError::UserOpFieldNotWritable {
+                detail: format!(
+                    "kc reports {} as read-only for this realm",
+                    locked_touched
+                        .iter()
+                        .map(|a| a.as_field_token())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+                fields: locked_touched,
+            });
+        }
+
+        // ---- Step 4: profile PUT (skipped for a password-only patch). ----
+        if !touched.is_empty() {
+            self.kc_factory
+                .with_reactive_401(
+                    &metadata.realm_name,
+                    &metadata.admin_client_id,
+                    &secret_source,
+                    |realm_admin| {
+                        let realm_name = metadata.realm_name.clone();
+                        let touched = touched.clone();
+                        async move {
+                            self.patch_user(&realm_admin, &realm_name, req, &touched)
+                                .await
+                        }
+                    },
+                )
+                .await
+                .map_err(user_translate_kc)?;
+        }
+
+        // ---- Step 5: credential reset. ----
+        if let Some(password) = req.patch.password.as_ref() {
+            self.kc_factory
+                .with_reactive_401(
+                    &metadata.realm_name,
+                    &metadata.admin_client_id,
+                    &secret_source,
+                    |realm_admin| {
+                        let realm_name = metadata.realm_name.clone();
+                        async move {
+                            self.reset_password(&realm_admin, &realm_name, req.user_id, password)
+                                .await
+                        }
+                    },
+                )
+                .await
+                .map_err(user_translate_kc)?;
+        }
+
+        // ---- Step 6: re-read and project. ----
+        let rep = self
+            .kc_factory
+            .with_reactive_401(
+                &metadata.realm_name,
+                &metadata.admin_client_id,
+                &secret_source,
+                |realm_admin| {
+                    let realm_name = metadata.realm_name.clone();
+                    async move {
+                        self.read_user_rep(&realm_admin, &realm_name, req.user_id)
+                            .await
+                    }
+                },
+            )
+            .await
+            .map_err(user_translate_kc)?;
+        Ok((
+            Self::user_rep_to_idp_user(rep),
+            metadata.realm_name,
+            metadata.realm_binding,
+        ))
+    }
+
+    /// Attributes in `patch` that this plugin cannot write at all,
+    /// independent of realm configuration.
+    ///
+    /// Only `display_name`: AM models it as a first-class field, but
+    /// Keycloak has no such property — the projection composes it from
+    /// `firstName`/`lastName` (see [`Self::user_rep_to_idp_user`]).
+    /// Accepting the write and silently dropping it would make a 200
+    /// response a lie, and splitting a single string back into given /
+    /// family names is guesswork, so the honest answer is a refusal
+    /// naming the field, which AM renders as a 400 carrying
+    /// `field=display_name, reason=IDP_MANAGED_FIELD`.
+    fn preflight_unwritable_attribute(patch: &IdpUserPatch) -> Option<IdpUserAttribute> {
+        patch
+            .display_name
+            .as_ref()
+            .map(|_| IdpUserAttribute::DisplayName)
+    }
+
+    /// Writable profile attributes the patch touches, in a stable order.
+    /// `Some(_)` counts as touched whether it sets or clears; `password`
+    /// is excluded because it is written through a separate endpoint and
+    /// is not a user-profile attribute.
+    fn touched_attributes(patch: &IdpUserPatch) -> Vec<IdpUserAttribute> {
+        let mut touched = Vec::new();
+        if patch.username.is_some() {
+            touched.push(IdpUserAttribute::Username);
+        }
+        if patch.email.is_some() {
+            touched.push(IdpUserAttribute::Email);
+        }
+        if patch.first_name.is_some() {
+            touched.push(IdpUserAttribute::FirstName);
+        }
+        if patch.last_name.is_some() {
+            touched.push(IdpUserAttribute::LastName);
+        }
+        touched
+    }
+
+    /// AM request-property names the patch touched, for the audit event.
+    /// Names only — never values (see [`audit::emit_user_updated`]).
+    fn changed_labels(patch: &IdpUserPatch) -> Vec<&'static str> {
+        let mut changed: Vec<&'static str> = Self::touched_attributes(patch)
+            .iter()
+            .map(|a| a.as_field_token())
+            .collect();
+        if patch.password.is_some() {
+            changed.push("password");
+        }
+        changed
+    }
+
+    /// `PUT /admin/realms/{realm}/users/{user_id}` — apply the touched
+    /// profile fields.
+    ///
+    /// Only touched fields are sent, which is what preserves AM's merge
+    /// semantics: KC leaves a property it does not receive unchanged. A
+    /// *clear* (`Some(None)`) is sent as an empty string, which is KC's
+    /// way of blanking a profile field — `null` is indistinguishable from
+    /// "absent" to KC and would silently no-op. Because step 6 re-reads
+    /// the user, a realm that refuses to blank a field surfaces the
+    /// still-populated value in the 200 body rather than a false claim of
+    /// success.
+    ///
+    /// `display_name` never reaches here — [`Self::preflight_unwritable_attribute`]
+    /// rejects it first.
+    async fn patch_user(
+        &self,
+        realm_admin: &KcAdminClient,
+        realm_name: &str,
+        req: &IdpUpdateUserRequest,
+        touched: &[IdpUserAttribute],
+    ) -> Result<(), PluginError> {
+        const PATH: &str = "/admin/realms/{realm}/users/{user_id}";
+        let url = format!(
+            "{}admin/realms/{}/users/{}",
+            self.kc_factory.base_url_str(),
+            encode_component(realm_name),
+            req.user_id,
+        );
+        let mut body = serde_json::Map::new();
+        // `username` is set-only: AM rejects an explicit `null` upstream
+        // (the login identifier is required), so `Some(v)` is always a
+        // rename to a concrete value.
+        if let Some(username) = req.patch.username.as_ref() {
+            body.insert(
+                "username".into(),
+                serde_json::Value::String(username.clone()),
+            );
+        }
+        // Tri-state → KC: `Some(Some(v))` sets, `Some(None)` blanks via
+        // the empty string, `None` omits the key entirely.
+        let mut insert_tristate = |key: &str, value: Option<&Option<String>>| {
+            if let Some(slot) = value {
+                body.insert(
+                    key.to_owned(),
+                    serde_json::Value::String(slot.clone().unwrap_or_default()),
+                );
+            }
+        };
+        insert_tristate("email", req.patch.email.as_ref());
+        insert_tristate("firstName", req.patch.first_name.as_ref());
+        insert_tristate("lastName", req.patch.last_name.as_ref());
+        let body = serde_json::Value::Object(body);
+        let (status, body_text) = realm_admin
+            .raw_request("PUT", &url, Some(&body), PATH)
+            .await
+            .map_err(user_translate_kc)?;
+        if (200..=299).contains(&status) {
+            return Ok(());
+        }
+        if status == 401 {
+            // Idempotent request → safe for the wrapper's exactly-once
+            // retry after re-minting the bearer.
+            return Err(PluginError::KcRest {
+                method: "PUT",
+                path_template: PATH.into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
+            });
+        }
+        let redacted = redact_secrets(&truncate_2kb(&body_text));
+        if status == 404 || status == 410 {
+            return Err(PluginError::UserOpNotFound {
+                detail: format!("user {} not found in this tenant scope", req.user_id),
+            });
+        }
+        if status == 409 {
+            // On this endpoint a 409 can only be a uniqueness collision
+            // from the rename; the body only refines which field.
+            return Err(PluginError::UserOpDuplicate {
+                field: classify_kc_conflict(&body_text),
+                detail: format!("user already exists: kc:PUT {PATH} -> 409: {redacted}"),
+            });
+        }
+        if status == 400 || status == 422 {
+            let read_only_fields = classify_kc_read_only_reject(&body_text, touched);
+            if !read_only_fields.is_empty() {
+                return Err(PluginError::UserOpFieldNotWritable {
+                    detail: format!(
+                        "kc reports {} read-only: kc:PUT {PATH} -> {status}: {redacted}",
+                        read_only_fields
+                            .iter()
+                            .map(|a| a.as_field_token())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ),
+                    fields: read_only_fields,
+                });
+            }
+            if is_kc_password_policy_reject(&body_text) {
+                return Err(PluginError::UserOpPasswordPolicy {
+                    detail: format!(
+                        "password policy rejected: kc:PUT {PATH} -> {status}: {redacted}"
+                    ),
+                });
+            }
+            return Err(PluginError::UserOpRejected {
+                detail: format!("kc:PUT {PATH} -> {status}: {redacted}"),
+            });
+        }
+        Err(PluginError::UserOpUnavailable {
+            detail: format!("kc:PUT {PATH} -> {status}: {redacted}"),
+        })
+    }
+
+    /// `PUT /admin/realms/{realm}/users/{user_id}/reset-password` — set a
+    /// new credential.
+    ///
+    /// A separate call because KC accepts an embedded `credentials` array
+    /// only on user-create; on update the credential endpoint is the
+    /// supported path. `temporary: true` makes KC require a password
+    /// change at next login. The plaintext lives only on this request's
+    /// stack and the outbound HTTPS body — it is never logged (the
+    /// failure details below carry only KC's response, itself passed
+    /// through [`redact_secrets`]).
+    async fn reset_password(
+        &self,
+        realm_admin: &KcAdminClient,
+        realm_name: &str,
+        user_id: Uuid,
+        password: &account_management_sdk::NewUserPassword,
+    ) -> Result<(), PluginError> {
+        const PATH: &str = "/admin/realms/{realm}/users/{user_id}/reset-password";
+        let url = format!(
+            "{}admin/realms/{}/users/{}/reset-password",
+            self.kc_factory.base_url_str(),
+            encode_component(realm_name),
+            user_id,
+        );
+        let body = serde_json::json!({
+            "type": "password",
+            "value": password.value,
+            "temporary": password.temporary,
+        });
+        let (status, body_text) = realm_admin
+            .raw_request("PUT", &url, Some(&body), PATH)
+            .await
+            .map_err(user_translate_kc)?;
+        if (200..=299).contains(&status) {
+            return Ok(());
+        }
+        if status == 401 {
+            return Err(PluginError::KcRest {
+                method: "PUT",
+                path_template: PATH.into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
+            });
+        }
+        let redacted = redact_secrets(&truncate_2kb(&body_text));
+        if status == 404 || status == 410 {
+            return Err(PluginError::UserOpNotFound {
+                detail: format!("user {user_id} not found in this tenant scope"),
+            });
+        }
+        if status == 400 || status == 422 {
+            if is_kc_password_policy_reject(&body_text) {
+                return Err(PluginError::UserOpPasswordPolicy {
+                    detail: format!(
+                        "password policy rejected: kc:PUT {PATH} -> {status}: {redacted}"
+                    ),
+                });
+            }
+            return Err(PluginError::UserOpRejected {
+                detail: format!("kc:PUT {PATH} -> {status}: {redacted}"),
+            });
+        }
+        Err(PluginError::UserOpUnavailable {
+            detail: format!("kc:PUT {PATH} -> {status}: {redacted}"),
+        })
+    }
+
+    /// `GET /admin/realms/{realm}/users/{user_id}?userProfileMetadata=true`
+    /// → `(stored tenant_id, attributes KC reports as non-writable)`.
+    ///
+    /// The update path's single pre-write read. It answers both questions
+    /// `update_user` must settle before touching anything, in one round trip:
+    ///
+    /// * **Who owns this user** — `attributes.tenant_id[0]`, the cross-tenant
+    ///   binding check (same datum [`Self::read_user_owner_tenant`] reads for
+    ///   the deprovision path).
+    /// * **Which attributes are writable** —
+    ///   `userProfileMetadata.attributes[].readOnly`, a structured boolean per
+    ///   attribute. This is KC's own computed verdict, so it accounts uniformly
+    ///   for every locking mechanism (the `editUsernameAllowed` realm flag,
+    ///   declarative-user-profile `permissions.edit`, a federated read-only
+    ///   mapper) without this code having to know which one applied.
+    ///
+    /// Preferring this over parsing the refusal is what keeps
+    /// [`classify_kc_read_only_reject`] a fallback: a structured boolean cannot
+    /// drift with KC's wording, and it lets the refusal name the offending
+    /// field even when the patch touched several.
+    ///
+    /// `tenant_id` mirrors [`Self::read_user_owner_tenant`]'s tolerance: an
+    /// absent user, a missing attribute, or an unparseable value all yield
+    /// `None`, which the caller treats as "no usable binding" and refuses. An
+    /// absent `userProfileMetadata` (older KC, or the query param ignored)
+    /// yields an empty lock set — pre-flight then permits everything and the
+    /// post-hoc classifier remains the guard.
+    async fn read_user_for_update(
+        &self,
+        realm_admin: &KcAdminClient,
+        realm_name: &str,
+        user_id: Uuid,
+    ) -> Result<(Option<Uuid>, Vec<IdpUserAttribute>), PluginError> {
+        const PATH: &str = "/admin/realms/{realm}/users/{user_id}";
+        let url = format!(
+            "{}admin/realms/{}/users/{}?userProfileMetadata=true",
+            self.kc_factory.base_url_str(),
+            encode_component(realm_name),
+            user_id,
+        );
+        let (status, body_text) = realm_admin
+            .raw_request("GET", &url, None, PATH)
+            .await
+            .map_err(user_translate_kc)?;
+        if status == 404 || status == 410 {
+            return Ok((None, Vec::new()));
+        }
+        if status == 401 {
+            return Err(PluginError::KcRest {
+                method: "GET",
+                path_template: PATH.into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
+            });
+        }
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::UserOpUnavailable {
+                detail: format!(
+                    "kc:GET {PATH}?userProfileMetadata=true -> {status}: {}",
+                    redact_secrets(&truncate_2kb(&body_text)),
+                ),
+            });
+        }
+        // Parsed loosely as `Value`: only two sub-trees are needed, and
+        // tolerating the rest keeps this resilient to KC representation growth.
+        let user: serde_json::Value =
+            serde_json::from_str(&body_text).map_err(|e| PluginError::UserOpUnavailable {
+                detail: format!("kc:GET {PATH}?userProfileMetadata=true json decode: {e}"),
+            })?;
+        let tenant_id = user
+            .get("attributes")
+            .and_then(|a| a.get("tenant_id"))
+            .and_then(|t| t.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok());
+        let read_only = user
+            .get("userProfileMetadata")
+            .and_then(|m| m.get("attributes"))
+            .and_then(serde_json::Value::as_array)
+            .map(|attrs| {
+                attrs
+                    .iter()
+                    .filter(|a| {
+                        a.get("readOnly")
+                            .and_then(serde_json::Value::as_bool)
+                            .unwrap_or(false)
+                    })
+                    .filter_map(|a| a.get("name").and_then(serde_json::Value::as_str))
+                    .filter_map(kc_field_to_attribute)
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok((tenant_id, read_only))
+    }
+
+    /// `GET /admin/realms/{realm}/users/{user_id}` → parsed [`UserRep`].
+    ///
+    /// The post-update read for [`Self::update_user_impl`]. Distinct from
+    /// [`Self::read_user_owner_tenant`], which decodes only the
+    /// `attributes.tenant_id` binding and folds a 404 into `Ok(None)`;
+    /// here an absent user is a genuine
+    /// [`PluginError::UserOpNotFound`] — it can only mean the user was
+    /// deleted concurrently between the patch and the read.
+    async fn read_user_rep(
+        &self,
+        realm_admin: &KcAdminClient,
+        realm_name: &str,
+        user_id: Uuid,
+    ) -> Result<UserRep, PluginError> {
+        const PATH: &str = "/admin/realms/{realm}/users/{user_id}";
+        let url = format!(
+            "{}admin/realms/{}/users/{}",
+            self.kc_factory.base_url_str(),
+            encode_component(realm_name),
+            user_id,
+        );
+        let (status, body_text) = realm_admin
+            .raw_request("GET", &url, None, PATH)
+            .await
+            .map_err(user_translate_kc)?;
+        if status == 401 {
+            return Err(PluginError::KcRest {
+                method: "GET",
+                path_template: PATH.into(),
+                status: KcStatusKind::Http(401),
+                body_first_2kb: redact_secrets(&truncate_2kb(&body_text)),
+            });
+        }
+        if status == 404 || status == 410 {
+            return Err(PluginError::UserOpNotFound {
+                detail: format!("user {user_id} not found in this tenant scope"),
+            });
+        }
+        if !(200..=299).contains(&status) {
+            return Err(PluginError::UserOpUnavailable {
+                detail: format!(
+                    "kc:GET {PATH} -> {status}: {}",
+                    redact_secrets(&truncate_2kb(&body_text)),
+                ),
+            });
+        }
+        serde_json::from_str::<UserRep>(&body_text).map_err(|e| PluginError::UserOpUnavailable {
+            detail: format!("kc:GET {PATH} json decode: {e}"),
+        })
+    }
+
     /// List users from the tenant's bound realm (DESIGN "Interactions & Sequences").
     ///
     /// 1. Decode tenant metadata.
@@ -1636,14 +2410,31 @@ impl UserFacade {
         if let Some(email) = rep.email {
             user = user.with_email(email);
         }
-        let display_name = match (rep.first_name, rep.last_name) {
-            (Some(f), Some(l)) if !f.is_empty() && !l.is_empty() => Some(format!("{f} {l}")),
-            (Some(f), _) if !f.is_empty() => Some(f),
-            (_, Some(l)) if !l.is_empty() => Some(l),
-            _ => None,
+        // KC blanks a profile field by storing the empty string (that is
+        // also how `patch_user` clears one), so treat empty as absent
+        // throughout: a cleared field must read back as omitted, not `""`.
+        let first_name = rep.first_name.filter(|f| !f.is_empty());
+        let last_name = rep.last_name.filter(|l| !l.is_empty());
+        let display_name = match (first_name.as_deref(), last_name.as_deref()) {
+            (Some(f), Some(l)) => Some(format!("{f} {l}")),
+            (Some(f), None) => Some(f.to_owned()),
+            (None, Some(l)) => Some(l.to_owned()),
+            (None, None) => None,
         };
         if let Some(dn) = display_name {
             user = user.with_display_name(dn);
+        }
+        // Project the underlying pair as well, not just the composed
+        // `display_name`. The SDK models `first_name` / `last_name`
+        // separately and they are the only writable half of the pair, so
+        // a caller that patches `first_name` has to be able to read it
+        // back — otherwise a successful update appears to have dropped
+        // the field.
+        if let Some(f) = first_name {
+            user = user.with_first_name(f);
+        }
+        if let Some(l) = last_name {
+            user = user.with_last_name(l);
         }
         user
     }

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/user_facade_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/domain/user_facade_tests.rs
@@ -10,7 +10,8 @@ use crate::domain::test_support::{
 use crate::infra::kc_http::ReqwestKcTransport;
 use account_management_sdk::idp_user::{
     IdpDeprovisionUserRequest, IdpListUsersRequest, IdpNewUser, IdpProvisionUserRequest,
-    IdpTenantContext, IdpUserFilterField, IdpUserPagination,
+    IdpTenantContext, IdpUpdateUserRequest, IdpUserAttribute, IdpUserFilterField,
+    IdpUserPagination, IdpUserPatch,
 };
 use credstore_sdk::CredStoreClientV1;
 use gts::GtsTypeId;
@@ -2352,4 +2353,871 @@ fn kc_password_policy_ignores_other_400s() {
     assert!(!is_kc_password_policy_reject(
         r#"{"error":"unknown_error"}"#
     ));
+}
+
+// -----------------------------------------------------------------
+// update_user
+// -----------------------------------------------------------------
+
+fn update_user_req(
+    tenant_id: Uuid,
+    metadata: Option<serde_json::Value>,
+    user_id: Uuid,
+    patch: IdpUserPatch,
+) -> IdpUpdateUserRequest {
+    IdpUpdateUserRequest::new(
+        IdpTenantContext::new(
+            tenant_id,
+            "stub-tenant",
+            GtsTypeId::new("gts.cf.core.am.tenant_type.v1~cf.core.am.customer.v1~"),
+            metadata,
+        ),
+        user_id,
+        patch,
+    )
+}
+
+/// Mount `GET /users/{id}` returning a representation bound to
+/// `bound_tenant`. Serves BOTH reads in the update saga: the binding
+/// check (which needs `attributes.tenant_id`) and the post-update
+/// projection (which needs the profile fields) — unknown keys are
+/// ignored by each decoder.
+async fn mount_user_get(
+    server: &MockServer,
+    user_id: Uuid,
+    bound_tenant: Uuid,
+    profile: serde_json::Value,
+) {
+    let mut body = serde_json::json!({
+        "id": user_id.to_string(),
+        "attributes": { "tenant_id": [bound_tenant.to_string()] },
+    });
+    let extra = profile.as_object().expect("profile must be a JSON object");
+    let base = body.as_object_mut().expect("body is a JSON object");
+    for (k, v) in extra {
+        base.insert(k.clone(), v.clone());
+    }
+    Mock::given(method("GET"))
+        .and(path(format!("/admin/realms/platform/users/{user_id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn update_user_happy_path_projects_the_reread_representation() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+        let tenant_uuid = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+        mount_user_get(
+            &server,
+            user_uuid,
+            tenant_uuid,
+            serde_json::json!({
+                "username": "alice",
+                "email": "alice@example.com",
+                "firstName": "Alice",
+                "lastName": "Partner",
+            }),
+        )
+        .await;
+        Mock::given(method("PUT"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let mut patch = IdpUserPatch::new();
+        patch.first_name = Some(Some("Alice".to_owned()));
+        let req = update_user_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+            patch,
+        );
+
+        let user = facade
+            .update_user_inner(&ctx, &req)
+            .await
+            .expect("update_user ok");
+        assert_eq!(user.id, user_uuid);
+        assert_eq!(user.username, "alice");
+        // The pair is projected alongside the composed display name: a
+        // caller that patches `first_name` must be able to read it back.
+        assert_eq!(user.first_name.as_deref(), Some("Alice"));
+        assert_eq!(user.last_name.as_deref(), Some("Partner"));
+        assert_eq!(user.display_name.as_deref(), Some("Alice Partner"));
+    })
+    .await;
+}
+
+/// Cross-tenant PATCH is the BOLA case for this endpoint: users live in
+/// KC, so the `AuthZ` SQL clamp that protects AM-DB writes never sees this
+/// path and the stored `tenant_id` attribute is the only defence. A user
+/// bound to another tenant MUST look exactly like a missing user — a
+/// distinguishable error would turn the endpoint into a cross-tenant
+/// existence oracle — and no write may be issued.
+#[tokio::test]
+async fn update_user_cross_tenant_is_not_found_and_issues_no_write() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+        let caller_tenant = Uuid::new_v4();
+        let owner_tenant = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+        // The user exists, but belongs to a different tenant.
+        mount_user_get(
+            &server,
+            user_uuid,
+            owner_tenant,
+            serde_json::json!({ "username": "victim" }),
+        )
+        .await;
+        Mock::given(method("PUT"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let mut patch = IdpUserPatch::new();
+        patch.email = Some(Some("attacker@example.com".to_owned()));
+        let req = update_user_req(
+            caller_tenant,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+            patch,
+        );
+
+        let err = facade
+            .update_user_inner(&ctx, &req)
+            .await
+            .expect_err("cross-tenant update must fail");
+        assert!(
+            matches!(err, PluginError::UserOpNotFound { .. }),
+            "cross-tenant update MUST be indistinguishable from absent, got {err:?}"
+        );
+        let received = server.received_requests().await.unwrap();
+        assert!(
+            !received.iter().any(|r| r.method.as_str() == "PUT"),
+            "no write may be issued once the binding check fails"
+        );
+    })
+    .await;
+}
+
+/// `display_name` is derived from KC's `firstName`/`lastName` pair and is
+/// not a writable provider attribute, so it is refused before any KC
+/// round trip rather than silently dropped.
+#[tokio::test]
+async fn update_user_display_name_is_refused_without_touching_kc() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+        let tenant_uuid = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let mut patch = IdpUserPatch::new();
+        patch.display_name = Some(Some("Alice P.".to_owned()));
+        let req = update_user_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+            patch,
+        );
+
+        let err = facade
+            .update_user_inner(&ctx, &req)
+            .await
+            .expect_err("display_name is not writable");
+        assert!(
+            matches!(err, PluginError::UserOpFieldNotWritable { .. }),
+            "expected FieldNotWritable(display_name), got {err:?}"
+        );
+        if let PluginError::UserOpFieldNotWritable { fields, .. } = &err {
+            assert_eq!(*fields, vec![IdpUserAttribute::DisplayName]);
+        }
+        let received = server.received_requests().await.unwrap();
+        assert!(
+            !received
+                .iter()
+                .any(|r| r.url.path().contains("/admin/realms/")),
+            "a statically-unwritable field must cost no KC round trip"
+        );
+    })
+    .await;
+}
+
+/// KC's declarative user profile reports read-only attributes per field;
+/// that `field` is authoritative and must reach AM as the violation
+/// target so a client can disable exactly that input.
+#[tokio::test]
+async fn update_user_kc_read_only_field_maps_to_field_not_writable() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+        let tenant_uuid = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+        mount_user_get(
+            &server,
+            user_uuid,
+            tenant_uuid,
+            serde_json::json!({ "username": "alice" }),
+        )
+        .await;
+        Mock::given(method("PUT"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "errors": [
+                    {"field": "email", "errorMessage": "error-user-attribute-read-only"}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        // Two attributes touched, so the per-field `errors[]` entry — not
+        // single-attribute inference — is what localises the failure.
+        let mut patch = IdpUserPatch::new();
+        patch.email = Some(Some("new@example.com".to_owned()));
+        patch.first_name = Some(Some("Alice".to_owned()));
+        let req = update_user_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+            patch,
+        );
+
+        let err = facade
+            .update_user_inner(&ctx, &req)
+            .await
+            .expect_err("read-only attribute must fail");
+        assert!(
+            matches!(err, PluginError::UserOpFieldNotWritable { .. }),
+            "expected FieldNotWritable(email) from the per-field errors[], got {err:?}"
+        );
+        if let PluginError::UserOpFieldNotWritable { fields, .. } = &err {
+            assert_eq!(*fields, vec![IdpUserAttribute::Email]);
+        }
+    })
+    .await;
+}
+
+/// A clear (`Some(None)`) is sent to KC as the empty string — `null` is
+/// indistinguishable from "absent" to KC and would silently no-op — while
+/// untouched fields stay out of the body entirely so KC leaves them alone.
+#[tokio::test]
+async fn update_user_clear_sends_empty_string_and_omits_untouched_fields() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+        let tenant_uuid = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+        mount_user_get(
+            &server,
+            user_uuid,
+            tenant_uuid,
+            serde_json::json!({ "username": "alice" }),
+        )
+        .await;
+        Mock::given(method("PUT"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let mut patch = IdpUserPatch::new();
+        patch.email = Some(None);
+        let req = update_user_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+            patch,
+        );
+        facade
+            .update_user_inner(&ctx, &req)
+            .await
+            .expect("update_user ok");
+
+        let received = server.received_requests().await.unwrap();
+        let put = received
+            .iter()
+            .find(|r| r.method.as_str() == "PUT")
+            .expect("PUT /users/{id} must be sent");
+        let body: serde_json::Value = serde_json::from_slice(&put.body).expect("PUT body is JSON");
+        assert_eq!(
+            body.get("email"),
+            Some(&serde_json::Value::String(String::new())),
+            "a clear MUST be an empty string, not null: {body}"
+        );
+        assert!(
+            body.get("firstName").is_none() && body.get("lastName").is_none(),
+            "untouched fields MUST be absent so KC leaves them unchanged: {body}"
+        );
+    })
+    .await;
+}
+
+/// A password-only patch has no user-profile fields, so the profile PUT
+/// is skipped entirely and only the credential endpoint is called.
+#[tokio::test]
+async fn update_user_password_only_skips_profile_put() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+        let tenant_uuid = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+        mount_user_get(
+            &server,
+            user_uuid,
+            tenant_uuid,
+            serde_json::json!({ "username": "alice" }),
+        )
+        .await;
+        Mock::given(method("PUT"))
+            .and(path(format!(
+                "/admin/realms/platform/users/{user_uuid}/reset-password"
+            )))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let patch = IdpUserPatch::new().with_password("s3cret-value", true);
+        let req = update_user_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+            patch,
+        );
+        facade
+            .update_user_inner(&ctx, &req)
+            .await
+            .expect("update_user ok");
+
+        let received = server.received_requests().await.unwrap();
+        let profile_puts = received
+            .iter()
+            .filter(|r| {
+                r.method.as_str() == "PUT"
+                    && r.url.path() == format!("/admin/realms/platform/users/{user_uuid}")
+            })
+            .count();
+        assert_eq!(
+            profile_puts, 0,
+            "a password-only patch must not issue a profile PUT"
+        );
+        let reset = received
+            .iter()
+            .find(|r| r.url.path().ends_with("/reset-password"))
+            .expect("reset-password must be called");
+        let body: serde_json::Value = serde_json::from_slice(&reset.body).expect("body is JSON");
+        assert_eq!(body.get("temporary"), Some(&serde_json::Value::Bool(true)));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn update_user_absent_user_is_not_found() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+        let tenant_uuid = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+        // Binding read 404s → no usable binding → absent.
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let mut patch = IdpUserPatch::new();
+        patch.email = Some(Some("ghost@example.com".to_owned()));
+        let req = update_user_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+            patch,
+        );
+
+        let err = facade
+            .update_user_inner(&ctx, &req)
+            .await
+            .expect_err("absent user must fail");
+        assert!(
+            matches!(err, PluginError::UserOpNotFound { .. }),
+            "expected UserOpNotFound, got {err:?}"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn update_user_rename_collision_is_duplicate() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+        let tenant_uuid = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+        mount_user_get(
+            &server,
+            user_uuid,
+            tenant_uuid,
+            serde_json::json!({ "username": "bob" }),
+        )
+        .await;
+        Mock::given(method("PUT"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(409).set_body_json(serde_json::json!({
+                "errorMessage": "User exists with same username"
+            })))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let patch = IdpUserPatch::new().with_username("alice");
+        let req = update_user_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+            patch,
+        );
+
+        let err = facade
+            .update_user_inner(&ctx, &req)
+            .await
+            .expect_err("collision must fail");
+        assert!(
+            matches!(
+                err,
+                PluginError::UserOpDuplicate {
+                    field: account_management_sdk::IdpUserDuplicateField::Username,
+                    ..
+                }
+            ),
+            "expected UserOpDuplicate(username), got {err:?}"
+        );
+    })
+    .await;
+}
+
+#[test]
+fn kc_read_only_classifier_prefers_the_named_field() {
+    // Per-field shape wins even when several attributes were touched.
+    assert_eq!(
+        classify_kc_read_only_reject(
+            r#"{"errors":[{"field":"lastName","errorMessage":"error-user-attribute-read-only"}]}"#,
+            &[IdpUserAttribute::Email, IdpUserAttribute::LastName],
+        ),
+        vec![IdpUserAttribute::LastName]
+    );
+}
+
+/// `errors[]` can carry one entry per locked attribute; every named field
+/// MUST be collected, not just the first, so a multi-field patch is refused
+/// with the whole locked set in one failure.
+#[test]
+fn kc_read_only_classifier_collects_every_named_field() {
+    assert_eq!(
+        classify_kc_read_only_reject(
+            r#"{"errors":[
+                {"field":"username","errorMessage":"error-user-attribute-read-only"},
+                {"field":"email","errorMessage":"error-user-attribute-read-only"}
+            ]}"#,
+            &[IdpUserAttribute::Username, IdpUserAttribute::Email],
+        ),
+        vec![IdpUserAttribute::Username, IdpUserAttribute::Email]
+    );
+}
+
+#[test]
+fn kc_read_only_classifier_infers_only_when_unambiguous() {
+    // Read-only KEY with no `field` named + exactly one touched attribute →
+    // the refusal can only be about that one, so it is attributed.
+    assert_eq!(
+        classify_kc_read_only_reject(
+            r#"{"errorMessage":"error-user-attribute-read-only"}"#,
+            &[IdpUserAttribute::Email],
+        ),
+        vec![IdpUserAttribute::Email]
+    );
+    // Same body but several touched → not attributable; the caller falls back
+    // to the generic rejection lane rather than blaming an arbitrary field.
+    assert_eq!(
+        classify_kc_read_only_reject(
+            r#"{"errorMessage":"error-user-attribute-read-only"}"#,
+            &[IdpUserAttribute::Email, IdpUserAttribute::FirstName],
+        ),
+        Vec::new()
+    );
+}
+
+/// The pre-24 `ReadOnlyAttributesUnsupportedException` prose is deliberately
+/// NOT recognised: this plugin targets KC 26, where every read-only refusal
+/// carries a message key, so a phrase test could only add false positives on
+/// unrelated 400s whose text happens to contain "read only".
+///
+/// Pinned so a future "be more lenient" change has to argue with this test
+/// rather than quietly reintroduce substring matching.
+#[test]
+fn kc_read_only_classifier_does_not_match_prose() {
+    for body in [
+        r#"{"errorMessage":"Update of read-only attribute rejected"}"#,
+        r#"{"errorMessage":"attribute is read only"}"#,
+        r#"{"errorMessage":"this field is readonly"}"#,
+        // The dangerous shape: an unrelated failure that merely mentions the
+        // phrase must never be reported as a locked field.
+        r#"{"errorMessage":"cannot link read-only federated store"}"#,
+    ] {
+        assert_eq!(
+            classify_kc_read_only_reject(body, &[IdpUserAttribute::Email]),
+            Vec::new(),
+            "prose must not classify as a read-only reject: {body}"
+        );
+    }
+}
+
+#[test]
+fn kc_read_only_classifier_ignores_other_400s() {
+    assert_eq!(
+        classify_kc_read_only_reject(
+            r#"{"errorMessage":"invalid email format"}"#,
+            &[IdpUserAttribute::Email],
+        ),
+        Vec::new()
+    );
+    assert_eq!(
+        classify_kc_read_only_reject("not json", &[IdpUserAttribute::Email]),
+        Vec::new()
+    );
+}
+
+/// Pre-flight refuses a non-writable attribute from the structured
+/// `userProfileMetadata.attributes[].readOnly` flags, WITHOUT attempting the
+/// write. This is the primary mechanism; parsing a rejection is the fallback.
+///
+/// Refusing before the PUT also means a multi-field patch containing one locked
+/// field cannot land half-applied.
+#[tokio::test]
+async fn update_user_preflight_refuses_read_only_attribute_without_writing() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+        let tenant_uuid = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+        // Shape verified against KC 26.5.3: `readOnly` is a real boolean, and
+        // it already reflects the `editUsernameAllowed` realm flag.
+        mount_user_get(
+            &server,
+            user_uuid,
+            tenant_uuid,
+            serde_json::json!({
+                "username": "alice",
+                "userProfileMetadata": {
+                    "attributes": [
+                        {"name": "username", "readOnly": true, "required": true},
+                        {"name": "email", "readOnly": true, "required": false},
+                        {"name": "firstName", "readOnly": false, "required": false},
+                        {"name": "lastName", "readOnly": false, "required": false},
+                    ]
+                },
+            }),
+        )
+        .await;
+        Mock::given(method("PUT"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        // `email` is locked, `first_name` is not — the patch as a whole must be
+        // refused and attributed to `email`.
+        let mut patch = IdpUserPatch::new();
+        patch.email = Some(Some("new@example.com".to_owned()));
+        patch.first_name = Some(Some("Alice".to_owned()));
+        let req = update_user_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+            patch,
+        );
+
+        let err = facade
+            .update_user_inner(&ctx, &req)
+            .await
+            .expect_err("locked attribute must be refused");
+        assert!(
+            matches!(err, PluginError::UserOpFieldNotWritable { .. }),
+            "expected FieldNotWritable(email) from profile metadata, got {err:?}"
+        );
+        if let PluginError::UserOpFieldNotWritable { fields, .. } = &err {
+            assert_eq!(*fields, vec![IdpUserAttribute::Email]);
+        }
+        let received = server.received_requests().await.unwrap();
+        assert!(
+            !received.iter().any(|r| r.method.as_str() == "PUT"),
+            "pre-flight must refuse before any write, so a partially-applicable \
+             patch cannot land half-applied"
+        );
+    })
+    .await;
+}
+
+/// A writable attribute still goes through when metadata is present — proves
+/// the pre-flight gate is keyed on the intersection with the patch, not on
+/// "metadata present ⇒ refuse".
+#[tokio::test]
+async fn update_user_preflight_allows_writable_attribute() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+        let tenant_uuid = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+        mount_user_get(
+            &server,
+            user_uuid,
+            tenant_uuid,
+            serde_json::json!({
+                "username": "alice",
+                "firstName": "Alice",
+                "userProfileMetadata": {
+                    "attributes": [
+                        {"name": "username", "readOnly": true},
+                        {"name": "firstName", "readOnly": false},
+                    ]
+                },
+            }),
+        )
+        .await;
+        Mock::given(method("PUT"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        let mut patch = IdpUserPatch::new();
+        patch.first_name = Some(Some("Alice".to_owned()));
+        let req = update_user_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+            patch,
+        );
+
+        let user = facade
+            .update_user_inner(&ctx, &req)
+            .await
+            .expect("writable attribute must be allowed through");
+        assert_eq!(user.first_name.as_deref(), Some("Alice"));
+    })
+    .await;
+}
+
+/// The actual payoff of the `fields: Vec<_>` widening: a patch touching TWO
+/// locked attributes is refused with BOTH named in one failure, not just the
+/// first one found. A client discovering locked fields one round trip at a
+/// time is exactly what the SDK's `FieldNotWritable` doc comment says this
+/// contract exists to avoid.
+#[tokio::test]
+async fn update_user_preflight_reports_every_locked_touched_attribute() {
+    let server = MockServer::start().await;
+    temp_env::async_with_vars([("TEST_REALM_ADMIN_SECRET", Some("ra"))], async move {
+        mount_token_endpoint(&server, "platform").await;
+        let tenant_uuid = Uuid::new_v4();
+        let user_uuid = Uuid::new_v4();
+        mount_user_get(
+            &server,
+            user_uuid,
+            tenant_uuid,
+            serde_json::json!({
+                "username": "alice",
+                "userProfileMetadata": {
+                    "attributes": [
+                        {"name": "username", "readOnly": true},
+                        {"name": "email", "readOnly": true},
+                        {"name": "firstName", "readOnly": false},
+                    ]
+                },
+            }),
+        )
+        .await;
+        Mock::given(method("PUT"))
+            .and(path(format!("/admin/realms/platform/users/{user_uuid}")))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let facade = build_facade(&server);
+        let ctx = build_system_ctx(Uuid::nil());
+        // Touches both locked attributes plus one writable one, so a
+        // single-attribute-at-a-time implementation would report only
+        // whichever it happened to check first.
+        let mut patch = IdpUserPatch::new();
+        patch.username = Some("bob".to_owned());
+        patch.email = Some(Some("new@example.com".to_owned()));
+        patch.first_name = Some(Some("Alice".to_owned()));
+        let req = update_user_req(
+            tenant_uuid,
+            Some(make_metadata(
+                "platform",
+                RealmBinding::Shared,
+                Uuid::new_v4(),
+                None,
+            )),
+            user_uuid,
+            patch,
+        );
+
+        let err = facade
+            .update_user_inner(&ctx, &req)
+            .await
+            .expect_err("both locked attributes must be refused");
+        assert!(
+            matches!(err, PluginError::UserOpFieldNotWritable { .. }),
+            "expected FieldNotWritable(username, email), got {err:?}"
+        );
+        if let PluginError::UserOpFieldNotWritable { fields, .. } = &err {
+            assert_eq!(
+                *fields,
+                vec![IdpUserAttribute::Username, IdpUserAttribute::Email],
+                "both locked attributes the patch touched must be reported together"
+            );
+        }
+        let received = server.received_requests().await.unwrap();
+        assert!(
+            !received.iter().any(|r| r.method.as_str() == "PUT"),
+            "pre-flight must refuse before any write when either locked \
+             attribute is touched"
+        );
+    })
+    .await;
+}
+
+/// Audit evidence contains only stable request-property names, even when the
+/// patch carries profile data and a plaintext password.
+#[test]
+fn update_user_audit_labels_include_names_but_never_values() {
+    let mut patch = IdpUserPatch::new().with_password("secret-value", false);
+    patch.email = Some(Some("sensitive@example.com".into()));
+    patch.first_name = Some(None);
+
+    let labels = UserFacade::changed_labels(&patch);
+    assert_eq!(labels, vec!["email", "first_name", "password"]);
+    assert!(!labels.join(",").contains("sensitive@example.com"));
+    assert!(!labels.join(",").contains("secret-value"));
+}
+
+/// Regression: KC's real refusal body is a FLAT object carrying an
+/// authoritative `field` — not the `{"errors":[…]}` array. Verified against KC
+/// 26.5.3:
+/// `{"field":"username","errorMessage":"error-user-attribute-read-only","params":["username"]}`
+///
+/// The earlier classifier only looked for `errors[]`, so it ignored that
+/// `field` and fell back to inferring from a single touched attribute — which
+/// returned `None` for a multi-field patch and silently downgraded an
+/// attributable refusal to a generic 400. `field` MUST win over inference.
+#[test]
+fn kc_read_only_classifier_reads_the_flat_field_key() {
+    assert_eq!(
+        classify_kc_read_only_reject(
+            r#"{"field":"username","errorMessage":"error-user-attribute-read-only","params":["username"]}"#,
+            // Several attributes touched: inference cannot disambiguate, so
+            // this can only pass by honouring the body's `field`.
+            &[IdpUserAttribute::Username, IdpUserAttribute::Email],
+        ),
+        vec![IdpUserAttribute::Username]
+    );
+}
+
+/// The message is a stable KEY, not localized prose — KC 26.5.3 returns the
+/// same body under `Accept-Language: de`. Exact-key matching is therefore a
+/// contract, and must not depend on the substring fallback.
+#[test]
+fn kc_read_only_classifier_matches_the_exact_message_key() {
+    // Exact key, no read-only substring reachable by prose matching on a
+    // different casing/spelling: still classified.
+    assert_eq!(
+        classify_kc_read_only_reject(
+            r#"{"field":"email","errorMessage":"error-user-attribute-read-only"}"#,
+            &[IdpUserAttribute::Email],
+        ),
+        vec![IdpUserAttribute::Email]
+    );
+    // A validation error that is NOT about writability must not be swept in,
+    // even though it names a field.
+    assert_eq!(
+        classify_kc_read_only_reject(
+            r#"{"field":"email","errorMessage":"error-invalid-email"}"#,
+            &[IdpUserAttribute::Email],
+        ),
+        Vec::new()
+    );
 }

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/idp_impl.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/idp_impl.rs
@@ -24,8 +24,8 @@ use account_management_sdk::idp_service_account::{
     IdpServiceAccountCredentials, IdpServiceAccountFailure, IdpServiceAccountSummary,
 };
 use account_management_sdk::idp_user::{
-    IdpDeprovisionUserRequest, IdpListUsersRequest, IdpProvisionUserRequest, IdpUser,
-    IdpUserOperationFailure,
+    IdpDeprovisionUserRequest, IdpListUsersRequest, IdpProvisionUserRequest, IdpUpdateUserRequest,
+    IdpUser, IdpUserOperationFailure,
 };
 use async_trait::async_trait;
 use toolkit_odata::Page;
@@ -93,6 +93,17 @@ impl IdpPluginClient for KeycloakIdpPlugin {
     ) -> Result<(), IdpUserOperationFailure> {
         self.user_facade
             .deprovision_user_inner(ctx, req)
+            .await
+            .map_err(translate_user_op_failure)
+    }
+
+    async fn update_user(
+        &self,
+        ctx: &SecurityContext,
+        req: &IdpUpdateUserRequest,
+    ) -> Result<IdpUser, IdpUserOperationFailure> {
+        self.user_facade
+            .update_user_inner(ctx, req)
             .await
             .map_err(translate_user_op_failure)
     }
@@ -356,6 +367,15 @@ fn translate_user_op_failure(e: PluginError) -> IdpUserOperationFailure {
         }
         PluginError::UserOpUnsupported { detail } => {
             IdpUserOperationFailure::UnsupportedOperation { detail }
+        }
+        // Absent users and users bound to another tenant are deliberately
+        // indistinguishable so the update endpoint cannot become a
+        // cross-tenant existence oracle.
+        PluginError::UserOpNotFound { detail } => IdpUserOperationFailure::NotFound { detail },
+        // Provider-managed attributes become structured AM field violations,
+        // allowing callers to disable every locked input from one response.
+        PluginError::UserOpFieldNotWritable { fields, detail } => {
+            IdpUserOperationFailure::FieldNotWritable { fields, detail }
         }
         PluginError::KcRest { .. } => IdpUserOperationFailure::Unavailable {
             detail: e.to_string(),

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/src/idp_impl_tests.rs
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/src/idp_impl_tests.rs
@@ -328,6 +328,33 @@ fn translate_user_op_unsupported_is_unsupported() {
 }
 
 #[test]
+fn translate_user_op_not_found_is_not_found() {
+    let e = PluginError::UserOpNotFound {
+        detail: "user absent from tenant scope".into(),
+    };
+    let f = translate_user_op_failure(e);
+    assert!(matches!(f, IdpUserOperationFailure::NotFound { .. }));
+    assert_eq!(f.detail(), "user absent from tenant scope");
+}
+
+#[test]
+fn translate_user_op_field_not_writable_preserves_all_fields() {
+    let expected = vec![
+        account_management_sdk::IdpUserAttribute::Email,
+        account_management_sdk::IdpUserAttribute::FirstName,
+    ];
+    let e = PluginError::UserOpFieldNotWritable {
+        fields: expected.clone(),
+        detail: "provider-managed profile".into(),
+    };
+    let f = translate_user_op_failure(e);
+    assert!(matches!(
+        f,
+        IdpUserOperationFailure::FieldNotWritable { ref fields, .. } if fields == &expected
+    ));
+}
+
+#[test]
 fn translate_user_op_leaked_kc_rest_is_unavailable() {
     // Defensive: if a `KcRest` ever leaks past the user-side translator
     // in the facade, the boundary still maps it to Unavailable so AM


### PR DESCRIPTION
## Description

Implements `IdpPluginClient::update_user` in the Keycloak IdP plugin, replacing the SDK default `UnsupportedOperation` response.

The implementation:

- verifies the user's stored `tenant_id` before any write and returns indistinguishable `NotFound` outcomes for absent and foreign users;
- applies JSON Merge Patch set/clear/omit semantics to `username`, `email`, `first_name`, and `last_name`;
- updates passwords through Keycloak's dedicated credential endpoint;
- rejects derived `display_name` and Keycloak-managed profile fields as `FieldNotWritable`;
- classifies duplicate, password-policy, terminal validation, and provider failures through the existing SDK taxonomy;
- re-reads the user after mutation so the result reflects provider normalization;
- emits `user.updated` audit evidence containing changed field names only and adds stable update metrics labels.

The plugin PRD and DESIGN now promote user update from deferred p2 behavior and document the provider mapping, tenant guard, and multi-call profile/password semantics.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] `make gear-ci GEAR=keycloak-idp-plugin` — 376 tests passed
- [x] `make dylint`
- [x] `make cfs-validate` — 0 errors, code coverage 153/153
- [x] New tests added for update lifecycle, tenant isolation, merge-patch clearing, password-only updates, duplicate/read-only outcomes, audit minimization, metric labels, and SDK-boundary translation
- [ ] Manual testing against a deployed Keycloak completed

`make check` reaches workspace-wide Clippy and currently fails in the unchanged `libs/rustls-corecrypto-provider/tests/handshake_smoke.rs:96` on `clippy::collapsible_if`. The scoped plugin Clippy gate passes through `make gear-ci`.

## Documentation

- [x] Plugin PRD updated
- [x] Plugin DESIGN updated
- [x] Public API documentation unchanged because the AM SDK and REST contract already define `update_user`

## Security

- Cross-tenant user IDs produce the same `NotFound` result as absent users and issue no mutation.
- Password and profile values are excluded from audit evidence.
- Provider error bodies remain redacted and truncated through the existing plugin boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating user profiles using partial updates.
  * Added password reset support during user updates.
  * Added validation for tenant boundaries and provider-managed, read-only fields.
  * Added clear failure responses for missing users and non-writable fields.
  * Added audit events that record updated field names without exposing values.
  * Improved user profile data handling for names and display names.

* **Documentation**
  * Updated product and technical documentation to reflect user update support, security controls, failure behavior, and operational requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->