### PR TITLE
docs(pr-review): enrich Rust checklist from external guidelines, add Windsurf parity

### DIFF
--- a/.claude/agents/toolkit-pr-review-v2-tests.md
+++ b/.claude/agents/toolkit-pr-review-v2-tests.md
@@ -1,6 +1,6 @@
 ---
 name: toolkit-pr-review-v2-tests
-description: "Test quality review sub-agent for toolkit-pr-review-v2. Covers RUST-TEST-001 and 8 test anti-patterns. Returns JSON array only."
+description: "Test quality review sub-agent for toolkit-pr-review-v2. Covers RUST-TEST-001 and 9 test anti-patterns. Returns JSON array only."
 tools: Read, Bash
 model: inherit
 ---

--- a/.claude/skills/toolkit-pr-review-v2/SKILL.md
+++ b/.claude/skills/toolkit-pr-review-v2/SKILL.md
@@ -137,8 +137,12 @@ Save the diff output for analysis.
 
 ### Step 2: Identify Rust files in diff
 
-Parse the diff to find all `.rs` files that were added or modified.
-For each file, note the changed line ranges (added lines only — you can only comment on lines present in the diff).
+Parse the diff to find all `.rs` files that were added, modified, or deleted.
+For added/modified files, note the changed line ranges (added lines only — you can only comment on lines present in the diff).
+
+Also record, per file, a **deletion anchor** for every hunk that removes lines with no added replacement in that hunk (a "pure deletion" hunk in a file that still exists at the review head) — needed so a finding about a partially deleted test (e.g. `TEST-QUALITY-9`) still has a valid line to anchor on. The anchor is the hunk's `newStart` value from its `@@ -oldStart,oldCount +newStart,newCount @@` header — the nearest surviving line in the new file at the deletion point. If `newStart` is `0`, use line `1`; if it falls past the end of the file, use the file's last line.
+
+For a `.rs` file **deleted entirely** (present in the base, absent at the review head — its diff hunk targets `/dev/null`), include its path in `rust_files` too, but track it separately in a `deleted_files` list. A deleted file has **no** RIGHT-side line at all, so do not compute `changed_ranges` or a `deletion_anchors` entry for it — see Step 4a for how its content is snapshotted and Step 5 for how findings on it are posted.
 
 ### Step 3: Read review guidelines and classify files
 
@@ -169,22 +173,30 @@ Write `/tmp/toolkit-pr-review-v2-$REVIEW_ID/context.json` with the metadata, fil
   "branch": "<BRANCH_NAME, or null in PR mode>",
   "base_branch": "<BASE_BRANCH, or null in PR mode>",
   "head_sha": "<HEAD_SHA>",
-  "rust_files": [<list of .rs files from Step 2>],
+  "rust_files": [<list of .rs files from Step 2, including deleted files>],
+  "deleted_files": [<subset of rust_files deleted entirely — no RIGHT-side content>],
   "toolkit_owned_files": [<files classified as ToolKit-owned in Step 3>],
