### PR TITLE
docs(toolkit): correct stale OoP and runtime docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ release-plz updates this file in the Release PR.
 
 ## [Unreleased]
 
+### Fixed
+
+- Documented that OoP HTTP bootstrap `oop_http.allow_loopback_advertise` **defaults to `false`**. A loopback
+  or unspecified `advertise_uri` (`127.0.0.1`, `::1`, `localhost`, `0.0.0.0`, `[::]`) — including the value
+  derived from an unspecified `listen_addr` when `advertise_uri` is unset — refuses to boot. Set a routable
+  `advertise_uri`, or `oop_http.allow_loopback_advertise: true` for single-host / local-dev. (#4581)
+
 ## [0.10.19](https://github.com/constructorfabric/gears-rust/compare/cf-gears-mini-chat-sdk-v0.10.18...cf-gears-mini-chat-sdk-v0.10.19) - 2026-08-24
 
 ### Other

--- a/docs/arch/toolkit-oop/ADR/0009-cpt-cf-adr-instance-addressable-discovery.md
+++ b/docs/arch/toolkit-oop/ADR/0009-cpt-cf-adr-instance-addressable-discovery.md
@@ -215,11 +215,11 @@ resolution is service-name-scoped"):
   service-name analogue of the role-qualified gear names in §1. A bare, shared service name is intentionally
   reachable across every advertising role.
 * **The edge exposes public routes of the resolved name.** The `api-gateway` reverse-proxy edge already keys its
-  route table on gear name; it exposes only the **public** routes (via the `.exposed()` / `x-toolkit-visibility`
-  visibility split the edge introduces - a prerequisite not yet in the tree, see Consequences) of the
-  names it syncs from the directory. An internal role never enters the edge's public route table because its
-  **name** is internal - a role-split gear simply does not register its internal role-names as edge-eligible, or
-  exposes no public routes on them. No `entrypoint` predicate is needed at the edge.
+  route table on gear name; it exposes only the **public** routes (via the `.exposed()` /
+  `x-toolkit-visibility` visibility split) of the names it syncs from the directory. An internal role never
+  enters the edge's public route table because its **name** is internal - a role-split gear simply does not
+  register its internal role-names as edge-eligible, or exposes no public routes on them. No `entrypoint`
+  predicate is needed at the edge.
 * **One public contract per directory name (constraint):** instances registered under **one** directory name
   MUST expose the **same logical public API** - a directory name *is* one logical service. This does **not**
   forbid **transient version skew** during a rolling deploy of the *same* contract: while v1 and v2 pods coexist
@@ -451,13 +451,13 @@ convergence-latency optimization, not a correctness prerequisite. Until it lands
   endpoint (i.e. not a shared VIP); the *mechanism* - `StatefulSet` + headless Service, a self-registering
   `Deployment` advertising its pod IP / per-pod DNS, etc. - is the **gear developer's choice** and is **not**
   mandated here. Front-door role-names may keep a Service VIP.
-* **Ordering dependency on the edge work (these prerequisites do not exist today).** Layer 1's edge story and
-  the enumeration decision below depend on directory/edge changes that are **not yet in the tree** and are **not
-  specified by the current edge ADRs** (ADR-0003 defines only the `GatewayProvider` trait; ADR-0007 defines the
-  edge auth *modes*) - they are a separate, not-yet-written directory/edge work item: `directory.proto` has
-  **no `ListAllInstances` RPC**, `openapi_spec` lives on `RegisterInstanceRequest` only (not on `InstanceInfo`),
-  and there is **no `.exposed()` / `x-toolkit-visibility`** visibility split. Layer 1 therefore **must merge after
-  (or reconcile with) that edge implementation**; it is **not** available today and must not be read as such.
+* **Edge / directory ordering dependency (discharged).** Layer 1's edge story and the enumeration decision
+  below depended on directory/edge machinery that has since landed: `directory.proto` has `ListAllInstances`,
+  `InstanceInfo` carries `openapi_spec` (field 6), and the `.exposed()` / `x-toolkit-visibility` visibility
+  split is emitted by `OperationBuilder` and consumed by `toolkit-gateway`. ADR-0003 still defines only the
+  `GatewayProvider` trait and ADR-0007 the edge auth *modes*; the concrete crates (`toolkit-gateway`,
+  `api-gateway` directory-sync) exist in-tree even though those two ADRs have not been amended to specify
+  them. Layer 1 merged on top of that edge (#4540); the ordering dependency is satisfied.
 * **Requires amendments to sibling ADRs / PRD / DESIGN** (not just cross-references), because it changes shapes
   they assert - **ADR-0001**, **PRD `cpt-cf-fr-k8s-native`**, **DESIGN.md (§3 Profile 3)**, and **ADR-0004**
   (Helm); enumerated under
@@ -602,19 +602,17 @@ defines the `GatewayProvider` trait and [`cpt-cf-adr-edge-architecture`](0007-cp
 this ADR's edge story depends on: the `libs/toolkit-gateway` crate (`GatewayProvider`, `ProxyRegistry`,
 `ToolKitGatewayProvider`), the `api-gateway` embedded reverse-proxy with its directory-sync loop (poll ->
 reconcile -> register/prune), the `ListAllInstances` RPC and `InstanceInfo.openapi_spec` field, and the
-`.exposed()` / `x-toolkit-visibility` edge-visibility split. Those pieces are a **separate directory/edge work
-item, an ordering dependency not in the tree today** (enumerated in Consequences); if they are ultimately
-specified by amending ADR-0003 / ADR-0007 rather than a new ADR, those two move from *references* to
-*amendments*. This ADR is **additive on top of that edge** (`labels` ride on the `InstanceInfo` the edge
-extends; role exclusion is structural), so Layer 1 must merge **after** / reconcile with that edge
-implementation. Labels ride on `InstanceInfo` for the per-name paths (`list_instances` /
+`.exposed()` / `x-toolkit-visibility` edge-visibility split. Those pieces have **landed in-tree** (see
+Consequences); if they are ultimately specified by amending ADR-0003 / ADR-0007 rather than a new ADR, those
+two move from *references* to *amendments*. This ADR is **additive on top of that edge** (`labels` ride on
+the `InstanceInfo` the edge extends; role exclusion is structural); Layer 1 merged after that edge
+implementation (#4540). Labels ride on `InstanceInfo` for the per-name paths (`list_instances` /
 `resolve_by_labels`); the `ListAllInstances` edge snapshot deliberately omits them (it routes by name - see
 Implementation notes), so its mapper is **not** extended to carry `labels`.
 
 ### Implementation notes
 
-For the implementing change (reconcile against the edge's directory rework - the separate edge/directory work
-item above, not the current ADR-0007):
+For the implementing change (reconcile against the landed edge directory rework - not the current ADR-0007):
 
 * **gRPC resolution is service-name-scoped, not gear-scoped.** `resolve_grpc_service` round-robins over every
   instance advertising a gRPC service *across all gears*, whereas `resolve_rest_service` is per-gear. Because

--- a/docs/arch/toolkit-oop/DESIGN.md
+++ b/docs/arch/toolkit-oop/DESIGN.md
@@ -320,6 +320,15 @@ What is **missing** and needs to be added:
     - **Probes MAY be exposed on a separate bind address** via `probe_bind_addr` config (default: same as main
       HTTP server). Operators typically route `/healthz`, `/readyz`, `/health`, `/metrics` to a sidecar port that is NOT
       mapped through the k8s Service so external traffic cannot reach them.
+    - **`advertise_uri` is fail-fast on loopback.** `oop_http.advertise_uri` is the REST endpoint registered with
+      DirectoryService. When unset, the bootstrap derives it from `listen_addr` and rewrites an unspecified host
+      (`0.0.0.0` / `[::]`) to loopback. `oop_http.allow_loopback_advertise` **defaults to `false`**: a loopback or
+      unspecified advertise host (`127.0.0.1`, `::1`, `localhost`, `0.0.0.0`, `[::]`) refuses to boot, so a gear
+      that previously started with no explicit `advertise_uri` on a `0.0.0.0` bind now fails. Production and
+      multi-host Profile 2 / Profile 3 must set a routable `advertise_uri` (prefer a stable DNS name). Single-host
+      / local-dev must set `oop_http.allow_loopback_advertise: true` (or a routable `advertise_uri`). Profile 1
+      (in-process) and single-node Profile 2 over UDS never reach this check. There are no checked-in `oop_http`
+      configs in this repo; Helm values and local scripts that start an OoP gear on loopback need the opt-out.
 - **Custom readiness checks**: readiness reuses the framework's standard healthcheck mechanism, so a gear expresses
   readiness once and it is honored identically whether the gear is hosted in-process by `api-gateway` or run OoP. A
   gear returns **one composite healthcheck** from its REST capability:

--- a/libs/toolkit/src/contracts.rs
+++ b/libs/toolkit/src/contracts.rs
@@ -132,7 +132,7 @@ pub trait ApiGatewayCapability: Send + Sync + 'static {
 /// 1. **Graceful stop request**: When `stop(deadline_token)` is called, the `deadline_token`
 ///    is *not* cancelled. This is the signal to begin graceful shutdown.
 ///
-/// 2. **Hard-stop deadline**: After the runtime's `shutdown_deadline` expires (default 30s),
+/// 2. **Hard-stop deadline**: After the runtime's `shutdown_deadline` expires (default 35s),
 ///    the `deadline_token` is cancelled. This signals that graceful shutdown time is over
 ///    and the gear should abort immediately.
 ///

--- a/libs/toolkit/src/lifecycle.rs
+++ b/libs/toolkit/src/lifecycle.rs
@@ -541,13 +541,15 @@ impl<T: Runnable> WithLifecycle<T> {
     /// # Relationship with `HostRuntime::shutdown_deadline`
     ///
     /// When running under `HostRuntime`, this `stop_timeout` races against the
-    /// runtime's `shutdown_deadline` (both default to 30s). To ensure deterministic behavior:
+    /// runtime's `shutdown_deadline` (`stop_timeout` defaults to 30s,
+    /// `shutdown_deadline` to 35s / [`DEFAULT_SHUTDOWN_DEADLINE`](crate::runtime::DEFAULT_SHUTDOWN_DEADLINE)). To ensure
+    /// deterministic behavior:
     ///
     /// - `stop_timeout` should be **less than** `shutdown_deadline`
     /// - This allows the lifecycle's internal timeout to trigger first for graceful cleanup
     /// - The runtime's `deadline_token` then acts as a hard backstop
     ///
-    /// Example: `stop_timeout = 25s`, `shutdown_deadline = 30s`
+    /// Example: `stop_timeout = 30s`, `shutdown_deadline = 35s`
     pub fn with_stop_timeout(mut self, d: Duration) -> Self {
         self.stop_timeout = d;
         self

--- a/libs/toolkit/src/runtime/host_runtime.rs
+++ b/libs/toolkit/src/runtime/host_runtime.rs
@@ -185,13 +185,14 @@ impl HostRuntime {
     /// # Relationship with `WithLifecycle::stop_timeout`
     ///
     /// When using `WithLifecycle`, its `stop_timeout` (default 30s) races against this
-    /// `shutdown_deadline` (also default 30s). To ensure deterministic behavior:
+    /// `shutdown_deadline` (default [`DEFAULT_SHUTDOWN_DEADLINE`], 35s). To ensure
+    /// deterministic behavior:
     ///
     /// - `WithLifecycle::stop_timeout` should be **less than** `shutdown_deadline`
     /// - This allows the lifecycle's internal timeout to trigger first for graceful cleanup
     /// - The runtime's `deadline_token` then acts as a hard backstop
     ///
-    /// Example: `stop_timeout = 25s`, `shutdown_deadline = 30s`
+    /// Example: `stop_timeout = 30s`, `shutdown_deadline = 35s`
     #[must_use]
     pub fn with_shutdown_deadline(mut self, deadline: std::time::Duration) -> Self {
         self.shutdown_deadline = deadline;

--- a/libs/toolkit/src/runtime/runner.rs
+++ b/libs/toolkit/src/runtime/runner.rs
@@ -130,7 +130,7 @@ pub struct RunOptions {
     pub oop: Option<OopSpawnOptions>,
     /// Maximum time allowed for each gear's graceful shutdown before hard-stop.
     ///
-    /// If `None`, uses `DEFAULT_SHUTDOWN_DEADLINE` (30 seconds).
+    /// If `None`, uses [`DEFAULT_SHUTDOWN_DEADLINE`](crate::runtime::DEFAULT_SHUTDOWN_DEADLINE) (35 seconds).
     ///
     /// See `HostRuntime::with_shutdown_deadline` for details on the relationship
     /// with `WithLifecycle::stop_timeout`.


### PR DESCRIPTION
Gear authors were reading the wrong shutdown_deadline (30s vs the shipped 35s default), a discharged ADR-0009 edge/directory ordering dependency, and no operator-facing note that allow_loopback_advertise defaults to false.

Closes #4479
Closes #4579
Closes #4581