### PR TITLE
feat(toolkit-oop): lazy connect DirectoryService client

### DIFF
--- a/libs/system-sdks/sdks/directory/src/grpc/client.rs
+++ b/libs/system-sdks/sdks/directory/src/grpc/client.rs
@@ -14,7 +14,7 @@ use crate::api::{
 };
 use std::collections::BTreeMap;
 use toolkit_transport_grpc::InternalAuthInterceptor;
-use toolkit_transport_grpc::client::{GrpcClientConfig, connect_with_retry};
+use toolkit_transport_grpc::client::{GrpcClientConfig, connect_lazy, connect_with_retry};
 
 use crate::{
     DeregisterInstanceRequest, DirectoryServiceClient, GetOpenApiSpecRequest, GrpcServiceEndpoint,
@@ -109,6 +109,51 @@ impl DirectoryGrpcClient {
     ) -> Result<Self> {
         let cfg = GrpcClientConfig::new("directory");
         let channel: Channel = connect_with_retry(uri, &cfg).await?;
+        Ok(Self::from_channel_with_interceptor(channel, interceptor))
+    }
+
+    /// Create a directory client with a **lazily-connecting** channel.
+    ///
+    /// Performs **no** eager connection: the channel connects on the first RPC
+    /// and transparently reconnects on failure. This is the eventual-readiness
+    /// entry point (`cpt-cf-adr-eventual-readiness`) for `OoP` bootstrap — the
+    /// process starts even when the `DirectoryService` is not yet reachable, and
+    /// the presence loop's backoff retry absorbs the startup window instead of
+    /// the process crashing (which would offload retries onto a k8s
+    /// `CrashLoopBackOff`).
+    ///
+    /// # Runtime context
+    /// Must be called from within a Tokio runtime context: building the lazy
+    /// channel initialises the hyper reactor. Calling it outside a runtime
+    /// returns an error rather than panicking (it still does not connect).
+    ///
+    /// # Errors
+    /// Returns an error if called outside a Tokio runtime context, or if `uri`
+    /// is malformed — never for an unreachable peer.
+    pub fn connect_lazy(uri: impl Into<String>) -> Result<Self> {
+        let cfg = GrpcClientConfig::new("directory");
+        let channel: Channel = connect_lazy(uri, &cfg)?;
+        Ok(Self::from_channel(channel))
+    }
+
+    /// Create a directory client with a **lazily-connecting** channel, attaching
+    /// `interceptor`'s platform-plane credential to every outbound call.
+    ///
+    /// The lazy counterpart of [`connect_with_interceptor`](Self::connect_with_interceptor);
+    /// see [`connect_lazy`](Self::connect_lazy) for the connection semantics.
+    /// The URI is validated before `interceptor` is consumed, so the credential
+    /// is only moved into the client on success.
+    ///
+    /// # Errors
+    /// Returns an error only if `uri` is malformed — never for an unreachable
+    /// peer.
+    pub fn connect_lazy_with_interceptor(
+        uri: impl Into<String>,
+        interceptor: InternalAuthInterceptor,
+    ) -> Result<Self> {
+        let cfg = GrpcClientConfig::new("directory");
+        // Validate the URI (build the channel) before consuming `interceptor`.
+        let channel: Channel = connect_lazy(uri, &cfg)?;
         Ok(Self::from_channel_with_interceptor(channel, interceptor))
     }
 
@@ -467,6 +512,68 @@ mod tests {
         let _authed = DirectoryGrpcClient::from_channel_with_interceptor(
             channel,
             InternalAuthInterceptor::disabled(),
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_lazy_succeeds_against_unreachable_peer() {
+        // The lazy constructor performs no eager connect, so an OoP gear can
+        // build its directory client before the `DirectoryService` is up
+        // (`cpt-cf-adr-eventual-readiness`). Nothing is listening on port 1, yet
+        // both the plain and interceptor-bearing constructors return `Ok`.
+        let plain = DirectoryGrpcClient::connect_lazy("http://127.0.0.1:1");
+        assert!(
+            plain.is_ok(),
+            "connect_lazy must not eagerly connect (unreachable peer -> Ok)"
+        );
+
+        let authed = DirectoryGrpcClient::connect_lazy_with_interceptor(
+            "http://127.0.0.1:1",
+            InternalAuthInterceptor::disabled(),
+        );
+        assert!(
+            authed.is_ok(),
+            "connect_lazy_with_interceptor must not eagerly connect (unreachable peer -> Ok)"
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_lazy_rejects_malformed_uri() {
+        // A malformed endpoint is a static misconfiguration worth failing fast
+        // on — the only error path of the lazy constructors.
+        assert!(
+            DirectoryGrpcClient::connect_lazy(String::new()).is_err(),
+            "connect_lazy should fail on a malformed URI"
+        );
+        assert!(
+            DirectoryGrpcClient::connect_lazy_with_interceptor(
+                String::new(),
+                InternalAuthInterceptor::disabled(),
+            )
+            .is_err(),
+            "connect_lazy_with_interceptor should fail on a malformed URI"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_grpc_service_through_lazy_client_errors_not_hangs() {
+        // A lazy client builds against an unreachable directory; the first RPC
+        // returns a lookup/call error rather than hanging (outer timeout proves
+        // non-hang; nothing is listening on port 1).
+        let client =
+            DirectoryGrpcClient::connect_lazy("http://127.0.0.1:1").expect("lazy build ok");
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            client.resolve_grpc_service("cf.directory.v1.DirectoryService"),
+        )
+        .await;
+        assert!(
+            outcome.is_ok(),
+            "resolve_grpc_service through a lazy client must not hang against an unreachable peer"
+        );
+        assert!(
+            outcome.unwrap().is_err(),
+            "resolve_grpc_service against an unreachable directory must return Err"
         );
     }
 

--- a/libs/toolkit-transport-grpc/src/client.rs
+++ b/libs/toolkit-transport-grpc/src/client.rs
@@ -241,6 +241,63 @@ where
     .await
 }
 
+/// Build a **lazily-connecting** gRPC client channel.
+///
+/// Unlike [`connect_with_stack`] and [`connect_with_retry`], this performs **no**
+/// eager TCP/HTTP2 connection: it validates the URI, builds the transport stack,
+/// and returns immediately with a `Channel` that establishes (and transparently
+/// re-establishes) the connection on first use.
+///
+/// This is the eventual-readiness entry point (`cpt-cf-adr-eventual-readiness`):
+/// a process can start before its dependency is reachable. The first RPC absorbs
+/// the startup window (pair it with a caller-side retry loop), and tonic
+/// reconnects automatically after transient failures.
+///
+/// # Runtime context
+/// Must be called from within a Tokio runtime context (building the lazy
+/// `Channel` initialises the hyper reactor); this is enforced with a runtime
+/// check that returns `Err` rather than panicking when no runtime is active.
+///
+/// # Errors
+/// Returns an error if called outside a Tokio runtime context, or if `uri` is
+/// not a valid endpoint (parse failure). It never errors for an unreachable
+/// peer — that is deferred to the first RPC.
+pub fn connect_lazy<TClient>(
+    uri: impl Into<String>,
+    cfg: &GrpcClientConfig,
+) -> anyhow::Result<TClient>
+where
+    TClient: From<Channel>,
+{
+    // Building the lazy `Channel` initialises the hyper reactor, which panics
+    // outside a runtime; return an error instead.
+    if tokio::runtime::Handle::try_current().is_err() {
+        anyhow::bail!(
+            "connect_lazy for '{}' must be called within a Tokio runtime context",
+            cfg.service_name
+        );
+    }
+
+    let uri_string = uri.into();
+    let endpoint = build_endpoint(uri_string, cfg)?;
+    let channel = endpoint.connect_lazy();
+
+    if cfg.enable_tracing {
+        // Logged at `info!` to match `connect_with_stack`: lazy creation is
+        // significant because connectivity was not verified at startup.
+        let connect_timeout_ms = duration_to_i64_ms(cfg.connect_timeout);
+        let rpc_timeout_ms = duration_to_i64_ms(cfg.rpc_timeout);
+        tracing::info!(
+            service_name = cfg.service_name,
+            connect_timeout_ms,
+            rpc_timeout_ms,
+            "gRPC client created (lazy connect; connects on first use)"
+        );
+    }
+
+    Ok(TClient::from(channel))
+}
+
 /// Connect to a gRPC service with retry logic using exponential backoff and jitter.
 ///
 /// This function attempts to establish a connection and retries on failure
@@ -411,5 +468,73 @@ mod tests {
         let cfg = GrpcClientConfig::default();
         let result = build_endpoint(String::new(), &cfg);
         assert!(result.is_err(), "build_endpoint should fail with empty URI");
+    }
+
+    #[tokio::test]
+    async fn test_connect_lazy_does_not_connect_eagerly() {
+        // A lazy channel must succeed even against an address nothing is
+        // listening on: no eager TCP connect happens, so an unreachable peer
+        // cannot fail bootstrap (`cpt-cf-adr-eventual-readiness`). The connect
+        // is deferred to the first RPC. (`connect_lazy` still needs a Tokio
+        // runtime context for the hyper reactor, which OoP bootstrap always
+        // has.)
+        let cfg = GrpcClientConfig::default();
+        let result: anyhow::Result<Channel> = connect_lazy("http://127.0.0.1:1", &cfg);
+        assert!(
+            result.is_ok(),
+            "connect_lazy must return Ok for an unreachable peer (no eager connect)"
+        );
+    }
+
+    #[test]
+    fn test_connect_lazy_outside_runtime_errors() {
+        // A plain `#[test]` has no runtime active, so the guard returns `Err`
+        // instead of panicking on the hyper reactor init.
+        let cfg = GrpcClientConfig::default();
+        let result: anyhow::Result<Channel> = connect_lazy("http://127.0.0.1:1", &cfg);
+        assert!(
+            result.is_err(),
+            "connect_lazy must return Err when called outside a Tokio runtime"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_connect_lazy_rpc_to_unreachable_peer_errors() {
+        use tower::ServiceExt as _;
+
+        // A lazy channel builds fine, but the first RPC against an unreachable
+        // peer must error rather than hang. Short connect timeout keeps it
+        // fast; the outer timeout proves non-hang.
+        let cfg = GrpcClientConfig::default().with_connect_timeout(Duration::from_millis(200));
+        let channel: Channel = connect_lazy("http://127.0.0.1:1", &cfg).expect("lazy build ok");
+
+        let req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri("http://127.0.0.1:1/test.Service/Method")
+            .header("content-type", "application/grpc")
+            .body(tonic::body::Body::empty())
+            .expect("request builds");
+
+        let outcome = tokio::time::timeout(Duration::from_secs(5), channel.oneshot(req)).await;
+        assert!(
+            outcome.is_ok(),
+            "RPC through a lazy channel must not hang against an unreachable peer"
+        );
+        assert!(
+            outcome.unwrap().is_err(),
+            "RPC to an unreachable peer must surface a transport error"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_connect_lazy_rejects_malformed_uri() {
+        // The only failure mode of a lazy connect is a malformed endpoint,
+        // which is a static config error worth failing fast on.
+        let cfg = GrpcClientConfig::default();
+        let result: anyhow::Result<Channel> = connect_lazy(String::new(), &cfg);
+        assert!(
+            result.is_err(),
+            "connect_lazy should fail fast on a malformed URI"
+        );
     }
 }

--- a/libs/toolkit/src/bootstrap/oop.rs
+++ b/libs/toolkit/src/bootstrap/oop.rs
@@ -7,7 +7,9 @@
 //!
 //! - Configuration loading using `toolkit-bootstrap`
 //! - Logging initialization with tracing
-//! - gRPC connection to `DirectoryService`
+//! - Lazy gRPC client to the `DirectoryService` (connects on first use, so a
+//!   cold `DirectoryService` never blocks or crashes bootstrap —
+//!   `cpt-cf-adr-eventual-readiness`)
 //! - Gear instance registration
 //! - Heartbeat management
 //! - Gear lifecycle execution
@@ -352,8 +354,9 @@ fn merge_json_objects(target: &mut serde_json::Value, source: &serde_json::Value
 /// 1. Creates a root `CancellationToken` for the process
 /// 2. Hooks OS signals (SIGTERM, SIGINT, Ctrl+C) to trigger cancellation
 /// 3. Loads configuration and initializes logging
-/// 4. Connects to the `DirectoryService`
-/// 5. Registers the gear instance
+/// 4. Creates a lazy `DirectoryService` client (connects on first use, not at
+///    bootstrap — `cpt-cf-adr-eventual-readiness`)
+/// 5. Registers the gear instance (background presence loop, with backoff)
 /// 6. Starts a background heartbeat loop (using a child token)
 /// 7. Runs the gear lifecycle with `ShutdownOptions::Token`
 /// 8. Deregisters from `DirectoryService` on shutdown
@@ -534,37 +537,35 @@ pub async fn run_oop_with_options(opts: OopRunOptions) -> Result<()> {
         return Ok(());
     }
 
-    // Connect to DirectoryService. When the gear configures a platform-plane
-    // credential, attach it (as `x-toolkit-internal-token`) to every outbound
-    // system call via an InternalAuthInterceptor (`cpt-cf-adr-two-plane-auth`).
+    // Create the DirectoryService client on a LAZY channel. Per
+    // `cpt-cf-adr-eventual-readiness`, an OoP gear must start even when the
+    // DirectoryService is not yet reachable; blocking or crashing on it at
+    // bootstrap would make it a hard startup dependency (the SPOF the ADR
+    // rejects). A lazy channel performs no eager connection: it fails fast only
+    // on a malformed endpoint and defers the connect to the first RPC.
+    //
+    // Recovery from a cold directory differs by lifecycle:
+    // - `oop_http` configured: the presence loop retries registration with
+    //   exponential backoff (100ms -> 30s, forever).
+    // - Legacy path (no `oop_http`): only a fixed-interval heartbeat runs, with
+    //   no registration retry — it relies on an external orchestrator.
+    //
+    // When a platform-plane credential is configured, it is attached (as
+    // `x-toolkit-internal-token`) to outbound system calls via an
+    // InternalAuthInterceptor (`cpt-cf-adr-two-plane-auth`).
     info!(
-        "Connecting to directory service at {}",
+        "Creating directory service client (lazy connect) for {}",
         opts.directory_endpoint
     );
     let internal_auth_cfg = final_config
         .oop_http
         .as_ref()
         .and_then(|h| h.internal_auth.as_ref());
-    // Build the outbound DirectoryService interceptor and the
-    // `InternalTokenProvider` (for `#[toolkit::provides]` clients) from one
-    // credential source so they can't diverge after a rotation — see
-    // `build_platform_credentials`. `None` => no outbound platform credential.
-    let (directory_client, internal_token_provider) = if let Some(cfg) = internal_auth_cfg {
-        let (interceptor, provider) = build_platform_credentials(cfg, &cancel).await?;
-        info!("Attaching platform-plane credential to outbound DirectoryService calls");
-        let client =
-            DirectoryGrpcClient::connect_with_interceptor(&opts.directory_endpoint, interceptor)
-                .await?;
-        (client, provider)
-    } else {
-        (
-            DirectoryGrpcClient::connect(&opts.directory_endpoint).await?,
-            None,
-        )
-    };
+    let (directory_client, internal_token_provider) =
+        build_directory_client(&opts.directory_endpoint, internal_auth_cfg, &cancel).await?;
     let directory_api: Arc<dyn DirectoryClient> = Arc::new(directory_client);
 
-    info!("Successfully connected to directory service");
+    info!("Directory service client ready (will connect on first use)");
 
     // Capture OoP HTTP config (if any) before moving the config into the provider.
     let oop_http = final_config.oop_http.clone();
@@ -759,6 +760,47 @@ async fn build_internal_authenticator(
     anyhow::bail!(
         "internal_auth is configured but no authenticator could be built for the selected provider"
     )
+}
+
+/// Build the `OoP` gear's `DirectoryService` client on a **lazy** channel, plus
+/// the outbound
+/// [`InternalTokenProvider`](toolkit_contract::runtime::config::InternalTokenProvider)
+/// when a platform-plane credential is configured (`None` => no credential).
+///
+/// The lazy channel performs no eager connection, so this succeeds even when
+/// `directory_endpoint` is unreachable (`cpt-cf-adr-eventual-readiness`).
+/// Interceptor and provider come from one credential source (see
+/// [`build_platform_credentials`]) so they can't diverge after a rotation.
+///
+/// # Errors
+/// Only if the endpoint is malformed or a configured credential source fails to
+/// initialise — never for an unreachable directory. The endpoint is validated
+/// before any credential work, so a malformed endpoint is reported ahead of a
+/// credential-source failure.
+async fn build_directory_client(
+    directory_endpoint: &str,
+    internal_auth_cfg: Option<&toolkit_security::InternalAuthConfig>,
+    cancel: &CancellationToken,
+) -> Result<(
+    DirectoryGrpcClient,
+    Option<toolkit_contract::runtime::config::InternalTokenProvider>,
+)> {
+    // Validate the endpoint up front — before any credential-source work — so a
+    // malformed endpoint is reported ahead of a credential failure. The lazy
+    // client performs no connection, only URI validation; it is reused as-is on
+    // the no-credential path.
+    let client = DirectoryGrpcClient::connect_lazy(directory_endpoint)?;
+
+    let Some(cfg) = internal_auth_cfg else {
+        return Ok((client, None));
+    };
+
+    let (interceptor, provider) = build_platform_credentials(cfg, cancel).await?;
+    // Rebuild with the interceptor attached (it must be set at construction);
+    // the endpoint was already validated above.
+    let client =
+        DirectoryGrpcClient::connect_lazy_with_interceptor(directory_endpoint, interceptor)?;
+    Ok((client, provider))
 }
 
 /// Build the platform-plane credential material from config: the **outbound**

--- a/libs/toolkit/src/bootstrap/oop_tests.rs
+++ b/libs/toolkit/src/bootstrap/oop_tests.rs
@@ -967,3 +967,93 @@ mod platform_credentials {
         );
     }
 }
+
+/// Tests for `build_directory_client`: the bootstrap slice that must build a
+/// `DirectoryService` client even when the directory is unreachable
+/// (`cpt-cf-adr-eventual-readiness`).
+mod directory_client_bootstrap {
+    use super::*;
+    use cf_system_sdks::directory::DirectoryClient;
+    use tokio_util::sync::CancellationToken;
+    use toolkit_security::InternalAuthConfig;
+
+    #[tokio::test]
+    async fn builds_against_unreachable_directory_without_credential() {
+        // Nothing is listening on port 1, yet the client builds: bootstrap is
+        // not blocked on directory reachability.
+        let (client, provider) =
+            build_directory_client("http://127.0.0.1:1", None, &CancellationToken::new())
+                .await
+                .expect("lazy directory client must build against an unreachable directory");
+        assert!(
+            provider.is_none(),
+            "no internal_auth => no outbound credential"
+        );
+
+        // The deferred connect surfaces as an RPC error, not a hang.
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(5),
+            client.resolve_grpc_service("cf.directory.v1.DirectoryService"),
+        )
+        .await;
+        assert!(outcome.is_ok(), "first RPC must not hang");
+        assert!(
+            outcome.unwrap().is_err(),
+            "first RPC to an unreachable directory must return Err"
+        );
+    }
+
+    #[tokio::test]
+    async fn builds_against_unreachable_directory_with_credential() {
+        // Same guarantee on the credentialed path: the client still builds and
+        // a configured credential yields an outbound provider.
+        let cfg = InternalAuthConfig::SharedSecret {
+            secret: "shared-tok".to_owned(),
+            peer_name: "toolkit-internal".to_owned(),
+        };
+        let (_client, provider) =
+            build_directory_client("http://127.0.0.1:1", Some(&cfg), &CancellationToken::new())
+                .await
+                .expect("credentialed lazy client must build against an unreachable directory");
+        assert!(
+            provider.is_some(),
+            "shared secret must yield an outbound token provider"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_malformed_endpoint() {
+        // A malformed endpoint must still fail fast.
+        assert!(
+            build_directory_client("", None, &CancellationToken::new())
+                .await
+                .is_err(),
+            "a malformed directory endpoint must fail fast"
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_endpoint_is_reported_before_credential_failure() {
+        // Both inputs are broken: a malformed endpoint AND a kube token_path
+        // that does not exist. The endpoint is validated first, so the error is
+        // the endpoint error — never the credential one (which would otherwise
+        // mask the misconfigured endpoint).
+        let cfg = InternalAuthConfig::Kube {
+            audiences: vec!["toolkit-internal".to_owned()],
+            token_path: Some(
+                std::env::temp_dir()
+                    .join("cf-oop-missing-token-regression")
+                    .join("token"),
+            ),
+        };
+        let Err(err) = build_directory_client("", Some(&cfg), &CancellationToken::new()).await
+        else {
+            panic!("a malformed endpoint must fail");
+        };
+        let msg = format!("{err:#}");
+        assert!(
+            !msg.contains("service-account token"),
+            "endpoint must be validated before credential work; got credential error: {msg}"
+        );
+    }
+}


### PR DESCRIPTION
OoP bootstrap eagerly connected to the DirectoryService via `DirectoryGrpcClient::connect[_with_interceptor]`, which blocked (and on failure crashed) startup when the directory was not yet reachable - making it a hard startup dependency and offloading retries onto k8s `CrashLoopBackOff`. This violates `cpt-cf-adr-eventual-readiness`.
 
Add lazy-connecting constructors that build the channel without an eager TCP/HTTP2 connect, deferring the actual connection to the first RPC where the background presence loop's exponential backoff absorbs the startup window; tonic reconnects transparently after transient failures.
 
 Changes:
- `toolkit-transport-grpc`: add `connect_lazy()` (no eager connect, fails fast only on a malformed URI)
- directory SDK: add `DirectoryGrpcClient::connect_lazy[_with_interceptor]`
- `toolkit/bootstrap/oop.rs`: use the lazy client so gears start immediately even against a cold DirectoryService

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lazy gRPC connection support for directory services.
  * Connections begin on the first request and reconnect automatically when needed.
  * Invalid service addresses still report errors immediately.

* **Bug Fixes**
  * Startup no longer fails or blocks when the directory service is temporarily unreachable.
  * Background retries handle unavailable directory services with exponential backoff.

* **Documentation**
  * Updated startup documentation and status messages to clarify lazy connection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->