-  "has_test_code": <boolean: true if any rust_files contains #[test], #[tokio::test], #[cfg(test)], or lives under tests/>,
+  "has_test_code": <boolean: true if any rust_files contains #[test], #[tokio::test], #[cfg(test)], or lives under tests/ — for deleted_files, check their base-side content instead of the (nonexistent) head content>,
   "changed_ranges": {
     "<filepath>": [[<start_line>, <end_line>], ...]
+  },
+  "deletion_anchors": {
+    "<filepath>": [<line>, ...]
   }
 }
 ```
 
 The `changed_ranges` dict maps each file to its list of changed line ranges (derived from parsing diff hunks in Step 2). Agents use this to validate that line numbers are within the diff.
 
-For each file in `rust_files`, read the file at the review head (the PR head commit in PR mode, `$BRANCH_NAME` in local mode) and write its full content to:
+The `deletion_anchors` dict maps each file to the pure-deletion-hunk anchor lines from Step 2. It is a secondary, narrower set of valid line targets — used only for findings about content partially removed from a file that still exists (no added line exists to anchor on), such as `TEST-QUALITY-9`. Omit a file's entry (or use `[]`) when it has no pure-deletion hunks. **Files listed in `deleted_files` never get an entry here** — they have no RIGHT-side line to anchor on at all; see Step 5 for how findings on them are posted instead.
+
+For each file in `rust_files` that is **not** in `deleted_files`, read the file at the review head (the PR head commit in PR mode, `$BRANCH_NAME` in local mode) and write its full content to:
 ```text
 /tmp/toolkit-pr-review-v2-$REVIEW_ID/files/<escaped-path>
 ```
-where `<escaped-path>` replaces `/` with `__` (e.g., `gears/foo/src/service.rs` → `gears__foo__src__service.rs`).
+For each file **in** `deleted_files`, read it instead at the base commit (the PR's base SHA in PR mode, the merge-base with `$BASE_BRANCH` in local mode) and write that pre-deletion content to the same path — this lets Agent F see what was removed.
+
+`<escaped-path>` replaces `/` with `__` (e.g., `gears/foo/src/service.rs` → `gears__foo__src__service.rs`).
 
 ### Step 4b: Spawn parallel sub-agents
 
@@ -211,7 +223,7 @@ Check IDs: TOOLKIT-CORE-001, TOOLKIT-CORE-002, TOOLKIT-CORE-003, TOOLKIT-REST-00
 (Gated: skip if toolkit_owned_files is empty)
 
 **Agent F — Test Quality** (`toolkit-pr-review-v2-tests`):
-Check IDs: RUST-TEST-001, TEST-QUALITY-1 through TEST-QUALITY-8
+Check IDs: RUST-TEST-001, TEST-QUALITY-1 through TEST-QUALITY-9
 (Gated: skip if has_test_code is false)
 
 Each agent returns a JSON array of findings. See `docs/pr-review/agents/toolkit-pr-review-v2-<name>.md` for detailed prompt structure.
@@ -227,7 +239,8 @@ Wait for all Agent calls to complete. For each result:
 Deduplicate: drop any finding where `(file, line, id)` duplicates an earlier finding.
 
 Apply filter rules:
-- Drop findings where `line` is not in `changed_ranges[file]` for that file.
+- For a finding whose `file` is in `deleted_files`: keep it regardless of `line` (it has none — it posts as a file-level comment in Step 5).
+- For every other finding: drop it if `line` is not in `changed_ranges[file]` and not in `deletion_anchors[file]` for that file.
 - Drop style-only issues that rustfmt or clippy should catch.
 - Drop speculative or hypothetical findings (containing phrases like "might", "could consider", "may want to").
 
@@ -241,7 +254,22 @@ This merged, filtered, sorted, capped list becomes the input to Step 5.
 
 Local mode skips this step entirely — go to Step 5L.
 
-Use `gh api` to create a pull request review with inline comments.
+Split the merged findings into two groups:
+- **Line-anchored findings** — `file` not in `deleted_files`. Post together in one review (below).
+- **File-level findings** — `file` in `deleted_files`. A deleted file has no RIGHT-side line, so these cannot go in the batch review's `comments` array (which requires `line`+`side`). Post each individually via the single-comment endpoint with `subject_type: "file"` and no `line`/`side`:
+
+```bash
+gh api repos/$REPO/pulls/<PR_NUMBER>/comments \
+  --method POST \
+  -f commit_id="<HEAD_SHA>" \
+  -f path="gears/foo/src/tests.rs" \
+  -f subject_type="file" \
+  -f body="**HIGH**\n\nTest `send_dead_letter_on_timeout` was deleted with no follow-up.\n\nRestore the test or open a tracked issue and link it here."
+```
+
+Post these after the batch review below. If there are zero findings in both groups, skip straight to the "zero findings" review call.
+
+Use `gh api` to create a pull request review with the line-anchored inline comments.
 
 Build the review payload:
 
@@ -271,7 +299,9 @@ gh api repos/$REPO/pulls/<PR_NUMBER>/reviews \
   --input /tmp/review-payload.json
 ```
 
-If there are zero findings, skip the payload above and post a single review whose
+If there are zero line-anchored findings but at least one file-level finding, skip this review call and post only the file-level comments above.
+
+If there are zero findings in both groups, skip the payload above and post a single review whose
 `body` carries the message instead of an inline comment:
 
 ```bash
@@ -327,7 +357,7 @@ Structure:
 Rules for the report:
 - One severity section per severity present. Omit empty sections.
 - Findings keep the same wording discipline as inline comments (see [Comment formatting rules](#comment-formatting-rules)) — but the checklist ID **is** included here, since there is no separate terminal-only table.
-- File paths are repo-relative and include the line number, so they are clickable.
+- File paths are repo-relative and include the line number, so they are clickable. Exception: a finding whose `file` is in `deleted_files` has no line — render just the file path (e.g. `` `gears/foo/src/tests.rs` ``).
 - If there are zero findings, write the header plus a single line: `No issues found.`
 
 ### Step 6: Print summary
@@ -343,6 +373,9 @@ After posting (PR mode) or writing the file (local mode), print a compact summar
 |---|----|-----|----------|-------|-----|
 | 1 | RUST-ERR-001 | HIGH | service.rs:42 | Error context lost | Preserve source error |
 | 2 | TOOLKIT-SEC-001 | CRIT | handler.rs:18 | Raw DB connection | Use SecureConn |
+| 3 | TEST-QUALITY-9 | HIGH | tests.rs | Test deleted, no follow-up | Restore or track |
+
+For a finding whose `file` is in `deleted_files`, the Location column shows just the file path (no `:<line>`), since it was posted as a file-level comment.
 
 Posted <N> inline comments on PR #<PR_NUMBER>.
 ```
@@ -378,7 +411,7 @@ Rules:
 - No "consider", "you might want to", "it would be nice if". State what is wrong and what to do.
 - One issue per comment. If a line has two problems, post two comments.
 - Line number must point to an added/modified line that exists in the diff. Do not comment on unchanged lines.
-- If you cannot determine the exact line, do not guess — skip that finding.
+- If you cannot determine the exact line, do not guess — skip that finding. Exception: a finding on a file in `deleted_files` has no line by design — post it as a file-level comment (see Step 5), don't skip it and don't force a line onto it.
 
 ---
 

--- a/.devin/workflows/toolkit-pr-review-v2.md
+++ b/.devin/workflows/toolkit-pr-review-v2.md
@@ -1,5 +1,5 @@
 ---
-description: Review a GitHub PR for Rust + ToolKit compliance. Runs 6 specialized agents in parallel, then posts inline comments.
+description: Review a GitHub PR for Rust + ToolKit compliance. Runs up to 6 specialized agents in parallel (some are skipped based on repository conditions), then posts inline comments.
 ---
 
 # ToolKit PR Review
