### PR TITLE
docs(notice): add Virtuozzo copyright line

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -9,6 +9,7 @@ Copyright 2025–2026 Hypernetix Pte. Ltd.
 Copyright 2026 Acronis International GmbH
 Copyright 2026 Cyber Fabric Foundation
 Copyright 2026–present Constructor Fabric Foundation
+Copyright 2026–present Virtuozzo International GmbH
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Adds `Copyright 2026–present Virtuozzo International GmbH` to the copyright list in `NOTICE`, recording Virtuozzo International GmbH as a contributing entity from 2026 onward. Appended as the last entry in the copyright list.

No code, build, or runtime changes.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed — verified UTF-8 en dash (U+2013) matches surrounding lines, LF endings, no trailing whitespace
- [ ] New tests added for new functionality

## Documentation
- [ ] Code is documented with rustdoc comments
- [ ] README updated (if applicable)
- [ ] API documentation updated (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No linting errors (`cargo clippy`) — N/A, no Rust changes
- [x] Code is properly formatted (`cargo fmt`) — N/A, no Rust changes
- [x] Tests pass (`cargo test`) — N/A, no code changes
- [x] Commit signed off (DCO)

## Versioning
No public contract is touched (no Rust API, REST, proto, or CLI surface), so no crate version bump is required — per CONTRIBUTING §3 "Enforcement".

## Related Issues
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a copyright notice for Virtuozzo International GmbH covering 2026–present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->