### PR TITLE
fix(api-gateway): seconds-scale bucket boundaries for http.server.req…

### DIFF
--- a/gears/system/api-gateway/src/middleware/http_metrics.rs
+++ b/gears/system/api-gateway/src/middleware/http_metrics.rs
@@ -21,6 +21,16 @@ use opentelemetry::{
     metrics::{Histogram, UpDownCounter},
 };
 
+/// [OTel semconv recommended boundaries][semconv] (seconds) for
+/// `http.server.request.duration`. Set explicitly because the SDK defaults
+/// are millisecond-scale and collapse seconds-valued observations into a
+/// single bucket, making percentiles meaningless.
+///
+/// [semconv]: https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration
+const DURATION_BOUNDARIES_SECS: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+];
+
 /// Holds the two OpenTelemetry instruments for HTTP server metrics.
 pub struct HttpMetrics {
     duration: Histogram<f64>,
@@ -56,6 +66,7 @@ impl HttpMetrics {
             .f64_histogram(duration_name)
             .with_description("Duration of HTTP server requests")
             .with_unit("s")
+            .with_boundaries(DURATION_BOUNDARIES_SECS.to_vec())
             .build();
 
         let active_requests = meter

--- a/gears/system/api-gateway/tests/http_metrics_tests.rs
+++ b/gears/system/api-gateway/tests/http_metrics_tests.rs
@@ -124,6 +124,24 @@ fn histogram_has_attributes(
     false
 }
 
+/// Extract the explicit bucket boundaries of the named histogram, if exported.
+fn histogram_bounds(exporter: &InMemoryMetricExporter, name: &str) -> Option<Vec<f64>> {
+    let metrics = exporter.get_finished_metrics().unwrap();
+    for resource_metrics in &metrics {
+        for scope_metrics in resource_metrics.scope_metrics() {
+            for metric in scope_metrics.metrics() {
+                if metric.name() == name
+                    && let AggregatedMetrics::F64(MetricData::Histogram(hist)) = metric.data()
+                    && let Some(dp) = hist.data_points().next()
+                {
+                    return Some(dp.bounds().collect());
+                }
+            }
+        }
+    }
+    None
+}
+
 async fn ok_handler() -> impl IntoResponse {
     StatusCode::OK
 }
@@ -437,6 +455,53 @@ async fn metrics_unmatched_route() -> Result<()> {
             ]
         ),
         "unmatched route should have http.route='unmatched' and status 404"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn metrics_duration_uses_second_scale_bucket_boundaries() -> Result<()> {
+    let _lock = METER_LOCK.lock().await;
+    let (provider, exporter) = install_test_meter_provider();
+    let ctx = create_api_gateway_ctx(base_config());
+    let api = api_gateway::ApiGateway::default();
+    api.init(&ctx).await?;
+
+    let router = OperationBuilder::get("/tests/v1/items")
+        .operation_id("test:list-items")
+        .summary("List items")
+        .anonymous()
+        .json_response(StatusCode::OK, "OK")
+        .handler(axum::routing::get(ok_handler))
+        .register(Router::new(), &api);
+    let app = api.rest_finalize(
+        &ctx,
+        router,
+        Arc::new(toolkit::RestHealthcheckRegistry::new()),
+    )?;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/tests/v1/items")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    provider.force_flush().unwrap();
+
+    let bounds = histogram_bounds(&exporter, "http.server.request.duration")
+        .expect("duration histogram should be exported with at least one data point");
+    assert_eq!(
+        bounds,
+        vec![
+            0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0
+        ],
+        "http.server.request.duration must use semconv seconds-scale bucket \
+         boundaries, not the SDK's millisecond-scale defaults"
     );
 
     Ok(())


### PR DESCRIPTION
…uest.duration

The duration histogram records seconds (semconv unit "s") but never set explicit boundaries, so the OTel SDK applies its legacy default set (5, 10, 25, ... 10000) — numbers designed for millisecond values. With seconds-valued observations the first finite boundary le="5" means five SECONDS, so any server responding well below that lands entirely in a single bucket: the histogram then carries no information about the sub-second range where such a server actually operates, and histogram_quantile() degenerates into linear interpolation inside that bucket (p95 pins to a constant 4.75 = 0.95 x 5, whatever the real latency is).

Set the OTel semconv recommended boundaries for
http.server.request.duration, matching the recorded unit. The client-side layer (toolkit-http MetricsLayer) already sets explicit seconds-scale boundaries for the same reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request-duration metrics by using standardized, seconds-based histogram boundaries for more accurate monitoring and analysis.

* **Tests**
  * Added coverage to verify that exported request-duration metrics use the expected boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->