@@ -44,7 +44,7 @@ If `--repo` was passed as an argument, use that value instead. Store as `REPO`.
 PR_NUMBER=<PR_NUMBER>
 mkdir -p /tmp/toolkit-pr-review-v2-${PR_NUMBER}/files
 gh pr view ${PR_NUMBER} --repo ${REPO} \
-  --json number,title,body,headRefOid,baseRefName,headRefName \
+  --json number,title,body,headRefOid,baseRefOid,baseRefName,headRefName \
   > /tmp/toolkit-pr-review-v2-${PR_NUMBER}/meta.json
 gh pr diff ${PR_NUMBER} --repo ${REPO} \
   > /tmp/toolkit-pr-review-v2-${PR_NUMBER}/diff.patch
@@ -55,13 +55,15 @@ echo "HEAD SHA: $(jq -r .headRefOid /tmp/toolkit-pr-review-v2-${PR_NUMBER}/meta.
 
 Parse `/tmp/toolkit-pr-review-v2-${PR_NUMBER}/diff.patch` to extract:
 
-- **`rust_files`** — all added/modified `.rs` files (strip `a/`/`b/` prefix)
-- **`changed_ranges`** — per-file list of `[start, end]` line ranges from diff hunks
+- **`rust_files`** — all added, modified, or deleted `.rs` files (strip `a/`/`b/` prefix)
+- **`deleted_files`** — subset of `rust_files` whose diff hunk targets `/dev/null` on the new side (deleted entirely). These have no RIGHT-side line at all — no `changed_ranges` or `deletion_anchors` entry is computed for them; see Step 4 (base-side snapshot) and Step 7 (file-level comment).
+- **`changed_ranges`** — per-file list of `[start, end]` line ranges from diff hunks (added lines only; empty for files in `deleted_files`)
+- **`deletion_anchors`** — per-file list of anchor lines for pure-deletion hunks in a file that still exists (hunks that remove lines with no added replacement). The anchor is the hunk's `newStart` from its `@@ -oldStart,oldCount +newStart,newCount @@` header (clamp to line `1` if `0`, or the file's last line if past EOF). Needed so a finding about a partially deleted test (e.g. `TEST-QUALITY-9`) still has a valid line to anchor on.
 - **`toolkit_owned_files`** — subset of `rust_files` where **any** of these signals is present:
   - nearest `Cargo.toml` declares `toolkit` dependency/feature, or crate name starts with `toolkit`
   - file path matches `libs/toolkit*/`, `gears/*/src/`
   - source imports `use toolkit_*` or references `OperationBuilder`, `SecureConn`, `SecureORM`, `ClientHub`, `GearLifecycle`
-- **`has_test_code`** — `true` if any file contains `#[test]`, `#[tokio::test]`, or `#[cfg(test)]`
+- **`has_test_code`** — `true` if `diff.patch` contains `#[test]`, `#[tokio::test]`, or `#[cfg(test)]` on **any** line (added or removed) — scanning the raw diff, not just head-side file content, so a wholesale-deleted test file still sets this `true`
 
 ## Step 4: Write context and file snapshots
 
@@ -74,15 +76,23 @@ cat > /tmp/toolkit-pr-review-v2-${PR_NUMBER}/context.json << 'EOF'
   "repo": "<REPO>",
   "head_sha": "<HEAD_SHA>",
   "rust_files": [],
+  "deleted_files": [],
   "toolkit_owned_files": [],
   "has_test_code": false,
-  "changed_ranges": {}
+  "changed_ranges": {},
+  "deletion_anchors": {}
 }
 EOF
 
-# For each rust file, fetch content at HEAD and write to files/ with / replaced by __
+# For each rust file NOT in deleted_files, fetch content at HEAD and write to files/ with / replaced by __
 # Example:
 # gh api repos/${REPO}/contents/path/to/file.rs?ref=<HEAD_SHA> -q .content \
