### PR TITLE
feat(grpc): platform-plane gRPC mTLS (framework)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,6 +2459,8 @@ dependencies = [
  "http",
  "inventory",
  "parking_lot",
+ "rcgen",
+ "rustls",
  "secrecy",
  "serde",
  "serde_json",
@@ -3694,11 +3696,14 @@ name = "cf-gears-toolkit-transport-grpc"
 version = "0.7.4"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "cf-gears-toolkit-security",
  "futures-util",
  "http",
  "parking_lot",
  "rand 0.10.1",
+ "rcgen",
+ "rustls-pki-types",
  "secrecy",
  "serde",
  "serde_json",
@@ -3710,6 +3715,7 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
+ "x509-parser 0.18.1",
 ]
 
 [[package]]
@@ -11520,6 +11526,7 @@ dependencies = [
  "socket2",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -511,6 +511,9 @@ rustls-native-certs = "0.8"
 rustls-pki-types = "1"
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
 rcgen = { version = "0.14", default-features = false, features = ["aws_lc_rs", "pem"] }
+# X.509 parsing for extracting the SPIFFE URI SAN from a verified client cert.
+# Pinned to 0.18 (already present transitively) to avoid a third lockfile version.
+x509-parser = "0.18"
 http-body-util = "0.1"
 http-body = "1"
 

--- a/gears/system/grpc-hub/Cargo.toml
+++ b/gears/system/grpc-hub/Cargo.toml
@@ -42,13 +42,22 @@ serde_json = { workspace = true }
 serde = { workspace = true }
 parking_lot = { workspace = true }
 http = { workspace = true }
+# Exposes the mTLS private key only at the ServerTlsConfig build site.
+secrecy = { workspace = true }
+# Assert the process crypto provider is installed before building the acceptor
+# (a clean startup error instead of a rustls panic).
+rustls = { workspace = true }
 
-# gRPC server
-tonic = { workspace = true }
+# gRPC server. `tls-aws-lc` adds tonic's rustls server TLS (ServerTlsConfig) on
+# the workspace-standard aws-lc-rs provider so the hub can terminate mTLS. Never
+# pair with a `ring`-backed TLS feature (dual rustls backends panic at runtime;
+# `ring` is FIPS-banned).
+tonic = { workspace = true, features = ["tls-aws-lc"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
 uuid = { workspace = true }
 bytes = { workspace = true }
-secrecy = { workspace = true }
 tonic = { workspace = true, features = ["transport"] }
+# Real X.509 fixtures (CA + server + client leaf) for the mTLS serve tests.
+rcgen = { workspace = true }

--- a/gears/system/grpc-hub/src/gear.rs
+++ b/gears/system/grpc-hub/src/gear.rs
@@ -14,8 +14,8 @@ use toolkit::{
 };
 
 use parking_lot::RwLock;
+use secrecy::ExposeSecret;
 use serde::Deserialize;
-#[cfg(unix)]
 use std::path::PathBuf;
 use std::{
     collections::HashSet,
@@ -25,10 +25,15 @@ use std::{
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tokio_util::sync::CancellationToken;
-use tonic::{service::RoutesBuilder, transport::Server};
+use tonic::{
+    service::RoutesBuilder,
+    transport::{Certificate, Identity, Server, ServerTlsConfig},
+};
 
 use toolkit_security::{DynInternalAuthenticator, InternalAuthConfig};
-use toolkit_transport_grpc::{InternalAuthEnforcement, InternalAuthGrpcLayer};
+use toolkit_transport_grpc::{
+    InternalAuthEnforcement, InternalAuthGrpcLayer, TlsGeneration, TlsPaths,
+};
 
 #[cfg(windows)]
 use toolkit_transport_grpc::create_named_pipe_incoming;
@@ -105,6 +110,15 @@ pub struct GrpcHubConfig {
     /// re-validates). Bounded at boot by [`MAX_INTERNAL_AUTH_CACHE_TTL_SECS`] to
     /// keep the token-revocation window tight.
     pub internal_auth_cache_ttl_secs: u64,
+
+    /// Server-side mTLS for the **TCP** listener. Omit for plaintext h2c (the
+    /// backward-compatible default; Profile 1 / trusted network). When present
+    /// with `mode = "required"` (the default once the block is set), the TCP
+    /// listener terminates mTLS: it presents `cert`/`key` and verifies every
+    /// client certificate against `ca` (the platform CA). UDS / named-pipe
+    /// listeners are unaffected — their trust root is the OS boundary plus
+    /// filesystem permissions (`cpt-cf-adr-platform-plane-auth`).
+    pub tls: Option<GrpcTlsConfig>,
 }
 
 impl Default for GrpcHubConfig {
@@ -116,6 +130,54 @@ impl Default for GrpcHubConfig {
             internal_auth_enforcement: InternalAuthEnforcement::default(),
             internal_auth_exempt_methods: None,
             internal_auth_cache_ttl_secs: DEFAULT_INTERNAL_AUTH_CACHE_TTL_SECS,
+            tls: None,
+        }
+    }
+}
+
+/// How the TCP listener treats TLS when a [`GrpcTlsConfig`] block is present.
+///
+/// A staging switch: an operator can configure the cert paths and flip `mode`
+/// between `disabled` and `required` without editing paths, mirroring the
+/// staged rollout the platform-plane auth work uses.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GrpcTlsMode {
+    /// Serve plaintext h2c even though cert paths are configured (rollout off
+    /// switch).
+    Disabled,
+    /// Terminate mTLS: present the server certificate and require + verify a
+    /// client certificate against the platform CA.
+    #[default]
+    Required,
+}
+
+/// Server-side mTLS material for the TCP listener, keyed off well-known PEM
+/// paths (`cpt-cf-adr-platform-plane-auth`: the runtime consumes rotated certs
+/// from a well-known path). The paths are read and validated when the TCP
+/// listener starts; the private key never appears in this struct, only its
+/// path.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GrpcTlsConfig {
+    /// `disabled` | `required`. Defaults to `required` when the block is set.
+    #[serde(default)]
+    pub mode: GrpcTlsMode,
+    /// Well-known path to the server leaf certificate chain, PEM (leaf-first).
+    pub cert_path: PathBuf,
+    /// Well-known path to the server private key, PEM.
+    pub key_path: PathBuf,
+    /// Well-known path to the platform CA, PEM (verifies client certificates).
+    pub ca_path: PathBuf,
+}
+
+impl GrpcTlsConfig {
+    /// The well-known PEM paths as a [`TlsPaths`].
+    fn paths(&self) -> TlsPaths {
+        TlsPaths {
+            cert: self.cert_path.clone(),
+            key: self.key_path.clone(),
+            ca: self.ca_path.clone(),
         }
     }
 }
@@ -258,6 +320,11 @@ pub struct GrpcHub {
     /// Platform-plane middleware applied to every served gRPC RPC; a
     /// pass-through layer when `internal_auth` is unset.
     pub(crate) auth_layer: OnceLock<InternalAuthGrpcLayer>,
+    /// Resolved server-mTLS config for the TCP listener, set by `init`. `None`
+    /// when no `tls` block is configured or `mode = disabled` (plaintext);
+    /// `Some` carries the validated paths, loaded into a `ServerTlsConfig` when
+    /// the TCP listener starts.
+    pub(crate) tls_config: OnceLock<Option<GrpcTlsConfig>>,
 }
 
 impl Default for GrpcHub {
@@ -270,6 +337,7 @@ impl Default for GrpcHub {
             instance_id: OnceLock::new(),
             bound_endpoint: RwLock::new(None),
             auth_layer: OnceLock::new(),
+            tls_config: OnceLock::new(),
         }
     }
 }
@@ -331,18 +399,83 @@ impl GrpcHub {
         })
     }
 