+#   | base64 -d > /tmp/toolkit-pr-review-v2-${PR_NUMBER}/files/path__to__file.rs
+
+# For each file IN deleted_files, fetch its pre-deletion content at the base commit instead
+# (BASE_SHA = baseRefOid from meta.json) — the file no longer exists at HEAD_SHA:
+# BASE_SHA=$(jq -r .baseRefOid /tmp/toolkit-pr-review-v2-${PR_NUMBER}/meta.json)
+# gh api repos/${REPO}/contents/path/to/file.rs?ref=${BASE_SHA} -q .content \
 #   | base64 -d > /tmp/toolkit-pr-review-v2-${PR_NUMBER}/files/path__to__file.rs
 ```
 
@@ -161,23 +171,28 @@ for name in order:
     except Exception as e:
         print(f"WARNING: {name}: {e}", file=sys.stderr)
 
-# Load changed_ranges for line validation
+# Load changed_ranges / deletion_anchors / deleted_files for line validation
 ctx = json.load(open(f"/tmp/toolkit-pr-review-v2-{PR_NUMBER}/context.json"))
 ranges = ctx.get("changed_ranges", {})
+deletion_anchors = ctx.get("deletion_anchors", {})
+deleted_files = set(ctx.get("deleted_files", []))
 
 def in_range(file, line):
     for start, end in ranges.get(file, []):
         if start <= line <= end:
             return True
-    return False
+    # TEST-QUALITY-9 findings on partially deleted content may anchor here instead
+    return line in deletion_anchors.get(file, [])
 
-# Deduplicate by (file, line, id), validate line in diff
+# Deduplicate by (file, line, id), validate line in diff.
+# A finding on a fully deleted file has no line at all (it posts as a
+# file-level comment in Step 7) and skips the line check entirely.
 seen, filtered = set(), []
 for f in combined:
-    key = (f["file"], f["line"], f["id"])
+    key = (f["file"], f.get("line"), f["id"])
     if key in seen:
         continue
-    if not in_range(f["file"], f["line"]):
+    if f["file"] not in deleted_files and not in_range(f["file"], f.get("line")):
         continue
     seen.add(key)
     filtered.append(f)
@@ -208,6 +223,15 @@ import json, os
 PR_NUMBER = os.environ["PR_NUMBER"]
 HEAD_SHA = os.environ["HEAD_SHA"]
 findings = json.load(open(f"/tmp/toolkit-pr-review-v2-{PR_NUMBER}/findings.json"))
+ctx = json.load(open(f"/tmp/toolkit-pr-review-v2-{PR_NUMBER}/context.json"))
+deleted_files = set(ctx.get("deleted_files", []))
+
+# A deleted file has no RIGHT-side line, so its findings can't go in the
+# batch review's `comments` array (which requires line+side). Post those
+# individually via the single-comment endpoint with subject_type="file".
+line_findings = [f for f in findings if f["file"] not in deleted_files]
+file_findings = [f for f in findings if f["file"] in deleted_files]
+
 comments = [
     {
         "path": f["file"],
@@ -215,28 +239,45 @@ comments = [
         "side": "RIGHT",
         "body": f"**{f['severity']}**\n\n{f['issue']}\n\n{f['fix']}"
     }
-    for f in findings
+    for f in line_findings
 ]
 payload = {
     "commit_id": HEAD_SHA,
     "event": "COMMENT",
     "body": "",
-    "comments": comments if comments else []
+    "comments": comments
 }
 json.dump(payload, open("/tmp/review-payload.json", "w"))
-print(f"Prepared {len(comments)} comments")
+json.dump(file_findings, open("/tmp/file-level-findings.json", "w"))
+print(f"Prepared {len(comments)} line comments, {len(file_findings)} file-level comments")
 PY
 
-if [ $(jq '.comments | length' /tmp/review-payload.json) -eq 0 ]; then
+LINE_COUNT=$(jq '.comments | length' /tmp/review-payload.json)
+FILE_COUNT=$(jq 'length' /tmp/file-level-findings.json)
+
+if [ "$LINE_COUNT" -eq 0 ] && [ "$FILE_COUNT" -eq 0 ]; then
   gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews \
     --method POST \
     -f commit_id="${HEAD_SHA}" \
     -f event="COMMENT" \
     -f body="No issues found."
 else
-  gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews \
-    --method POST \
-    --input /tmp/review-payload.json
+  if [ "$LINE_COUNT" -gt 0 ]; then
+    gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews \
+      --method POST \
+      --input /tmp/review-payload.json
+  fi
+  # File-level comments: a deleted file has no RIGHT-side line to anchor on.
+  jq -c '.[]' /tmp/file-level-findings.json | while read -r finding; do
+    path=$(echo "$finding" | jq -r '.file')
+    body=$(echo "$finding" | jq -r '"**" + .severity + "**\n\n" + .issue + "\n\n" + .fix')
+    gh api repos/${REPO}/pulls/${PR_NUMBER}/comments \
+      --method POST \
+      -f commit_id="${HEAD_SHA}" \
+      -f path="${path}" \
+      -f subject_type="file" \
+      -f body="${body}"
+  done
 fi
 ```
 
@@ -252,7 +293,8 @@ print(f"\n## Rust PR Review: #{PR_NUMBER}\n")
 print("| # | ID | Sev | Location | Issue | Fix |")
 print("|---|----|-----|----------|-------|-----|")
 for i, f in enumerate(findings, 1):
-    loc = f"{f['file'].split('/')[-1]}:{f['line']}"
+    name = f['file'].split('/')[-1]
+    loc = f"{name}:{f['line']}" if f.get('line') else name
     print(f"| {i} | {f['id']} | {f['severity']} | {loc} | {f['issue'][:60]} | {f['fix'][:60]} |")
 print(f"\nPosted {len(findings)} inline comments on PR #{PR_NUMBER}.")
 PY

--- a/.windsurf/workflows/toolkit-pr-review-v2.md
+++ b/.windsurf/workflows/toolkit-pr-review-v2.md
@@ -1,0 +1,11 @@
+---
+description: Review a GitHub PR for Rust + ToolKit compliance. Runs up to 6 specialized agents in parallel (some are skipped based on repository conditions), then posts inline comments.
+---
+
+# ToolKit PR Review
+
+Review a GitHub PR for Rust + ToolKit compliance and post inline comments.
+
+ALWAYS open and follow `.claude/skills/toolkit-pr-review-v2/SKILL.md`.
+
+Usage: `/toolkit-pr-review-v2 <PR_NUMBER> [--repo <owner/repo>]`

--- a/.windsurf/workflows/toolkit-pr-review.md
+++ b/.windsurf/workflows/toolkit-pr-review.md
@@ -1,0 +1,7 @@
+# /toolkit-pr-review
+
+Review a GitHub PR for Rust + ToolKit compliance and post inline comments.
+
+ALWAYS open and follow `.claude/skills/toolkit-pr-review/SKILL.md`.
+
+Usage: `/toolkit-pr-review <PR_NUMBER> [--repo <owner/repo>]`

--- a/docs/pr-review/agents/toolkit-pr-review-v2-async.md
+++ b/docs/pr-review/agents/toolkit-pr-review-v2-async.md
@@ -33,6 +33,9 @@ Apply **only** these specific check IDs:
    - `.unwrap()` or `.expect()` on futures without `.await`
    - CPU-bound work without spawning a blocking task
    - Lock acquisitions that may hold across await points (use tokio::sync::Mutex instead of std::sync::Mutex in async code)
+   - Functions holding partial/shared state across `.await` points with no consideration of what happens if the future is dropped mid-await (`select!`, timeout)
+   - `Drop` impls on async-held resources (transactions, connections, guards) that assume cleanup runs, when the cleanup actually needs an async call (`Drop` cannot `.await`)
+   - CPU-bound async loops with no periodic `tokio::task::yield_now()`, starving other tasks on the executor
 
 2. **RUST-CONC-001** — Concurrent state access must be safe. Check for:
    - Unjustified `unsafe` blocks in concurrent code
@@ -47,6 +50,8 @@ Apply **only** these specific check IDs:
    - Unbounded collections that could grow without limit
    - Inefficient string handling (repeated concatenation)
    - Excessive logging or tracing in performance-critical paths
+   - `.collect::<Vec<_>>()` immediately consumed by another loop/iteration instead of chaining iterators
+   - `Box::new([0; N])` for large buffers instead of `vec![0; n]`
 
 4. **RUST-NO-004** — No async blocking footguns. Do not block the async runtime — equivalent to RUST-ASYNC-001 but phrased as a "must not."
 

--- a/docs/pr-review/agents/toolkit-pr-review-v2-design.md
+++ b/docs/pr-review/agents/toolkit-pr-review-v2-design.md
@@ -36,18 +36,30 @@ Apply **only** these specific check IDs:
    - Non-standard builder patterns or factory methods
    - Overly broad public visibility (pub when pub(crate) suffices)
    - APIs that require the caller to violate Rust idioms (e.g., force them to use unsafe, leak memory, or panic)
+   - Owned-string parameters that force callers to pre-convert instead of accepting `impl Into<String>`
+   - More than 2-3 boolean parameters on one function (should be an options struct/enum/builder)
+   - Validating constructors that panic or silently clamp instead of returning `Result`
+   - `Deref`/`DerefMut` impls used to fake inheritance on a wrapper type (leaks the inner API, blurs ownership)
 
 2. **RUST-TYPE-001** — Type system must preserve invariants. Check for:
    - Types that allow invalid states (should use enum or newtype)
    - Weak typing (using primitives instead of semantic types)
    - Type safety holes (e.g., bool parameters that should be enums)
    - Lost type information (erasing types to dynamic types unnecessarily)
+   - Wildcard `_ =>` catch-all on a crate-owned enum where an exhaustive match would force new variants to be handled
+   - Public enums/structs expected to grow that are missing `#[non_exhaustive]`
+   - Easily-dropped-by-accident results (builders, "must apply" configs) missing `#[must_use]`
 
 3. **RUST-OWN-001** — Ownership and borrowing patterns must be clear and efficient. Check for:
    - Unnecessary copies (passing owned values when references suffice)
    - Over-borrowing (taking &T when T would be clearer)
    - Lifetime confusion (unnecessarily explicit lifetimes or missing lifetime bounds)
    - Inefficient patterns (frequent cloning where a reference would work)
+   - Owned-type parameters where a borrowed type would do (`&String` instead of `&str`, `&Vec<T>` instead of `&[T]`, `&Box<T>` instead of `&T`)
+   - Cloning to move a field out of `&mut self`/an enum variant instead of `mem::take`/`mem::replace`
+   - A single lifetime parameter bounding both an input argument and a stored/returned reference (over-constrains callers)
+   - Manual acquire/release pairs where an RAII guard (`Drop`) would be safer
+   - Fallible functions that take ownership of an argument but don't return that value inside the error variant, forcing the caller to re-clone before retrying
 
 4. **RUST-DATA-001** — Serialization contracts must be explicit and maintainable. Check for:
    - Serialization without explicit versioning or backwards-compatibility consideration
@@ -66,12 +78,14 @@ Apply **only** these specific check IDs:
    - Implementation details exposed as pub (should be pub(crate) or inside modules)
    - Deep nesting without clear separation of concerns
    - Modules mixing unrelated functionality
+   - `#![deny(warnings)]` (or equivalent) added directly in source instead of denying specific lints by name or gating via CI/`RUSTFLAGS`
 
 7. **RUST-NO-007** — No accidental contract drift. Check for:
    - Public API changes without documentation (docs, changelog)
    - Removing or renaming public items without deprecation
    - Breaking changes to serialization formats of published types
    - Changes to error types that break caller code
+   - New blanket trait impls (`impl<T: Bound> Trait for T`) added to a public API without deliberate justification (semver/coherence hazard)
 
 ## Checklist References
 

--- a/docs/pr-review/agents/toolkit-pr-review-v2-errors.md
+++ b/docs/pr-review/agents/toolkit-pr-review-v2-errors.md
@@ -27,7 +27,7 @@ supplies the concrete directory path. In the filename escaping, `/` becomes `__`
 
 Apply **only** these specific check IDs:
 