+    /// The resolved TCP-listener TLS config; `Ok(None)` means plaintext.
+    ///
+    /// Like [`effective_auth_layer`](Self::effective_auth_layer), an unset value
+    /// means `init` never ran — a startup-ordering bug — so this refuses to
+    /// serve rather than silently downgrading the TLS posture.
+    ///
+    /// # Errors
+    /// Returns an error if `init` has not run.
+    fn effective_tls_config(&self) -> anyhow::Result<Option<&GrpcTlsConfig>> {
+        self.tls_config.get().map(Option::as_ref).ok_or_else(|| {
+            anyhow::anyhow!(
+                "GrpcHub tls_config not initialized: Gear::init must run before serving \
+                 (refusing to serve with TLS posture undetermined)"
+            )
+        })
+    }
+
+    /// Whether the TCP listener terminates TLS. Drives the advertised scheme.
+    fn tls_enabled(&self) -> bool {
+        matches!(self.tls_config.get(), Some(Some(_)))
+    }
+
+    /// The URL scheme the TCP listener advertises: `https` when it terminates
+    /// mTLS, `http` otherwise.
+    fn tcp_scheme(&self) -> &'static str {
+        if self.tls_enabled() { "https" } else { "http" }
+    }
+
+    /// Load and build the TCP listener's [`ServerTlsConfig`] from the validated
+    /// well-known material. `Ok(None)` when TLS is disabled.
+    ///
+    /// The material is loaded once here at serve start; a rotation is picked up
+    /// on the next (re)serve. Live reload without a restart is a follow-up that
+    /// keeps a [`toolkit_transport_grpc::TlsMaterialReader`] alive and re-serves
+    /// on its generation counter (see the platform-plane mTLS plan).
+    ///
+    /// # Errors
+    /// Returns an error if `init` has not run or the material cannot be read or
+    /// validated.
+    async fn build_server_tls(&self) -> anyhow::Result<Option<ServerTlsConfig>> {
+        let Some(tls_cfg) = self.effective_tls_config()? else {
+            return Ok(None);
+        };
+        // tonic builds its rustls `ServerConfig` through the process-default
+        // crypto provider; with both aws-lc-rs and ring unified on rustls in
+        // this workspace there is no compiled-in default, so an uninstalled
+        // provider would make the acceptor build *panic*. Fail with a clear,
+        // actionable error instead (the provider is installed by
+        // `toolkit::bootstrap::init_crypto_provider` before serving).
+        anyhow::ensure!(
+            rustls::crypto::CryptoProvider::get_default().is_some(),
+            "rustls crypto provider is not installed; call \
+             toolkit::bootstrap::init_crypto_provider() before serving gRPC mTLS"
+        );
+        let material = TlsGeneration::load(&tls_cfg.paths())
+            .await
+            .context("loading gRPC hub server mTLS material")?;
+        let identity = Identity::from_pem(material.cert_pem(), material.key_pem().expose_secret());
+        let server_tls = ServerTlsConfig::new()
+            .identity(identity)
+            .client_ca_root(Certificate::from_pem(material.ca_pem()));
+        Ok(Some(server_tls))
+    }
+
     /// Pick the endpoint to register with Directory for a TCP listener.
     ///
     /// Returns `None` when the bound address is unspecified (e.g. `0.0.0.0`)
     /// and no explicit `advertise_addr` is configured — in that case the
     /// endpoint is not routable and registration must be skipped.
     fn tcp_directory_endpoint(&self, bound_addr: SocketAddr) -> Option<String> {
+        let scheme = self.tcp_scheme();
         if let Some((host, port)) = self.advertise_addr.get() {
             let resolved = format!("{}:{}", host, port.unwrap_or(bound_addr.port()));
 
-            Some(format!("http://{resolved}"))
+            Some(format!("{scheme}://{resolved}"))
         } else if !bound_addr.ip().is_unspecified() {
-            Some(format!("http://{bound_addr}"))
+            Some(format!("{scheme}://{bound_addr}"))
         } else {
             None
         }
@@ -579,32 +712,61 @@ impl GrpcHub {
         cancel: CancellationToken,
         ready: ReadySignal,
     ) -> anyhow::Result<()> {
+        // Load the mTLS material (structural PEM validation only at this point).
+        let server_tls = self.build_server_tls().await?;
+
         let listener = TcpListener::bind(addr).await?;
         let bound_addr = listener.local_addr()?;
-        tracing::info!(%bound_addr, transport = "tcp", "gRPC hub listening");
+        let scheme = self.tcp_scheme();
+        tracing::info!(%bound_addr, transport = "tcp", tls = self.tls_enabled(), "gRPC hub listening");
 
-        self.set_bound_endpoint(format!("http://{bound_addr}"));
-
-        if let Some(endpoint) = self.tcp_directory_endpoint(bound_addr) {
-            self.register_gears(gears, &endpoint).await?;
-        } else {
-            tracing::warn!(
-                %bound_addr,
-                "listen_addr is unspecified and no advertise_addr configured; skipping Directory registration"
-            );
+        // Assemble the router — including `tls_config`, which eagerly builds the
+        // rustls acceptor and needs the process crypto provider — *before*
+        // announcing. This way a semantic TLS error (cert/key mismatch,
+        // unsupported algorithm) or a provider-ordering violation fails startup
+        // here, rather than after we have advertised an `https` endpoint to
+        // Directory and signaled readiness. TLS is configured ahead of
+        // `add_routes` (tonic requires that); `None` leaves the listener as
+        // plaintext h2c — the backward-compatible default.
+        let mut builder = Server::builder();
+        if let Some(tls) = server_tls {
+            builder = builder
+                .tls_config(tls)
+                .context("applying gRPC hub server TLS config")?;
         }
+        let serving = builder
+            .layer(self.effective_auth_layer()?)
+            .add_routes(routes);
 
+        self.set_bound_endpoint(format!("{scheme}://{bound_addr}"));
+        self.register_tcp_endpoint(gears, bound_addr).await?;
         ready.notify();
 
         let incoming = TcpListenerStream::new(listener);
-        Server::builder()
-            .layer(self.effective_auth_layer()?)
-            .add_routes(routes)
+        serving
             .serve_with_incoming_shutdown(incoming, async move {
                 cancel.cancelled().await;
             })
             .await?;
         Ok(())
+    }
+
+    /// Register the TCP listener's endpoint with Directory, or log-and-skip when
+    /// the bound address is unroutable and no `advertise_addr` is configured.
+    async fn register_tcp_endpoint(
+        &self,
+        gears: &[GearInstallers],
+        bound_addr: SocketAddr,
+    ) -> anyhow::Result<()> {
+        if let Some(endpoint) = self.tcp_directory_endpoint(bound_addr) {
+            self.register_gears(gears, &endpoint).await
+        } else {
+            tracing::warn!(
+                %bound_addr,
+                "listen_addr is unspecified and no advertise_addr configured; skipping Directory registration"
+            );
+            Ok(())
+        }
     }
 
     /// Serve gRPC over Unix Domain Socket with Directory registration.
@@ -833,6 +995,21 @@ impl Gear for GrpcHub {
             .set(auth_layer)
             .map_err(|_| anyhow::anyhow!("auth_layer already set (init called twice?)"))?;
 
+        // Resolve the TCP-listener TLS posture once here so the serve path and
+        // the advertised scheme share one source of truth. An absent block or
+        // `mode = disabled` collapses to `None` (plaintext); the material itself
+        // is loaded when the TCP listener starts.
+        let tls_config = cfg.tls.filter(|t| t.mode == GrpcTlsMode::Required);
+        if let Some(tls) = &tls_config {
+            tracing::info!(
+                cert = %tls.cert_path.display(),
+                "grpc-hub TCP listener will terminate mTLS (required)"
+            );
+        }
+        self.tls_config
+            .set(tls_config)
+            .map_err(|_| anyhow::anyhow!("tls_config already set (init called twice?)"))?;
+
         if let Some(advertise_addr) = cfg.advertise_addr {
             let parsed = parse_advertise_addr(&advertise_addr)?;
 
@@ -1060,6 +1237,7 @@ mod tests {
         hub.auth_layer
             .set(InternalAuthGrpcLayer::disabled())
             .unwrap();
+        hub.tls_config.set(None).unwrap();
         let data = GrpcInstallerData {
             gears: vec![GearInstallers {
                 gear_name: "test".to_owned(),
@@ -1121,6 +1299,7 @@ mod tests {
         hub.auth_layer
             .set(InternalAuthGrpcLayer::disabled())
             .unwrap();
+        hub.tls_config.set(None).unwrap();
 
         let cancel = CancellationToken::new();
         let cancel_clone = cancel.clone();
@@ -1741,5 +1920,153 @@ mod tests {
             .await
             .expect("task should join")
             .expect("server should exit cleanly");
+    }
+
+    // ---- W2: server mTLS config parsing + serve wiring ----
+
+    #[test]
+    fn tls_block_parses_as_required_by_default() {
+        let cfg: GrpcHubConfig = serde_json::from_value(serde_json::json!({
+            "tls": { "cert_path": "/x/tls.crt", "key_path": "/x/tls.key", "ca_path": "/x/ca.crt" }
+        }))
+        .expect("tls block should deserialize");
+        let tls = cfg.tls.expect("tls present");
+        assert_eq!(tls.mode, GrpcTlsMode::Required);
+        assert_eq!(tls.cert_path, PathBuf::from("/x/tls.crt"));
+    }
+
+    #[test]
+    fn tls_mode_disabled_parses() {
+        let cfg: GrpcHubConfig = serde_json::from_value(serde_json::json!({
+            "tls": {
+                "mode": "disabled",
+                "cert_path": "/x/tls.crt", "key_path": "/x/tls.key", "ca_path": "/x/ca.crt"
+            }
+        }))
+        .expect("tls block should deserialize");
+        assert_eq!(cfg.tls.expect("tls present").mode, GrpcTlsMode::Disabled);
+    }
+
+    #[test]
+    fn omitted_tls_is_none() {
+        let cfg: GrpcHubConfig =
+            serde_json::from_value(serde_json::json!({})).expect("empty config");
+        assert!(
+            cfg.tls.is_none(),
+            "absent tls block must be None (plaintext)"
+        );
+    }
+
+    /// Writes a CA + server leaf (cert+key) into `dir` via rcgen; returns the
+    /// (cert, key, ca) paths.
+    fn write_server_tls_fixture(dir: &std::path::Path) -> (PathBuf, PathBuf, PathBuf) {
+        use rcgen::{BasicConstraints, CertificateParams, IsCa, KeyPair};
+        std::fs::create_dir_all(dir).unwrap();
+        let ca_key = KeyPair::generate().unwrap();
+        let mut ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let ca = ca_params.self_signed(&ca_key).unwrap();
+        let leaf_key = KeyPair::generate().unwrap();
+        let leaf_params = CertificateParams::new(vec!["localhost".to_owned()]).unwrap();
+        let issuer = rcgen::Issuer::new(ca_params, ca_key);
+        let leaf = leaf_params.signed_by(&leaf_key, &issuer).unwrap();
+        let (cert_p, key_p, ca_p) = (dir.join("tls.crt"), dir.join("tls.key"), dir.join("ca.crt"));
+        std::fs::write(&cert_p, leaf.pem()).unwrap();
+        std::fs::write(&key_p, leaf_key.serialize_pem()).unwrap();
+        std::fs::write(&ca_p, ca.pem()).unwrap();
+        (cert_p, key_p, ca_p)
+    }
+
+    #[tokio::test]
+    async fn build_server_tls_from_valid_fixture() {
+        // `build_server_tls` asserts a rustls provider is installed (matches the
+        // runtime, where bootstrap installs it); do the same for the test.
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .ok();
+        let dir =
+            std::env::temp_dir().join(format!("hubtls-{}-{}", std::process::id(), Uuid::new_v4()));
+        let (cert_path, key_path, ca_path) = write_server_tls_fixture(&dir);
+        let hub = GrpcHub::default();
+        hub.tls_config
+            .set(Some(GrpcTlsConfig {
+                mode: GrpcTlsMode::Required,
+                cert_path,
+                key_path,
+                ca_path,
+            }))
+            .unwrap();
+
+        assert!(hub.tls_enabled());
+        assert_eq!(hub.tcp_scheme(), "https");
+        assert!(
+            hub.build_server_tls().await.expect("build ok").is_some(),
+            "required TLS must build a ServerTlsConfig from valid material"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn build_server_tls_is_none_when_disabled() {
+        let hub = GrpcHub::default();
+        hub.tls_config.set(None).unwrap();
+        assert!(!hub.tls_enabled());
+        assert_eq!(hub.tcp_scheme(), "http");
+        assert!(hub.build_server_tls().await.expect("ok").is_none());
+    }
+
+    #[tokio::test]
+    async fn build_server_tls_errors_on_missing_material() {
+        let hub = GrpcHub::default();
+        hub.tls_config
+            .set(Some(GrpcTlsConfig {
+                mode: GrpcTlsMode::Required,
+                cert_path: PathBuf::from("/nonexistent/tls.crt"),
+                key_path: PathBuf::from("/nonexistent/tls.key"),
+                ca_path: PathBuf::from("/nonexistent/ca.crt"),
+            }))
+            .unwrap();
+        assert!(
+            hub.build_server_tls().await.is_err(),
+            "missing material must fail the serve-time build, not serve plaintext"
+        );
+    }
+
+    #[tokio::test]
+    async fn init_resolves_required_tls_to_https() {
+        let hub = GrpcHub::default();
+        let ctx = GearCtx::new(
+            "grpc-hub",
+            Uuid::new_v4(),
+            Arc::new(config_provider_with(serde_json::json!({
+                "tls": { "cert_path": "/x/tls.crt", "key_path": "/x/tls.key", "ca_path": "/x/ca.crt" }
+            }))),
+            Arc::new(ClientHub::default()),
+            CancellationToken::new(),
+        );
+        hub.init(&ctx).await.expect("init ok");
+        assert!(hub.tls_enabled(), "required tls must resolve to enabled");
+        assert_eq!(hub.tcp_scheme(), "https");
+    }
+
+    #[tokio::test]
+    async fn init_resolves_disabled_tls_to_plaintext() {
+        let hub = GrpcHub::default();
+        let ctx = GearCtx::new(
+            "grpc-hub",
+            Uuid::new_v4(),
+            Arc::new(config_provider_with(serde_json::json!({
+                "tls": {
+                    "mode": "disabled",
+                    "cert_path": "/x/tls.crt", "key_path": "/x/tls.key", "ca_path": "/x/ca.crt"
+                }
+            }))),
+            Arc::new(ClientHub::default()),
+            CancellationToken::new(),
+        );
+        hub.init(&ctx).await.expect("init ok");
+        assert!(!hub.tls_enabled(), "disabled tls must resolve to plaintext");
+        assert_eq!(hub.tcp_scheme(), "http");
     }
 }

--- a/libs/toolkit-transport-grpc/Cargo.toml
+++ b/libs/toolkit-transport-grpc/Cargo.toml
@@ -19,7 +19,13 @@ name = "toolkit_transport_grpc"
 workspace = true
 
 [dependencies]
-tonic = { workspace = true }
+# `tls-aws-lc` adds tonic's rustls TLS surface (ServerTlsConfig / ClientTlsConfig)
+# on the workspace-standard aws-lc-rs provider. It transitively enables
+# `_tls-any` → `tls-connect-info`, so `TlsConnectInfo::peer_certs()` is available
+# for SPIFFE identity extraction. Do NOT add a `ring`-backed TLS feature: two
+# active rustls crypto backends make provider auto-detection panic at runtime,
+# and `ring` is FIPS-banned.
+tonic = { workspace = true, features = ["tls-aws-lc"] }
 toolkit-security = { workspace = true }
 
 futures-util = { workspace = true }
@@ -37,6 +43,13 @@ secrecy = { workspace = true }
 parking_lot = { workspace = true }
 tower = { workspace = true }
 http = { workspace = true }
+# mTLS material: atomically-swappable cert generation + PEM validation at load.
+arc-swap = { workspace = true }
+rustls-pki-types = { workspace = true }
+# Parse the SPIFFE URI SAN out of a verified client certificate (inbound mTLS).
+x509-parser = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
+# Generates real X.509 fixtures (CA + leaf) for the TLS-material tests.
+rcgen = { workspace = true }

--- a/libs/toolkit-transport-grpc/src/client.rs
+++ b/libs/toolkit-transport-grpc/src/client.rs
@@ -10,13 +10,33 @@
 
 use std::time::Duration;
 
+use secrecy::ExposeSecret;
 use tokio_retry::Retry;
 use tokio_retry::strategy::{ExponentialBackoff, jitter};
-use tonic::transport::{Channel, Endpoint};
+use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity};
 use tracing::Instrument;
+
+use crate::tls::{TlsGeneration, TlsPaths};
 
 fn duration_to_i64_ms(duration: Duration) -> i64 {
     i64::try_from(duration.as_millis()).unwrap_or(i64::MAX)
+}
+
+/// Client-side mTLS settings for an outbound gRPC channel.
+///
+/// The cert/key/CA are read from the well-known [`TlsPaths`] at connect time
+/// (so a rotation is picked up on the next connect), and `domain_name` is the
+/// name verified against the server certificate's DNS/IP SAN — this is *not*
+/// the SPIFFE URI SAN: rustls verifies DNS/IP names, not URI SANs, so the
+/// server cert must carry a DNS/IP SAN matching the endpoint host (the SPIFFE
+/// URI SAN rides along for identity only). In Profile 3 `domain_name` is the
+/// service DNS name, e.g. `{gear}.{namespace}.svc.cluster.local`.
+#[derive(Debug, Clone)]
+pub struct ClientTlsSettings {
+    /// Well-known cert/key/CA PEM paths.
+    pub paths: TlsPaths,
+    /// The DNS/IP name to verify against the server certificate (and use for SNI).
+    pub domain_name: String,
 }
 
 /// Configuration for gRPC client transport stack.
@@ -66,6 +86,11 @@ pub struct GrpcClientConfig {
 
     /// Enable OpenTelemetry tracing.
     pub enable_tracing: bool,
+
+    /// Client-side mTLS. `None` (the default) builds a plaintext channel — the
+    /// backward-compatible behavior; `Some` makes the channel present a client
+    /// certificate and verify the server against the configured CA.
+    pub tls: Option<ClientTlsSettings>,
 }
 
 impl Default for GrpcClientConfig {
@@ -80,6 +105,7 @@ impl Default for GrpcClientConfig {
             service_name: "grpc_client",
             enable_metrics: true,
             enable_tracing: true,
+            tls: None,
         }
     }
 }
@@ -143,9 +169,20 @@ impl GrpcClientConfig {
         self.enable_tracing = false;
         self
     }
+
+    /// Enable client-side mTLS with material at the given well-known paths,
+    /// verifying the server against `domain_name` (its DNS/IP SAN).
+    pub fn with_tls(mut self, paths: TlsPaths, domain_name: impl Into<String>) -> Self {
+        self.tls = Some(ClientTlsSettings {
+            paths,
+            domain_name: domain_name.into(),
+        });
+        self
+    }
 }
 
-/// Build a tonic `Endpoint` with timeouts and keepalive settings.
+/// Build a tonic `Endpoint` with timeouts, keepalive, and — when
+/// [`GrpcClientConfig::tls`] is set — client mTLS.
 ///
 /// Configures:
 /// - Connect timeout
@@ -154,11 +191,23 @@ impl GrpcClientConfig {
 /// - HTTP/2 keepalive interval (30 seconds)
 /// - Keepalive timeout (10 seconds)
 /// - Keep alive while idle
-fn build_endpoint(
-    uri: String,
-    cfg: &GrpcClientConfig,
-) -> Result<Endpoint, tonic::transport::Error> {
-    let endpoint = Endpoint::from_shared(uri)?
+/// - Client mTLS (present a client cert, verify the server against the CA and
+///   `domain_name`) when `cfg.tls` is `Some`
+///
+/// Async because the mTLS material is read from the well-known paths at build
+/// time, so a rotation is picked up on the next connect. The crypto provider is
+/// the process-installed rustls default (installed by
+/// `toolkit::bootstrap::init_crypto_provider`); tonic builds its `ClientConfig`
+/// through it, so a FIPS build inherits the FIPS provider with no extra wiring.
+///
+/// # Errors
+/// Returns an error if the URI is invalid or the TLS material cannot be read,
+/// validated, or applied.
+async fn build_endpoint(uri: String, cfg: &GrpcClientConfig) -> anyhow::Result<Endpoint> {
+    use anyhow::Context as _;
+
+    let mut endpoint = Endpoint::from_shared(uri)
+        .context("invalid gRPC endpoint URI")?
         .connect_timeout(cfg.connect_timeout)
         .timeout(cfg.rpc_timeout)
         .tcp_keepalive(Some(Duration::from_secs(30)))
@@ -166,7 +215,44 @@ fn build_endpoint(
         .keep_alive_timeout(Duration::from_secs(10))
         .keep_alive_while_idle(true);
 
+    if let Some(tls) = &cfg.tls {
+        let material = TlsGeneration::load(&tls.paths)
+            .await
+            .context("loading client mTLS material")?;
+        let client_tls = ClientTlsConfig::new()
+            .ca_certificate(Certificate::from_pem(material.ca_pem()))
+            .identity(Identity::from_pem(
+                material.cert_pem(),
+                material.key_pem().expose_secret(),
+            ))
+            .domain_name(tls.domain_name.clone());
+        endpoint = endpoint
+            .tls_config(client_tls)
+            .context("applying client mTLS config")?;
+    }
+
     Ok(endpoint)
+}
+
+/// Build a lazily-connecting [`Channel`] with the configured transport stack
+/// (timeouts, keepalive, and optional client mTLS).
+///
+/// This is the framework-owned seam a gear SDK uses to obtain a channel without
+/// touching cert material or owning a `tls_config` of its own: it passes a
+/// [`GrpcClientConfig`] (optionally carrying [`ClientTlsSettings`]) and gets
+/// back a ready channel. `connect_lazy` defers the TCP/TLS handshake to first
+/// use, but the mTLS material is still read here (async) so a bad path fails
+/// fast rather than at first RPC.
+///
+/// # Errors
+/// Returns an error if the URI is invalid or the TLS material cannot be read,
+/// validated, or applied.
+pub async fn build_channel_lazy(
+    uri: impl Into<String>,
+    cfg: &GrpcClientConfig,
+) -> anyhow::Result<Channel> {
+    let endpoint = build_endpoint(uri.into(), cfg).await?;
+    Ok(endpoint.connect_lazy())
 }
 
 /// Connect to a gRPC service with the configured transport stack.
@@ -221,7 +307,7 @@ where
     );
 
     async move {
-        let endpoint = build_endpoint(uri_string, cfg)?;
+        let endpoint = build_endpoint(uri_string, cfg).await?;
         let channel = endpoint.connect().await?;
 
         if cfg.enable_tracing {
@@ -396,20 +482,251 @@ mod tests {
         assert!(!cfg.enable_tracing);
     }
 
-    #[test]
-    fn test_build_endpoint_succeeds() {
+    #[tokio::test]
+    async fn test_build_endpoint_succeeds() {
         let cfg = GrpcClientConfig::default();
-        let result = build_endpoint("http://localhost:50051".to_owned(), &cfg);
+        let result = build_endpoint("http://localhost:50051".to_owned(), &cfg).await;
         assert!(
             result.is_ok(),
             "build_endpoint should succeed with valid URI"
         );
     }
 
-    #[test]
-    fn test_build_endpoint_empty_uri() {
+    #[tokio::test]
+    async fn test_build_endpoint_empty_uri() {
         let cfg = GrpcClientConfig::default();
-        let result = build_endpoint(String::new(), &cfg);
+        let result = build_endpoint(String::new(), &cfg).await;
         assert!(result.is_err(), "build_endpoint should fail with empty URI");
+    }
+
+    #[test]
+    fn with_tls_sets_settings() {
+        let cfg = GrpcClientConfig::new("svc").with_tls(
+            TlsPaths {
+                cert: "/x/tls.crt".into(),
+                key: "/x/tls.key".into(),
+                ca: "/x/ca.crt".into(),
+            },
+            "gear.ns.svc.cluster.local",
+        );
+        let tls = cfg.tls.expect("tls set");
+        assert_eq!(tls.domain_name, "gear.ns.svc.cluster.local");
+        assert_eq!(tls.paths.cert, std::path::PathBuf::from("/x/tls.crt"));
+    }
+
+    #[tokio::test]
+    async fn build_endpoint_with_missing_tls_material_errors() {
+        let cfg = GrpcClientConfig::new("svc").with_tls(
+            TlsPaths {
+                cert: "/nonexistent/tls.crt".into(),
+                key: "/nonexistent/tls.key".into(),
+                ca: "/nonexistent/ca.crt".into(),
+            },
+            "localhost",
+        );
+        let result = build_endpoint("https://localhost:50051".to_owned(), &cfg).await;
+        assert!(
+            result.is_err(),
+            "TLS enabled with unreadable material must fail the build"
+        );
+    }
+
+    // ---- end-to-end mTLS: the client seam against a real tonic TLS server ----
+
+    use rcgen::{CertificateParams, Issuer, KeyPair, SanType};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use tonic::codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder};
+    use tonic::transport::{Certificate as TCert, Identity as TIdentity, Server, ServerTlsConfig};
+
+    fn unique_dir(tag: &str) -> std::path::PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("clienttls-{tag}-{}-{n}", std::process::id()))
+    }
+
+    struct Pki {
+        ca_pem: String,
+        server_cert: String,
+        server_key: String,
+        client_cert: String,
+        client_key: String,
+    }
+
+    /// CA + a server leaf (SAN DNS:localhost) + a client leaf, all signed by CA.
+    fn make_pki() -> Pki {
+        let ca_key = KeyPair::generate().unwrap();
+        let ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+        let ca_pem = ca_cert.pem();
+        let issuer = Issuer::new(ca_params, ca_key);
+
+        let leaf = |sans: Vec<SanType>| {
+            let key = KeyPair::generate().unwrap();
+            let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
+            params.subject_alt_names = sans;
+            let cert = params.signed_by(&key, &issuer).unwrap();
+            (cert.pem(), key.serialize_pem())
+        };
+        let (server_cert, server_key) =
+            leaf(vec![SanType::DnsName("localhost".try_into().unwrap())]);
+        let (client_cert, client_key) =
+            leaf(vec![SanType::DnsName("client.local".try_into().unwrap())]);
+        Pki {
+            ca_pem,
+            server_cert,
+            server_key,
+            client_cert,
+            client_key,
+        }
+    }
+
+    // A no-op `()` codec so we can issue a unary RPC with no .proto codegen; we
+    // only care whether the request traverses the mTLS channel to the server.
+    #[derive(Default)]
+    struct EmptyCodec;
+    struct Noop;
+    impl Codec for EmptyCodec {
+        type Encode = ();
+        type Decode = ();
+        type Encoder = Noop;
+        type Decoder = Noop;
+        fn encoder(&mut self) -> Noop {
+            Noop
+        }
+        fn decoder(&mut self) -> Noop {
+            Noop
+        }
+    }
+    impl Encoder for Noop {
+        type Item = ();
+        type Error = tonic::Status;
+        fn encode(&mut self, _item: (), _dst: &mut EncodeBuf<'_>) -> Result<(), tonic::Status> {
+            Ok(())
+        }
+    }
+    impl Decoder for Noop {
+        type Item = ();
+        type Error = tonic::Status;
+        fn decode(&mut self, _: &mut DecodeBuf<'_>) -> Result<Option<()>, tonic::Status> {
+            Ok(Some(()))
+        }
+    }
+
+    /// Write the client's cert/key/ca to files and return a TLS-enabled config.
+    async fn client_cfg(dir: &std::path::Path, pki: &Pki) -> GrpcClientConfig {
+        tokio::fs::create_dir_all(dir).await.unwrap();
+        let paths = TlsPaths {
+            cert: dir.join("tls.crt"),
+            key: dir.join("tls.key"),
+            ca: dir.join("ca.crt"),
+        };
+        tokio::fs::write(&paths.cert, &pki.client_cert)
+            .await
+            .unwrap();
+        tokio::fs::write(&paths.key, &pki.client_key).await.unwrap();
+        tokio::fs::write(&paths.ca, &pki.ca_pem).await.unwrap();
+        GrpcClientConfig::new("test").with_tls(paths, "localhost")
+    }
+
+    /// Spawn a tonic server terminating mTLS (server identity + client CA) on an
+    /// ephemeral port; returns (addr, shutdown, join).
+    async fn spawn_mtls_server(
+        pki: &Pki,
+    ) -> (
+        std::net::SocketAddr,
+        tokio::sync::oneshot::Sender<()>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let server_tls = ServerTlsConfig::new()
+            .identity(TIdentity::from_pem(&pki.server_cert, &pki.server_key))
+            .client_ca_root(TCert::from_pem(&pki.ca_pem));
+        let handle = tokio::spawn(async move {
+            Server::builder()
+                .tls_config(server_tls)
+                .expect("server tls")
+                .add_routes(tonic::service::Routes::default())
+                .serve_with_shutdown(addr, async {
+                    rx.await.ok();
+                })
+                .await
+                .ok();
+        });
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        (addr, tx, handle)
+    }
+
+    /// Issue one unary RPC over `channel`; `true` if it reached the server
+    /// (empty router answers `Unimplemented` — proof the mTLS channel is up).
+    async fn rpc_reaches_server(channel: Channel) -> bool {
+        let mut grpc = tonic::client::Grpc::new(channel);
+        if grpc.ready().await.is_err() {
+            return false;
+        }
+        let path = http::uri::PathAndQuery::from_static("/probe.Svc/Probe");
+        match grpc
+            .unary::<(), (), _>(tonic::Request::new(()), path, EmptyCodec)
+            .await
+        {
+            Ok(_) => true,
+            Err(status) => status.code() == tonic::Code::Unimplemented,
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn mtls_client_reaches_server_through_the_seam() {
+        let pki = make_pki();
+        let (addr, tx, handle) = spawn_mtls_server(&pki).await;
+        let dir = unique_dir("ok");
+        let cfg = client_cfg(&dir, &pki).await;
+
+        let channel = build_channel_lazy(format!("https://localhost:{}", addr.port()), &cfg)
+            .await
+            .expect("channel built");
+        assert!(
+            rpc_reaches_server(channel).await,
+            "an mTLS client built through the seam should reach the server"
+        );
+
+        tx.send(()).ok();
+        handle.await.ok();
+        tokio::fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn client_rejects_server_signed_by_an_untrusted_ca() {
+        let pki = make_pki();
+        let (addr, tx, handle) = spawn_mtls_server(&pki).await;
+        // Client trusts a DIFFERENT CA than the one that signed the server cert.
+        let other = make_pki();
+        let dir = unique_dir("badca");
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        let paths = TlsPaths {
+            cert: dir.join("tls.crt"),
+            key: dir.join("tls.key"),
+            ca: dir.join("ca.crt"),
+        };
+        tokio::fs::write(&paths.cert, &pki.client_cert)
+            .await
+            .unwrap();
+        tokio::fs::write(&paths.key, &pki.client_key).await.unwrap();
+        tokio::fs::write(&paths.ca, &other.ca_pem).await.unwrap();
+        let cfg = GrpcClientConfig::new("test").with_tls(paths, "localhost");
+
+        // Server-cert verification is client-side, so it fails at connect().
+        let channel = build_channel_lazy(format!("https://localhost:{}", addr.port()), &cfg)
+            .await
+            .expect("channel builds lazily");
+        assert!(
+            !rpc_reaches_server(channel).await,
+            "a server cert signed by an untrusted CA must be rejected"
+        );
+
+        tx.send(()).ok();
+        handle.await.ok();
+        tokio::fs::remove_dir_all(&dir).await.ok();
     }
 }

--- a/libs/toolkit-transport-grpc/src/internal_auth_server.rs
+++ b/libs/toolkit-transport-grpc/src/internal_auth_server.rs
@@ -44,12 +44,14 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures_util::future::Either;
+use rustls_pki_types::CertificateDer;
 use secrecy::{ExposeSecret, SecretString};
 use tonic::Status;
+use tonic::transport::server::{TcpConnectInfo, TlsConnectInfo};
 use toolkit_security::constants::INTERNAL_TOKEN_HEADER;
 use toolkit_security::{
     DynInternalAuthenticator, InternalAuthNError, InternalAuthenticator, PeerAuthenticated,
-    PlatformSecurityContext,
+    PlatformIdentity, PlatformSecurityContext,
 };
 use tower::{Layer, Service};
 
@@ -274,6 +276,81 @@ fn prefix_matches_boundary(path: &str, prefix: &str) -> bool {
     prefix.ends_with('/') || rest.is_empty() || rest.starts_with('/')
 }
 
+/// Parse a SPIFFE ID of the platform shape
+/// `spiffe://<trust_domain>/gear/<name>/<version>` into its three components.
+///
+/// Returns `None` for any URI that is not exactly that shape (wrong scheme,
+/// empty trust domain, missing `gear` segment, missing/empty name or version,
+/// or trailing segments) — a strict parse so a malformed SAN cannot be coerced
+/// into a partial identity.
+fn parse_spiffe_uri(uri: &str) -> Option<(String, String, String)> {
+    let rest = uri.strip_prefix("spiffe://")?;
+    // A canonical SPIFFE ID carries no query or fragment component.
+    if rest.contains('?') || rest.contains('#') {
+        return None;
+    }
+    let (trust_domain, path) = rest.split_once('/')?;
+    // The trust domain is a bare authority: no userinfo (`@`) and no port (`:`).
+    if trust_domain.is_empty() || trust_domain.contains('@') || trust_domain.contains(':') {
+        return None;
+    }
+    let mut segments = path.split('/');
+    if segments.next()? != "gear" {
+        return None;
+    }
+    let name = segments.next().filter(|s| !s.is_empty())?;
+    let version = segments.next().filter(|s| !s.is_empty())?;
+    if segments.next().is_some() {
+        // Exactly `gear/<name>/<version>` — reject anything longer.
+        return None;
+    }
+    Some((trust_domain.to_owned(), name.to_owned(), version.to_owned()))
+}
+
+/// Build a [`PlatformIdentity::Spiffe`] from a leaf certificate's URI SAN, if it
+/// carries a well-formed platform SPIFFE ID.
+///
+/// The certificate chain has already been verified against the platform CA by
+/// the TLS handshake; this only *reads the identity* out of the (trusted) leaf.
+/// Returns `None` when the leaf has no parseable `spiffe://…/gear/…` URI SAN.
+fn spiffe_identity_from_leaf(der: &CertificateDer<'_>) -> Option<PlatformIdentity> {
+    use x509_parser::extensions::GeneralName;
+
+    let (_, cert) = x509_parser::parse_x509_certificate(der.as_ref()).ok()?;
+    let san = cert.subject_alternative_name().ok()??;
+    let mut found: Option<PlatformIdentity> = None;
+    for general_name in &san.value.general_names {
+        if let GeneralName::URI(uri) = general_name
+            && let Some((trust_domain, name, version)) = parse_spiffe_uri(uri)
+        {
+            if found.is_some() {
+                // More than one parseable platform SPIFFE URI SAN: the identity
+                // is ambiguous, so fail closed rather than silently pick one.
+                tracing::warn!(
+                    "client certificate presents multiple SPIFFE identities; rejecting as ambiguous"
+                );
+                return None;
+            }
+            found = Some(PlatformIdentity::Spiffe {
+                trust_domain,
+                name,
+                version,
+            });
+        }
+    }
+    found
+}
+
+/// The leaf (first) peer certificate of an inbound mTLS connection, if the
+/// request carries tonic's [`TlsConnectInfo`] with a verified client chain.
+///
+/// Absent for a plaintext connection, or a TLS connection where the client
+/// presented no certificate.
+fn peer_leaf_cert<B>(req: &http::Request<B>) -> Option<CertificateDer<'static>> {
+    let info = req.extensions().get::<TlsConnectInfo<TcpConnectInfo>>()?;
+    info.peer_certs()?.first().cloned()
+}
+
 impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for InternalAuthGrpcService<S>
 where
     S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Clone + Send + 'static,
@@ -305,12 +382,10 @@ where
         let clone = self.inner.clone();
         let mut inner = std::mem::replace(&mut self.inner, clone);
 
-        // Disabled layer (Profile 1 / in-process): straight pass-through.
-        let AuthMode::Enforced(authenticator) = &self.config.mode else {
-            return Either::Left(inner.call(req));
-        };
-
-        // Infrastructure methods (health, reflection) bypass enforcement.
+        // Infrastructure methods (health, reflection) bypass *everything* —
+        // including mTLS identity resolution — so an unauthenticated probe (or a
+        // probe over a connection whose client cert lacks a SPIFFE identity) is
+        // never rejected. Checked first, on the borrowed path (no allocation).
         let path = req.uri().path();
         if self
             .config
@@ -320,10 +395,60 @@ where
         {
             return Either::Left(inner.call(req));
         }
+        // Own the path so the request can be mutated below without a borrow conflict.
+        let path = path.to_owned();
+
+        // A verified client certificate is authoritative in *every* mode. mTLS
+        // identity resolution is deliberately independent of token enforcement:
+        // whether the token layer is Enforced, Permissive, or Disabled, an
+        // mTLS-authenticated peer always gets its `PlatformSecurityContext`
+        // stamped, and the per-request token degrades to a shim (never a second
+        // gate that could reject an already-authenticated peer). Resolving this
+        // *before* the enforcement branch is what stops an mTLS + disabled-token
+        // deployment from silently dropping the caller identity. This is the
+        // mTLS end-state identity backend of `cpt-cf-adr-platform-plane-auth`;
+        // the token path below serves non-mTLS (SA-token phase) connections.
+        if let Some(leaf) = peer_leaf_cert(&req) {
+            if let Some(identity) = spiffe_identity_from_leaf(&leaf) {
+                // Cert is authoritative — strip any token so the handler never
+                // sees it, and stamp the same context the token path would
+                // (downstream cannot tell which backend produced it).
+                req.headers_mut().remove(INTERNAL_TOKEN_HEADER);
+                let name = identity.peer_name().to_owned();
+                tracing::debug!(
+                    peer = %name,
+                    method = %path,
+                    "platform-plane gRPC call authenticated via mTLS"
+                );
+                req.extensions_mut().insert(PeerAuthenticated { name });
+                req.extensions_mut()
+                    .insert(PlatformSecurityContext::new(identity));
+                return Either::Left(inner.call(req));
+            }
+            // A CA-verified cert with no SPIFFE identity is a misconfiguration
+            // (the platform CA should only sign SPIFFE workload certs); fail
+            // closed rather than fall back to the token path.
+            tracing::warn!(
+                method = %path,
+                "platform-plane gRPC call rejected: client certificate has no SPIFFE identity"
+            );
+            return Either::Right(Box::pin(async move {
+                Ok(
+                    Status::unauthenticated("client certificate has no SPIFFE identity")
+                        .into_http(),
+                )
+            }));
+        }
+
+        // No client certificate — fall back to token-based platform-plane auth.
+        // A disabled layer (Profile 1 / in-process: the process boundary is the
+        // trust root) passes such non-mTLS requests through untouched.
+        let AuthMode::Enforced(authenticator) = &self.config.mode else {
+            return Either::Left(inner.call(req));
+        };
 
         let config = Arc::clone(&self.config);
         let authenticator = authenticator.clone();
-        let path = path.to_owned();
 
         Either::Right(Box::pin(async move {
             match read_token(req.headers_mut()) {
@@ -682,5 +807,89 @@ mod tests {
             "/pkg.Svc/List/sub",
             "/pkg.Svc/List"
         ));
+    }
+
+    // ---- W4: SPIFFE identity extraction from a verified client cert ----
+
+    #[test]
+    fn parse_spiffe_uri_accepts_platform_shape() {
+        assert_eq!(
+            parse_spiffe_uri("spiffe://example.org/gear/cluster/v1"),
+            Some((
+                "example.org".to_owned(),
+                "cluster".to_owned(),
+                "v1".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_spiffe_uri_rejects_malformed() {
+        for bad in [
+            "https://example.org/gear/cluster/v1",        // wrong scheme
+            "spiffe:///gear/cluster/v1",                  // empty trust domain
+            "spiffe://example.org/svc/cluster/v1",        // not `gear`
+            "spiffe://example.org/gear/cluster",          // missing version
+            "spiffe://example.org/gear//v1",              // empty name
+            "spiffe://example.org/gear/cluster/v1/extra", // trailing segment
+            "spiffe://user@example.org/gear/cluster/v1",  // userinfo in authority
+            "spiffe://example.org:8443/gear/cluster/v1",  // port in authority
+            "spiffe://example.org/gear/cluster/v1?x=1",   // query component
+            "spiffe://example.org/gear/cluster/v1#frag",  // fragment component
+        ] {
+            assert!(parse_spiffe_uri(bad).is_none(), "must reject {bad}");
+        }
+    }
+
+    fn leaf_der_with_sans(sans: Vec<rcgen::SanType>) -> rustls_pki_types::CertificateDer<'static> {
+        let key = rcgen::KeyPair::generate().unwrap();
+        let mut params = rcgen::CertificateParams::new(Vec::<String>::new()).unwrap();
+        params.subject_alt_names = sans;
+        let cert = params.self_signed(&key).unwrap();
+        cert.der().clone()
+    }
+
+    #[test]
+    fn spiffe_identity_from_leaf_reads_uri_san() {
+        let der = leaf_der_with_sans(vec![
+            rcgen::SanType::URI("spiffe://td/gear/foo/v2".try_into().unwrap()),
+            rcgen::SanType::DnsName("foo.ns.svc".try_into().unwrap()),
+        ]);
+        match spiffe_identity_from_leaf(&der) {
+            Some(PlatformIdentity::Spiffe {
+                trust_domain,
+                name,
+                version,
+            }) => {
+                assert_eq!(trust_domain, "td");
+                assert_eq!(name, "foo");
+                assert_eq!(version, "v2");
+            }
+            _ => panic!("expected Spiffe identity"),
+        }
+    }
+
+    #[test]
+    fn spiffe_identity_from_leaf_is_none_without_uri_san() {
+        // A cert that verifies against the CA but carries only a DNS SAN has no
+        // SPIFFE identity — the caller (the layer) fails such a peer closed.
+        let der = leaf_der_with_sans(vec![rcgen::SanType::DnsName(
+            "foo.ns.svc".try_into().unwrap(),
+        )]);
+        assert!(spiffe_identity_from_leaf(&der).is_none());
+    }
+
+    #[test]
+    fn spiffe_identity_from_leaf_rejects_ambiguous_multiple_sans() {
+        // Two parseable platform SPIFFE URI SANs ⇒ ambiguous identity ⇒ reject
+        // (fail closed) rather than silently pick the first.
+        let der = leaf_der_with_sans(vec![
+            rcgen::SanType::URI("spiffe://td/gear/foo/v1".try_into().unwrap()),
+            rcgen::SanType::URI("spiffe://td/gear/bar/v1".try_into().unwrap()),
+        ]);
+        assert!(
+            spiffe_identity_from_leaf(&der).is_none(),
+            "a cert with multiple SPIFFE identities must be rejected as ambiguous"
+        );
     }
 }

--- a/libs/toolkit-transport-grpc/src/lib.rs
+++ b/libs/toolkit-transport-grpc/src/lib.rs
@@ -4,6 +4,7 @@ pub mod internal_auth;
 pub mod internal_auth_server;
 pub mod rpc_retry;
 pub mod sa_token;
+pub mod tls;
 
 #[cfg(windows)]
 pub mod windows_named_pipe;
@@ -20,6 +21,9 @@ pub use internal_auth_server::{
     InternalAuthGrpcService,
 };
 pub use sa_token::{DEFAULT_REFRESH_INTERVAL, ServiceAccountTokenReader};
+pub use tls::{
+    DEFAULT_TLS_REFRESH_INTERVAL, TlsGeneration, TlsMaterialError, TlsMaterialReader, TlsPaths,
+};
 
 pub const SECCTX_METADATA_KEY: &str = "x-secctx-bin";
 

--- a/libs/toolkit-transport-grpc/src/tls.rs
+++ b/libs/toolkit-transport-grpc/src/tls.rs
@@ -1,0 +1,615 @@
+//! mTLS material for the gRPC transport, loaded from well-known PEM paths and
+//! refreshed in place so a long-lived process picks up cert-manager / SPIRE
+//! rotation without a restart.
+//!
+//! Per ADR-0006 the out-of-process runtime consumes rotated certs from a well-known path
+//! (Profile 2: a host file; Profile 3: a projected volume). This reader mirrors
+//! [`ServiceAccountTokenReader`](crate::sa_token::ServiceAccountTokenReader): it
+//! **re-reads on a bounded interval** rather than subscribing to filesystem
+//! events, so it needs no `notify` dependency and covers both the host-file and
+//! projected-volume cases with one code path.
+//!
+//! A [`TlsGeneration`] bundles the three PEM artifacts — the leaf cert chain,
+//! the private key, and the platform CA — as a single unit. The reader only
+//! ever swaps a **fully validated** generation into place ([`arc_swap`]), so a
+//! consumer never observes a torn mix of an old key with a new cert, and a bad
+//! read (unreadable, empty, or malformed PEM) is logged and **ignored**, keeping
+//! the last-known-good material live rather than breaking the next handshake.
+//!
+//! The reader does not build [`tonic`](https://docs.rs/tonic) TLS configs
+//! itself; that is the server's / client's job. It exposes the validated PEM
+//! plus a [`watch`](tokio::sync::watch) generation counter
+//! ([`subscribe`](TlsMaterialReader::subscribe)) so those layers can rebuild
+//! their `ServerTlsConfig` / channel when — and only when — the material
+//! actually changes.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use arc_swap::ArcSwap;
+use rustls_pki_types::pem::PemObject;
+use rustls_pki_types::{CertificateDer, PrivateKeyDer};
+use secrecy::{ExposeSecret, SecretString};
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+
+/// Default cadence for re-reading the cert paths. Certificate rotation is
+/// infrequent (cert-manager renews well before expiry) and a re-read is cheap,
+/// so a coarse interval keeps overhead negligible while still picking up a
+/// rotation within roughly one interval. Matches the order of magnitude of
+/// [`crate::sa_token::DEFAULT_REFRESH_INTERVAL`].
+pub const DEFAULT_TLS_REFRESH_INTERVAL: Duration = Duration::from_mins(1);
+
+/// The well-known PEM paths for a workload's mTLS material. Mirrors the field
+/// shape of `toolkit_security`'s `InternalCredential::MtlsIdentity`, so the
+/// outbound credential maps onto it one-to-one.
+#[derive(Debug, Clone)]
+pub struct TlsPaths {
+    /// Leaf certificate chain, PEM, leaf-first.
+    pub cert: PathBuf,
+    /// Private key, PEM (PKCS#8 / PKCS#1 / SEC1).
+    pub key: PathBuf,
+    /// Platform CA used to verify the peer, PEM.
+    pub ca: PathBuf,
+}
+
+/// A single, fully-validated generation of mTLS material.
+///
+/// The private key is held in a [`SecretString`] so it is redacted in `Debug`
+/// output and zeroized on drop; the certificate and CA are public material.
+#[derive(Clone)]
+pub struct TlsGeneration {
+    cert: Arc<str>,
+    key: SecretString,
+    ca: Arc<str>,
+}
+
+impl TlsGeneration {
+    /// The leaf certificate chain, PEM, leaf-first.
+    #[must_use]
+    pub fn cert_pem(&self) -> &str {
+        &self.cert
+    }
+
+    /// The platform CA certificate(s), PEM.
+    #[must_use]
+    pub fn ca_pem(&self) -> &str {
+        &self.ca
+    }
+
+    /// The private key, PEM. The secret is exposed only at the call site that
+    /// hands it to the TLS-config builder; it never escapes as a plain `String`
+    /// through this type's `Debug`/`Clone`.
+    #[must_use]
+    pub fn key_pem(&self) -> &SecretString {
+        &self.key
+    }
+
+    /// Load and validate the cert/key/CA PEM triple from `paths` once.
+    ///
+    /// This is the one-shot path a server or client uses to build its TLS
+    /// config at startup. [`TlsMaterialReader`] wraps the same load to keep the
+    /// material refreshed for live rotation.
+    ///
+    /// # Errors
+    /// Returns [`TlsMaterialError`] if any path cannot be read, is empty, or
+    /// does not parse as valid PEM.
+    pub async fn load(paths: &TlsPaths) -> Result<Self, TlsMaterialError> {
+        read_and_validate(paths).await
+    }
+
+    /// Content equality across a reload: two generations are equal when all
+    /// three PEM artifacts match byte-for-byte. Used to suppress a no-op swap
+    /// (and its rebuild signal) when a re-read returns unchanged material.
+    fn content_eq(&self, other: &Self) -> bool {
+        self.cert == other.cert
+            && self.ca == other.ca
+            && self.key.expose_secret() == other.key.expose_secret()
+    }
+}
+
+impl fmt::Debug for TlsGeneration {
+    /// Never prints PEM contents — the key is secret and the certs are noise;
+    /// report byte lengths and a redaction marker instead.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TlsGeneration")
+            .field("cert_len", &self.cert.len())
+            .field("ca_len", &self.ca.len())
+            .field("key", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Errors from loading mTLS material off the well-known paths.
+#[derive(Debug, thiserror::Error)]
+pub enum TlsMaterialError {
+    /// A PEM file could not be read from disk.
+    #[error("failed to read TLS material at {path}")]
+    Read {
+        /// The path that failed to read.
+        path: PathBuf,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// A PEM file was present but empty (or whitespace only).
+    #[error("TLS material at {path} is empty")]
+    Empty {
+        /// The path that was empty.
+        path: PathBuf,
+    },
+    /// A **public** PEM artifact (certificate or CA) did not parse. The parse
+    /// error is preserved as `source` for diagnostics — safe because cert/CA
+    /// material is public. (The private key uses [`Self::InvalidKey`], which
+    /// deliberately carries no source.)
+    #[error("TLS material at {path} is not valid PEM ({kind})")]
+    InvalidPem {
+        /// The path that failed to parse.
+        path: PathBuf,
+        /// What the artifact was expected to be (`certificate` / `CA certificate`).
+        kind: &'static str,
+        /// The underlying PEM decode error.
+        #[source]
+        source: rustls_pki_types::pem::Error,
+    },
+    /// The private-key PEM did not parse. The underlying parse error is
+    /// **deliberately not carried** as a `source`: its `Display` can render
+    /// bytes of the offending line, and for the private key a fragment must
+    /// never be able to reach a log via the error chain.
+    #[error("TLS private key at {path} is not valid PEM")]
+    InvalidKey {
+        /// The path whose private key failed to parse.
+        path: PathBuf,
+    },
+    /// A certificate PEM parsed but contained no certificate blocks.
+    #[error("TLS material at {path} contains no {kind}")]
+    NoCertificate {
+        /// The path with no certificate blocks.
+        path: PathBuf,
+        /// Which certificate artifact was empty (`certificate`, `CA certificate`).
+        kind: &'static str,
+    },
+}
+
+/// Reads a workload's mTLS PEM triple and keeps a validated, atomically
+/// swappable copy in memory so the server / client always build against the
+/// current (post-rotation) material.
+///
+/// Dropping the reader stops the background refresh task at the next tick: the
+/// task holds a [`Weak`] handle to the shared state and exits once the reader
+/// (the sole strong holder) is gone.
+#[derive(Debug)]
+pub struct TlsMaterialReader {
+    paths: TlsPaths,
+    current: Arc<ArcSwap<TlsGeneration>>,
+    /// Generation counter; ticks each time a *changed* generation is swapped in.
+    generation: watch::Sender<u64>,
+}
+
+impl TlsMaterialReader {
+    /// Load the material once and spawn a background task that re-reads it every
+    /// [`DEFAULT_TLS_REFRESH_INTERVAL`].
+    ///
+    /// # Errors
+    /// Returns [`TlsMaterialError`] if any of the three paths cannot be read, is
+    /// empty, or does not parse as valid PEM on the initial load.
+    pub async fn new(paths: TlsPaths) -> Result<Self, TlsMaterialError> {
+        Self::with_refresh_interval(paths, DEFAULT_TLS_REFRESH_INTERVAL, None).await
+    }
+
+    /// Like [`new`](Self::new) but ties the refresh task to a
+    /// [`CancellationToken`] so it stops promptly on shutdown instead of
+    /// lingering for up to a full interval.
+    ///
+    /// # Errors
+    /// See [`new`](Self::new).
+    pub async fn with_cancellation(
+        paths: TlsPaths,
+        cancel: CancellationToken,
+    ) -> Result<Self, TlsMaterialError> {
+        Self::with_refresh_interval(paths, DEFAULT_TLS_REFRESH_INTERVAL, Some(cancel)).await
+    }
+
+    /// Like [`new`](Self::new) but with a custom re-read `interval` and optional
+    /// cancellation. Primarily for tests and the bootstrap layer.
+    ///
+    /// # Errors
+    /// See [`new`](Self::new).
+    pub async fn with_refresh_interval(
+        paths: TlsPaths,
+        interval: Duration,
+        cancel: Option<CancellationToken>,
+    ) -> Result<Self, TlsMaterialError> {
+        let generation = read_and_validate(&paths).await?;
+        let current = Arc::new(ArcSwap::from_pointee(generation));
+        let (tx, _rx) = watch::channel(0u64);
+
+        spawn_refresh_task(
+            paths.clone(),
+            Arc::downgrade(&current),
+            tx.clone(),
+            interval,
+            cancel,
+        );
+
+        Ok(Self {
+            paths,
+            current,
+            generation: tx,
+        })
+    }
+
+    /// The well-known paths this reader watches.
+    #[must_use]
+    pub fn paths(&self) -> &TlsPaths {
+        &self.paths
+    }
+
+    /// Snapshot the current validated generation.
+    #[must_use]
+    pub fn current(&self) -> Arc<TlsGeneration> {
+        self.current.load_full()
+    }
+
+    /// Subscribe to the generation counter. The value increments each time a
+    /// *changed* generation is swapped in (an unchanged re-read does not tick),
+    /// so the server / client rebuild their TLS config only on a real rotation.
+    #[must_use]
+    pub fn subscribe(&self) -> watch::Receiver<u64> {
+        self.generation.subscribe()
+    }
+}
+
+/// Spawn the interval re-read loop. Terminates when `current` can no longer be
+/// upgraded (the reader has been dropped) or, when a [`CancellationToken`] is
+/// supplied, as soon as it is cancelled.
+fn spawn_refresh_task(
+    paths: TlsPaths,
+    current: Weak<ArcSwap<TlsGeneration>>,
+    generation: watch::Sender<u64>,
+    interval: Duration,
+    cancel: Option<CancellationToken>,
+) {
+    tokio::spawn(async move {
+        loop {
+            match &cancel {
+                Some(token) => {
+                    tokio::select! {
+                        () = tokio::time::sleep(interval) => {}
+                        () = token.cancelled() => break,
+                    }
+                }
+                None => tokio::time::sleep(interval).await,
+            }
+            let Some(current) = current.upgrade() else {
+                break;
+            };
+            reload_once(&paths, &current, &generation).await;
+        }
+    });
+}
+
+/// Perform one re-read: on success, swap in only if the material changed and
+/// tick the generation counter; on failure, keep the previous generation.
+async fn reload_once(
+    paths: &TlsPaths,
+    current: &ArcSwap<TlsGeneration>,
+    generation: &watch::Sender<u64>,
+) {
+    match read_and_validate(paths).await {
+        Ok(next) => {
+            if current.load().content_eq(&next) {
+                return;
+            }
+            current.store(Arc::new(next));
+            // Read the current counter into an owned value FIRST so the
+            // `borrow()` read guard is dropped before `send_replace` takes the
+            // write lock — holding both in one statement self-deadlocks the
+            // task. `send_replace` tolerates zero receivers (unlike `send`), so
+            // no meaningful `Result` is discarded.
+            let next_generation = generation.borrow().wrapping_add(1);
+            generation.send_replace(next_generation);
+            tracing::info!(cert = %paths.cert.display(), "reloaded rotated TLS material");
+        }
+        Err(e) => {
+            tracing::warn!(
+                cert = %paths.cert.display(),
+                error = %e,
+                "failed to reload TLS material; keeping previous generation",
+            );
+        }
+    }
+}
+
+/// Read and validate the three PEM artifacts into a [`TlsGeneration`].
+async fn read_and_validate(paths: &TlsPaths) -> Result<TlsGeneration, TlsMaterialError> {
+    let cert = read_nonempty(&paths.cert).await?;
+    let key = read_nonempty(&paths.key).await?;
+    let ca = read_nonempty(&paths.ca).await?;
+
+    validate_certs(&paths.cert, &cert, "certificate")?;
+    validate_key(&paths.key, &key)?;
+    validate_certs(&paths.ca, &ca, "CA certificate")?;
+
+    Ok(TlsGeneration {
+        cert: Arc::from(cert),
+        key: SecretString::from(key),
+        ca: Arc::from(ca),
+    })
+}
+
+/// Read a file to a string, erroring if it is missing/unreadable or empty.
+async fn read_nonempty(path: &Path) -> Result<String, TlsMaterialError> {
+    let raw = tokio::fs::read_to_string(path)
+        .await
+        .map_err(|source| TlsMaterialError::Read {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    if raw.trim().is_empty() {
+        return Err(TlsMaterialError::Empty {
+            path: path.to_path_buf(),
+        });
+    }
+    Ok(raw)
+}
+
+/// Validate that `pem` parses as one or more X.509 certificates.
+fn validate_certs(path: &Path, pem: &str, kind: &'static str) -> Result<(), TlsMaterialError> {
+    let mut count = 0usize;
+    for item in CertificateDer::pem_slice_iter(pem.as_bytes()) {
+        item.map_err(|source| TlsMaterialError::InvalidPem {
+            path: path.to_path_buf(),
+            kind,
+            source,
+        })?;
+        count += 1;
+    }
+    if count == 0 {
+        return Err(TlsMaterialError::NoCertificate {
+            path: path.to_path_buf(),
+            kind,
+        });
+    }
+    Ok(())
+}
+
+/// Validate that `pem` parses as a private key.
+fn validate_key(path: &Path, pem: &str) -> Result<(), TlsMaterialError> {
+    PrivateKeyDer::from_pem_slice(pem.as_bytes())
+        .map(|_| ())
+        // Drop the parse error's `source`: it can render key-file bytes.
+        .map_err(|_| TlsMaterialError::InvalidKey {
+            path: path.to_path_buf(),
+        })
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Unique temp dir per test, without pulling in a UUID dependency.
+    fn unique_dir(tag: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("tls-{tag}-{}-{n}", std::process::id()))
+    }
+
+    /// A CA plus one leaf (cert + key) signed by it, all PEM. Uses the
+    /// workspace `rcgen` so the fixtures are real, parseable X.509.
+    struct Fixture {
+        ca: String,
+        cert: String,
+        key: String,
+    }
+
+    fn make_fixture(dns: &str) -> Fixture {
+        use rcgen::{CertificateParams, KeyPair};
+        let ca_key = KeyPair::generate().expect("ca key");
+        let ca_params = CertificateParams::new(Vec::<String>::new()).expect("ca params");
+        let ca = ca_params.self_signed(&ca_key).expect("self-sign ca");
+
+        let leaf_key = KeyPair::generate().expect("leaf key");
+        let leaf_params = CertificateParams::new(vec![dns.to_owned()]).expect("leaf params");
+        let issuer = rcgen::Issuer::new(ca_params, ca_key);
+        let leaf = leaf_params
+            .signed_by(&leaf_key, &issuer)
+            .expect("sign leaf");
+
+        Fixture {
+            ca: ca.pem(),
+            cert: leaf.pem(),
+            key: leaf_key.serialize_pem(),
+        }
+    }
+
+    /// Write a fixture's three artifacts into `dir` and return the paths.
+    async fn write_fixture(dir: &Path, fx: &Fixture) -> TlsPaths {
+        tokio::fs::create_dir_all(dir).await.expect("mkdir");
+        let paths = TlsPaths {
+            cert: dir.join("tls.crt"),
+            key: dir.join("tls.key"),
+            ca: dir.join("ca.crt"),
+        };
+        tokio::fs::write(&paths.cert, &fx.cert)
+            .await
+            .expect("write cert");
+        tokio::fs::write(&paths.key, &fx.key)
+            .await
+            .expect("write key");
+        tokio::fs::write(&paths.ca, &fx.ca).await.expect("write ca");
+        paths
+    }
+
+    #[tokio::test]
+    async fn loads_valid_material() {
+        let dir = unique_dir("valid");
+        let fx = make_fixture("localhost");
+        let paths = write_fixture(&dir, &fx).await;
+
+        let reader = TlsMaterialReader::new(paths).await.expect("load");
+        let material = reader.current();
+        assert!(material.cert_pem().contains("BEGIN CERTIFICATE"));
+        assert!(material.ca_pem().contains("BEGIN CERTIFICATE"));
+        assert!(material.key_pem().expose_secret().contains("PRIVATE KEY"));
+
+        tokio::fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn missing_file_is_an_error() {
+        let dir = unique_dir("missing");
+        let paths = TlsPaths {
+            cert: dir.join("nope.crt"),
+            key: dir.join("nope.key"),
+            ca: dir.join("nope-ca.crt"),
+        };
+        match TlsMaterialReader::new(paths).await {
+            Err(TlsMaterialError::Read { .. }) => {}
+            _ => panic!("expected Read error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_file_is_an_error() {
+        let dir = unique_dir("empty");
+        let fx = make_fixture("localhost");
+        let paths = write_fixture(&dir, &fx).await;
+        tokio::fs::write(&paths.cert, "   \n").await.expect("blank");
+
+        match TlsMaterialReader::new(paths).await {
+            Err(TlsMaterialError::Empty { .. }) => {}
+            _ => panic!("expected Empty error"),
+        }
+        tokio::fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn non_pem_cert_is_rejected() {
+        // Load-time validation is PEM-structural (framing + base64); it is the
+        // fail-safe against an unreadable / empty / truncated / non-PEM file, so
+        // a rotation never swaps in obviously-bad material. Full X.509 structural
+        // validity is enforced by rustls at handshake time. A file with no PEM
+        // certificate block therefore yields `NoCertificate`.
+        let dir = unique_dir("nonpem");
+        let fx = make_fixture("localhost");
+        let paths = write_fixture(&dir, &fx).await;
+        tokio::fs::write(&paths.cert, "this is not a certificate\n")
+            .await
+            .expect("garbage");
+
+        assert!(
+            matches!(
+                TlsMaterialReader::new(paths).await,
+                Err(TlsMaterialError::NoCertificate {
+                    kind: "certificate",
+                    ..
+                })
+            ),
+            "expected NoCertificate(certificate)"
+        );
+        tokio::fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn malformed_key_is_rejected_without_leaking_bytes() {
+        // A malformed private key yields `InvalidKey`, and neither the error's
+        // Display nor its full source chain carries the key-file bytes.
+        let dir = unique_dir("badkey");
+        let fx = make_fixture("localhost");
+        let paths = write_fixture(&dir, &fx).await;
+        // No valid PRIVATE KEY PEM block ⇒ the key parser rejects it. The marker
+        // stands in for private-key bytes; it must not resurface via the error.
+        let secret_marker = "SUPERSECRETKEYBYTES";
+        tokio::fs::write(&paths.key, format!("not a private key {secret_marker}"))
+            .await
+            .expect("garbage key");
+
+        let err = TlsMaterialReader::new(paths)
+            .await
+            .expect_err("malformed key must be rejected");
+        assert!(
+            matches!(err, TlsMaterialError::InvalidKey { .. }),
+            "expected InvalidKey, got {err:?}"
+        );
+        // Walk Display, Debug, and the full source chain — none may leak bytes.
+        let mut rendered = format!("{err} || {err:?}");
+        let mut src = std::error::Error::source(&err);
+        while let Some(inner) = src {
+            rendered = format!("{rendered} || {inner}");
+            src = inner.source();
+        }
+        assert!(
+            !rendered.contains(secret_marker),
+            "key-file bytes must never appear in the error chain: {rendered}"
+        );
+        tokio::fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn debug_redacts_private_key() {
+        let dir = unique_dir("redact");
+        let fx = make_fixture("localhost");
+        let key_body = fx.key.clone();
+        let paths = write_fixture(&dir, &fx).await;
+
+        let reader = TlsMaterialReader::new(paths).await.expect("load");
+        let dbg = format!("{:?}", reader.current());
+        assert!(dbg.contains("<redacted>"), "debug must mark key redacted");
+        assert!(
+            !dbg.contains(key_body.trim()),
+            "debug must not leak the private-key PEM body"
+        );
+        tokio::fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn rotation_bumps_generation_only_on_change() {
+        let dir = unique_dir("rotate");
+        let fx1 = make_fixture("localhost");
+        let paths = write_fixture(&dir, &fx1).await;
+
+        let reader = TlsMaterialReader::with_refresh_interval(
+            paths.clone(),
+            Duration::from_millis(20),
+            None,
+        )
+        .await
+        .expect("load");
+        let mut rx = reader.subscribe();
+        assert_eq!(*rx.borrow(), 0);
+        let first = reader.current().cert_pem().to_owned();
+
+        // Unchanged re-reads must not tick the generation counter.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert_eq!(
+            *rx.borrow(),
+            0,
+            "unchanged material must not bump generation"
+        );
+
+        // Rotate to a fresh cert/key/ca.
+        let fx2 = make_fixture("localhost");
+        write_fixture(&dir, &fx2).await;
+
+        rx.changed().await.expect("generation should tick");
+        // At least one tick — `write_fixture` writes the three files separately,
+        // so an interval read can land on an intermediate state and bump the
+        // counter more than once before it settles.
+        assert!(
+            *rx.borrow() >= 1,
+            "generation should advance on a real rotation"
+        );
+        assert_ne!(
+            reader.current().cert_pem(),
+            first.as_str(),
+            "current material should reflect the rotation"
+        );
+
+        tokio::fs::remove_dir_all(&dir).await.ok();
+    }
+}


### PR DESCRIPTION
Implements ADR-0006's mTLS + SPIFFE end state at the framework layer so every out-of-process gear inherits transport confidentiality with no gear config. Framework-only (toolkit-transport-grpc + grpc-hub); TLS defaults to disabled, so plaintext h2c behavior is unchanged and every change is additive/backward-compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional mutual TLS (mTLS) support for gRPC clients and servers.
  * Added configurable certificate, private-key, and CA file settings with automatic certificate rotation.
  * Added secure client-certificate authentication using validated SPIFFE identities.
  * Added lazy channel creation for TLS-enabled connections.
* **Bug Fixes**
  * Invalid or incomplete TLS materials now fail safely without starting insecure connections.
  * Invalid certificate reloads retain the last known-good configuration.
* **Tests**
  * Added coverage for TLS setup, certificate validation, rotation, and end-to-end mTLS authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Deferred follow-ups (non-blocking)

Scoped to unblock cluster's out-of-process implementation; TLS defaults to `disabled` and the change is additive. The items below were raised in review and are tracked as **follow-up PRs**. None affects the security posture that ships (no plaintext downgrade, no auth bypass, no key/token leak):

1. **Live certificate rotation without a restart** (server + client) — the material is read once at serve/connect. Follow-up: a custom `ArcSwap` tokio-rustls acceptor/connector keyed off `TlsMaterialReader`'s generation counter (per-connection, no re-serve); interim option: a cert-expiry metric + alert. Safe now: the acceptor is built before the endpoint is advertised, and `build_channel_lazy` isn't consumed on this branch yet.
2. **Stronger load-time cert validation** — full X.509 parse + cert↔key match in `read_and_validate`. Safe now: a bad/mismatched pair is already caught when the acceptor / client config is built; the only unguarded path (`TlsMaterialReader` live-reload) isn't wired yet.
3. **Per-connection peer-cert resolution** — a connection-level interceptor (or cache) to avoid a per-RPC X.509 parse on the hot path.

**Already addressed in this PR from review:** mTLS identity is resolved independent of the token-auth mode (so an mTLS + disabled-token deployment still stamps the caller identity), and ambiguous / no-SPIFFE client certs fail closed.