-1. **RUST-ERR-001** — Errors must preserve context and original cause. Check for `map_err(|_| ...)` patterns that discard the source error. Errors should be useful to callers, not opaque.
+1. **RUST-ERR-001** — Errors must preserve context and original cause. Check for `map_err(|_| ...)` patterns that discard the source error. Errors should be useful to callers, not opaque. Also flag `From` impls used for conversions that can fail (panic or silently coerce on bad input) — use `TryFrom` instead.
 
 2. **RUST-PANIC-001** — Code should not panic at runtime except in truly exceptional conditions (e.g., internal invariant violations). Check for panic-prone patterns: unwrap/expect on fallible operations, indexing without bounds checks, panic-driven control flow.
 

--- a/docs/pr-review/agents/toolkit-pr-review-v2-security.md
+++ b/docs/pr-review/agents/toolkit-pr-review-v2-security.md
@@ -27,7 +27,12 @@ supplies the concrete directory path. In the filename escaping, `/` becomes `__`
 
 Apply **only** these specific check IDs:
 
-1. **RUST-SEC-001** — Input validation is mandatory at system boundaries. All user-provided input (query params, request bodies, file uploads, API calls) must be validated. Check for missing validation, insufficiently restrictive validators, or data passed directly to queries/commands without sanitization. Tenant/resource scoping must be enforced — endpoints must verify that the caller owns/can access the resource. Secrets (API keys, passwords, tokens) must never be logged, stored in plain text, or embedded in error messages.
+1. **RUST-SEC-001** — Input validation is mandatory at system boundaries. All user-provided input (query params, request bodies, file uploads, API calls) must be validated. Check for missing validation, insufficiently restrictive validators, or data passed directly to queries/commands without sanitization. Tenant/resource scoping must be enforced — endpoints must verify that the caller owns/can access the resource. Secrets (API keys, passwords, tokens) must never be logged, stored in plain text, or embedded in error messages. Also check for:
+   - Internal details (stack traces, file paths, SQL text, dependency versions) leaked in error responses to external callers
+   - Security-sensitive randomness (tokens, session IDs, nonces) generated with a general-purpose or seeded PRNG instead of a CSPRNG
+   - Outbound requests built from user-supplied URLs/hosts with no SSRF guard (destination validation/allowlisting) before the request is issued
+   - Hardcoded secrets, API keys, passwords, or tokens committed literally in the diff
+   - Disabled or weakened TLS certificate validation
 
 2. **RUST-NO-006** — Unsafe blocks are permitted only when necessary for FFI or performance-critical code with formal justification. Every `unsafe` block must have a comment explaining WHY it is safe (the invariant being relied on, not just what the code does). Unsafe code without justification is a finding.
 

--- a/docs/pr-review/agents/toolkit-pr-review-v2-tests.md
+++ b/docs/pr-review/agents/toolkit-pr-review-v2-tests.md
@@ -1,6 +1,6 @@
 ---
 name: toolkit-pr-review-v2-tests
-description: "Test quality review sub-agent for toolkit-pr-review-v2. Covers RUST-TEST-001 and 8 test anti-patterns. Returns JSON array only."
+description: "Test quality review sub-agent for toolkit-pr-review-v2. Covers RUST-TEST-001 and 9 test anti-patterns. Returns JSON array only."
 tools: Read, Bash
 model: inherit
 ---
@@ -9,7 +9,7 @@ model: inherit
 
 You are a Rust code reviewer responsible exclusively for **test quality**. Your findings identify:
 - Missing or inadequate test coverage
-- 8 common test anti-patterns that make tests weak or misleading
+- 9 common test anti-patterns that make tests weak or misleading
 - Tests that don't actually verify behavior
 
 This agent is **gated**: return `[]` immediately if `has_test_code` is false in context.json.
@@ -19,7 +19,7 @@ This agent is **gated**: return `[]` immediately if `has_test_code` is false in 
 Read these files from the provided paths:
 1. `/tmp/toolkit-pr-review-v2-$REVIEW_ID/context.json` — review metadata, file lists, changed line ranges
 2. `/tmp/toolkit-pr-review-v2-$REVIEW_ID/diff.patch` — the full diff under review
-3. `/tmp/toolkit-pr-review-v2-$REVIEW_ID/files/<escaped-path>` — full source file contents
+3. `/tmp/toolkit-pr-review-v2-$REVIEW_ID/files/<escaped-path>` — full source file contents. For a file listed in `context.json`'s `deleted_files`, this is the file's **pre-deletion** content from the base commit (the file no longer exists at the review head) — use it to see what test code was removed.
 
 `$REVIEW_ID` is the PR number in PR mode, or `local-<branch-slug>` in local mode — the orchestrator
 supplies the concrete directory path. In the filename escaping, `/` becomes `__`.
@@ -139,6 +139,18 @@ fn test_config() {
 
 **Finding**: If a test relies solely on snapshot assertions (insta, pretty_assertions snapshots, etc.) without also asserting on specific properties or behavior, flag it as TEST-QUALITY-8.
 
+### TEST-QUALITY-9 — Suppressed or Deleted Failing Test
+
+**Anti-pattern**: A previously-failing test is deleted, weakened (assertion loosened or removed), or marked `#[ignore]` in the diff, with no linked follow-up issue or clear justification.
+
+**Problem**: This hides a real regression instead of fixing it — the diff makes CI pass by silencing the signal, not by correcting the underlying bug.
+
+**Finding**: If the diff removes, weakens, or `#[ignore]`s a test that would otherwise fail, and there is no comment/justification linking to a tracked follow-up, flag it as TEST-QUALITY-9. Two anchor cases:
+- The test was removed from a file that still exists (no surviving added line at that location) — anchor on that file's `deletion_anchors` line from `context.json`.
+- The **entire file** containing the test was deleted (listed in `context.json`'s `deleted_files`) — its pre-deletion content is in `files/<escaped-path>` (fetched from the base commit). Emit the finding with no `line` field at all; see Output Contract.
+
+Do not omit either case for lack of a line — see Scope Rules and Output Contract.
+
 ---
 
 ## Checklist References
@@ -156,7 +168,8 @@ fn test_config() {
   - Assertions added to test files or test modules
   - Integration tests under `tests/` directory
   - Test helper functions used by tests
-- If a line number is outside the changed ranges for its file, omit the finding — do not guess.
+- If a line number is outside the changed ranges for its file, omit the finding — do not guess. Exception: a `TEST-QUALITY-9` finding about a deleted test in a file that still exists may use a line from that file's `deletion_anchors` in `context.json`.
+- If the file is listed in `context.json`'s `deleted_files`, it has no RIGHT-side line at all — a `TEST-QUALITY-9` finding on it must omit `line` entirely rather than guessing or being dropped.
 
 ## Output Contract
 
@@ -176,10 +189,21 @@ Schema (one object per finding):
 }
 ```
 
+For a `TEST-QUALITY-9` finding whose `"file"` is listed in `context.json`'s `deleted_files`, omit `"line"` entirely (do not invent one — the file has no RIGHT-side content):
+```json
+{
+  "file": "gears/foo/tests/dead_letter.rs",
+  "severity": "HIGH",
+  "id": "TEST-QUALITY-9",
+  "issue": "Test file was deleted wholesale with no linked follow-up.",
+  "fix": "Restore the test or open a tracked issue and reference it in the PR description."
+}
+```
+
 Field rules:
 - `"file"`: repo-root-relative path, exactly as it appears in the diff (strip `a/` or `b/` prefix).
-- `"line"`: integer, must be in `changed_ranges[file]` for that file. If unsure, omit the finding.
+- `"line"`: integer, must be in `changed_ranges[file]` for that file. If unsure, omit the finding. Omit this field entirely (do not set it to a guessed value) when `"file"` is in `deleted_files`.
 - `"severity"`: one of `"CRITICAL"`, `"HIGH"`, `"MEDIUM"`, `"LOW"` (verbatim strings, uppercase). Test quality issues are typically MEDIUM or LOW.
-- `"id"`: exact check ID: `"RUST-TEST-001"` for coverage gaps, or `"TEST-QUALITY-1"` through `"TEST-QUALITY-8"` for anti-patterns.
+- `"id"`: exact check ID: `"RUST-TEST-001"` for coverage gaps, or `"TEST-QUALITY-1"` through `"TEST-QUALITY-9"` for anti-patterns.
 - `"issue"`: one sentence, engineering English, no praise or hedging.
 - `"fix"`: one sentence, concrete and actionable (what to change, not a suggestion).

--- a/docs/pr-review/toolkit-rust-review.md
+++ b/docs/pr-review/toolkit-rust-review.md
@@ -109,6 +109,10 @@ Check that public APIs follow idiomatic Rust conventions.
 - Prefer domain types over primitive obsession
 - Prefer explicit enums/newtypes where they encode invariants
 - Avoid exposing implementation details in public signatures
+- Accept `impl Into<String>` for owned string parameters instead of forcing callers to pre-convert
+- Flag more than 2-3 boolean parameters on one function — use an options struct, enum, or builder instead
+- Validating constructors should return `Result`, not panic or silently clamp invalid input
+- Flag `Deref`/`DerefMut` impls used to simulate inheritance on a wrapper type — this leaks the inner type's full API and blurs ownership; prefer explicit delegation methods or a trait
 
 ---
 
@@ -125,6 +129,9 @@ Check that public APIs follow idiomatic Rust conventions.
 **Review guidance**:
 - Prefer compile-time guarantees over comments
 - Flag APIs that rely on caller discipline when the type system could help
+- Prefer exhaustive `match` over a wildcard `_ =>` catch-all on crate-owned enums, so a new variant forces a compile error at call sites instead of silently falling through
+- Use `#[non_exhaustive]` on public enums/structs expected to grow variants or fields later
+- Use `#[must_use]` on results that are easy to drop by accident (builders, "must be applied" configs, guards)
 
 ---
 
@@ -142,6 +149,7 @@ Check that public APIs follow idiomatic Rust conventions.
 - Flag `map_err(|_| ...)` if it destroys useful context
 - Flag generic error wrapping that hides root cause without reason
 - Prefer propagation with context over ad hoc stringification
+- Use `TryFrom`, not `From`, for conversions that can fail — a `From` impl that panics or silently coerces on bad input is a correctness bug
 
 ---
 
@@ -173,6 +181,11 @@ Check that public APIs follow idiomatic Rust conventions.
 - Flag defensive cloning without evidence
 - Flag ownership patterns that make APIs awkward or expensive
 - Flag unnecessary heap allocation or conversion churn
+- Prefer borrowed parameter types over owned (`&str` not `&String`, `&[T]` not `&Vec<T>`, `&T` not `&Box<T>`)
+- Use `mem::take`/`mem::replace` to move a field out of `&mut self` or an enum variant instead of cloning it
+- Fallible functions that take ownership of an argument should return that value inside the error so the caller can retry without re-cloning
+- Flag a single lifetime parameter used to bound both an input argument and a stored/returned reference — it over-constrains callers; use separate lifetimes
+- Prefer RAII guard types (custom `Drop`) over manual acquire/release call pairs
 
 ---
 
@@ -191,6 +204,9 @@ Check that public APIs follow idiomatic Rust conventions.
 - Flag `.await` inside critical sections
 - Flag detached tasks with no supervision or shutdown behavior
 - Flag loops that can retry forever without jitter, cap, or logging
+- Functions holding partial or shared state across `.await` points should be auditable for cancel-safety — consider what happens if the future is dropped mid-await via `select!` or a timeout
+- `Drop` cannot `.await` — audit `Drop` impls on async-held resources (transactions, connections, guards) for cleanup that actually needs an async call; it must be handled explicitly, not assumed to run via `Drop`
+- CPU-bound async loops should yield periodically (`tokio::task::yield_now()`) so they do not starve other tasks on the same executor thread
 
 ---
 
@@ -224,6 +240,11 @@ Check that public APIs follow idiomatic Rust conventions.
 - Flag missing validation on request or config boundaries
 - Flag security checks implemented too deep or too late
 - Flag implicit trust in upstream data without validation
+- Never leak internal details (stack traces, file paths, SQL text, dependency versions) in error responses returned to external callers
+- Security-sensitive randomness (tokens, session IDs, nonces) must use a CSPRNG, never a general-purpose or seeded PRNG
+- Outbound requests built from user-supplied URLs or hosts must guard against SSRF (validate/allowlist the destination, block internal/link-local ranges) before the request is issued
+- Flag hardcoded secrets, API keys, passwords, or tokens committed literally in the diff
+- Flag disabled or weakened TLS certificate validation
 
 ---
 
@@ -256,6 +277,8 @@ Check that public APIs follow idiomatic Rust conventions.
 - Do not micro-optimize blindly
 - Report only clear, likely-relevant footguns
 - Prefer evidence-based performance comments
+- Flag `.collect::<Vec<_>>()` immediately consumed by another loop or iteration — chain iterators instead of materializing an intermediate collection
+- Flag `Box::new([0; N])` for large buffers — allocate via `vec![0; n]` to avoid building an oversized value on the stack before the move
 
 ---
 
@@ -305,6 +328,7 @@ Check that public APIs follow idiomatic Rust conventions.
 - Flag "god gears"
 - Flag handlers/controllers doing domain work directly
 - Flag infrastructure details leaking into domain logic without need
+- Flag `#![deny(warnings)]` (or equivalent) added directly in source — it silently escalates any future lint, including new compiler lints, into a hard build break for downstream consumers; deny specific lints by name, or gate via CI/`RUSTFLAGS`, not a blanket source-level deny
 
 ---
 
@@ -373,6 +397,7 @@ Check that public APIs follow idiomatic Rust conventions.
 - No accidental serde/wire/schema changes
 - No accidental visibility expansion
 - No accidental behavior changes hidden inside refactoring
+- No new blanket trait impls (`impl<T: Bound> Trait for T`) in a public API without deliberate justification — they are a semver/coherence hazard for downstream crates
 
 ---
 

--- a/docs/pr-review/toolkit-tests-quality-review.md
+++ b/docs/pr-review/toolkit-tests-quality-review.md
@@ -45,6 +45,9 @@ Tests cover only successful execution but ignore invalid input, errors, boundary
 8. Snapshot Abuse
 A test that snapshots formatting or debug output instead of validating meaningful behavior. Formatting-only assertions should be treated with suspicion unless formatting itself is the contract.
 
+9. Suppressed or Deleted Failing Test
+A previously-failing test was deleted, weakened, or marked `#[ignore]` in the diff with no linked follow-up issue or clear justification. This hides a real regression instead of fixing it.
+
 What to do:
 - Flag meaningless or weak tests.
 - Explain why each flagged test is low-value.
@@ -58,6 +61,7 @@ What to do:
   - invariants
   - state transitions
   - interaction contracts
+- For parsing, validation, or serialization code, prefer at least one property-based test (proptest/quickcheck) over point examples alone.
 - Distinguish clearly between:
   - good tests
   - weak but salvageable tests


### PR DESCRIPTION
- Fold distilled checks from rmcp-server-kit's RUST_GUIDELINES.md into the existing toolkit-pr-review-v2 checklist (borrowed types, TryFrom vs From, cancel-safety/Drop auditing for async, SSRF/secrets/TLS/CSPRNG for security, blanket-impl semver hazards, deny(warnings) hygiene) without duplicating checks already covered, and mirror every addition into the sub-agent prompts that actually drive the review.

- Add missing .windsurf/workflows stubs so Windsurf redirects to the same SKILL.md as the existing Devin/Codex/Cursor stubs, giving all four harnesses one shared Rust-review prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added review workflow commands for Rust and ToolKit pull requests.
  * Expanded automated review coverage for API design, errors, async code, security, performance, ownership, and module practices.
  * Added detection for suppressed or deleted failing tests.
  * Improved review handling for changes involving deleted code.

* **Documentation**
  * Updated review checklists and agent guidance with expanded quality, security, and property-based testing criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->