### PR TITLE
feat(api-gateway): internal auth support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,8 @@ dependencies = [
  "cf-gears-toolkit-gateway",
  "cf-gears-toolkit-gts",
  "cf-gears-toolkit-http",
+ "cf-gears-toolkit-http-middleware",
+ "cf-gears-toolkit-k8s-auth",
  "cf-gears-toolkit-macros",
  "cf-gears-toolkit-security",
  "cf-gears-toolkit-transport-grpc",

--- a/gears/system/api-gateway/Cargo.toml
+++ b/gears/system/api-gateway/Cargo.toml
@@ -21,8 +21,10 @@ workspace = true
 [dependencies]
 toolkit = { workspace = true }
 toolkit-http = { workspace = true }
+toolkit-http-middleware = { workspace = true }
 toolkit-gateway = { workspace = true }
-toolkit-security = { workspace = true }
+toolkit-security = { workspace = true, features = ["internal-auth-cache"] }
+toolkit-k8s-auth = { workspace = true, optional = true }
 toolkit-transport-grpc = { workspace = true }
 toolkit-canonical-errors = { workspace = true, features = ["axum"] }
 cf-gears-system-sdks = { workspace = true, features = ["directory_grpc"] }
@@ -71,6 +73,7 @@ uuid = { workspace = true }
 grpc = []
 embed_elements = []
 otel = []
+k8s-auth = ["dep:toolkit-k8s-auth"]
 
 [build-dependencies]
 ureq = { workspace = true }

--- a/gears/system/api-gateway/src/config.rs
+++ b/gears/system/api-gateway/src/config.rs
@@ -87,6 +87,24 @@ pub struct ApiGatewayConfig {
     /// monolith is unaffected).
     #[serde(default)]
     pub gateway_proxy: GatewayProxyConfig,
+
+    /// Platform-plane credential for the embedded platform-host, serving **both
+    /// directions** from one block:
+    ///
+    /// - **Inbound** — `internal_auth_middleware`, installed ahead of the tenant
+    ///   plane, validates the `X-ToolKit-Internal-Token` on co-hosted internal
+    ///   routes (e.g. `authz-resolver`'s `/evaluate`) into a
+    ///   `PlatformSecurityContext`. Permissive on a missing token, so tenant
+    ///   traffic is unaffected. Kube uses `audiences`.
+    /// - **Outbound** — the credential attached to the edge's own
+    ///   `DirectoryService` polls (when [`GatewayProxyConfig::enabled`]). Kube
+    ///   uses `token_path`; omit it to attach no outbound credential.
+    ///
+    /// Each direction reads only the fields it needs, so one block (e.g.
+    /// `Kube { audiences, token_path }`) configures the whole platform plane
+    /// (`cpt-cf-adr-two-plane-auth`). Default: `None` (Profile 1 monolith).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub internal_auth: Option<toolkit_security::InternalAuthConfig>,
 }
 
 /// Reverse-proxy (embedded edge) configuration.
@@ -107,12 +125,6 @@ pub struct GatewayProxyConfig {
     /// Interval (seconds) between directory polls that refresh the proxy route
     /// table.
     pub sync_interval_secs: u64,
-    /// Platform-plane credential attached to the edge's `DirectoryService`
-    /// polls (`x-toolkit-internal-token`). Required when the directory host
-    /// enforces the platform plane; the `secret` must match the host's
-    /// `gear-orchestrator.internal_auth`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub internal_auth: Option<toolkit_security::InternalAuthConfig>,
 }
 
 impl Default for GatewayProxyConfig {
@@ -121,7 +133,6 @@ impl Default for GatewayProxyConfig {
             enabled: false,
             directory_endpoint: None,
             sync_interval_secs: default_gateway_sync_interval_secs(),
-            internal_auth: None,
         }
     }
 }
@@ -210,6 +221,7 @@ impl Default for ApiGatewayConfig {
             healthcheck_timeout_ms: default_healthcheck_timeout_ms(),
             health: HealthConfig::default(),
             gateway_proxy: GatewayProxyConfig::default(),
+            internal_auth: None,
         }
     }
 }

--- a/gears/system/api-gateway/src/gear.rs
+++ b/gears/system/api-gateway/src/gear.rs
@@ -53,8 +53,9 @@ use cf_system_sdks::directory::{DirectoryClient, DirectoryGrpcClient};
 
 use crate::config::{ApiGatewayConfig, GatewayProxyConfig, HealthServeMode};
 use crate::middleware::auth;
-use toolkit_security::SecurityContext;
+use toolkit_http_middleware::internal_auth_middleware;
 use toolkit_security::constants::{DEFAULT_SUBJECT_ID, DEFAULT_TENANT_ID};
+use toolkit_security::{DynInternalAuthenticator, InternalAuthConfig, SecurityContext};
 
 use crate::middleware;
 use crate::router_cache::RouterCache;
@@ -79,6 +80,11 @@ pub struct ApiGateway {
     pub(crate) final_router: Mutex<Option<axum::Router>>,
     // AuthN Resolver client (resolved during init, None when auth_disabled)
     pub(crate) authn_client: Mutex<Option<Arc<dyn AuthNResolverClient>>>,
+    // Inbound platform-plane authenticator (built in init from
+    // `config.internal_auth`, None in Profile 1). When present, the stack layers
+    // `internal_auth_middleware` ahead of the tenant plane so co-hosted internal
+    // routes get a validated `PlatformSecurityContext` (`cpt-cf-adr-two-plane-auth`).
+    pub(crate) internal_authenticator: Mutex<Option<DynInternalAuthenticator>>,
     // Readiness registry, set once from `rest_prepare`; `OnceLock` = lock-free reads.
     pub(crate) healthcheck_registry: OnceLock<Arc<toolkit::RestHealthcheckRegistry>>,
     // Built-once standalone health router. Served on the separate health listener in
@@ -112,6 +118,7 @@ impl Default for ApiGateway {
             router_cache: RouterCache::new(default_router),
             final_router: Mutex::new(None),
             authn_client: Mutex::new(None),
+            internal_authenticator: Mutex::new(None),
             healthcheck_registry: OnceLock::new(),
             health_router: OnceLock::new(),
             registered_routes: DashMap::new(),
@@ -204,6 +211,7 @@ impl ApiGateway {
             router_cache: RouterCache::new(default_router),
             final_router: Mutex::new(None),
             authn_client: Mutex::new(None),
+            internal_authenticator: Mutex::new(None),
             healthcheck_registry: OnceLock::new(),
             health_router: OnceLock::new(),
             registered_routes: DashMap::new(),
@@ -450,6 +458,13 @@ impl ApiGateway {
             return Err(anyhow::anyhow!(
                 "auth is enabled but no AuthN Resolver client is available; \
                  ensure `authn_resolver` gear is loaded or set `auth_disabled: true`"
+            ));
+        }
+
+        if let Some(internal) = self.internal_authenticator.lock().clone() {
+            router = router.layer(from_fn_with_state(
+                Arc::new(internal),
+                internal_auth_middleware::<DynInternalAuthenticator>,
             ));
         }
 
@@ -843,8 +858,17 @@ impl ApiGateway {
     /// throughout, and startup does not block on the first connection.
     fn start_proxy_sync(&self, cfg: &ApiGatewayConfig, cancel: CancellationToken) {
         let proxy_cfg = cfg.gateway_proxy.clone();
+        // The platform-plane credential is the single top-level `internal_auth`
+        // (outbound direction): the same block that gates inbound validation
+        // supplies the credential attached to directory polls.
+        let internal_auth = cfg.internal_auth.clone();
         let registry = Arc::clone(&self.proxy_registry);
-        tokio::spawn(Self::proxy_sync_supervisor(proxy_cfg, registry, cancel));
+        tokio::spawn(Self::proxy_sync_supervisor(
+            proxy_cfg,
+            internal_auth,
+            registry,
+            cancel,
+        ));
     }
 
     /// Retry the `DirectoryService` connection with exponential backoff until it
@@ -854,6 +878,7 @@ impl ApiGateway {
     /// spinning.
     async fn proxy_sync_supervisor(
         cfg: GatewayProxyConfig,
+        internal_auth: Option<InternalAuthConfig>,
         registry: Arc<toolkit_gateway::ProxyRegistry>,
         cancel: CancellationToken,
     ) {
@@ -865,7 +890,9 @@ impl ApiGateway {
         }
 
         let interval = Duration::from_secs(cfg.sync_interval_secs);
-        if let Some(directory) = Self::connect_with_backoff(&cfg, &cancel).await {
+        if let Some(directory) =
+            Self::connect_with_backoff(&cfg, internal_auth.as_ref(), &cancel).await
+        {
             // Drive the sync loop through the `GatewayProvider` trait so the
             // edge is pluggable (built-in reverse proxy here; a Kong/Tyk adapter
             // for Mode B). The built-in provider writes into the shared registry
@@ -882,6 +909,7 @@ impl ApiGateway {
     /// (returning `None`).
     async fn connect_with_backoff(
         cfg: &GatewayProxyConfig,
+        internal_auth: Option<&InternalAuthConfig>,
         cancel: &CancellationToken,
     ) -> Option<Arc<dyn DirectoryClient>> {
         const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
@@ -889,7 +917,7 @@ impl ApiGateway {
 
         let mut backoff = INITIAL_BACKOFF;
         loop {
-            match Self::connect_directory(cfg).await {
+            match Self::connect_directory(cfg, internal_auth).await {
                 Ok(directory) => return Some(directory),
                 Err(err) => tracing::warn!(
                     error = %err,
@@ -921,12 +949,13 @@ impl ApiGateway {
     /// Returns an error if `directory_endpoint` is unset or the connection fails.
     async fn connect_directory(
         cfg: &GatewayProxyConfig,
+        internal_auth: Option<&InternalAuthConfig>,
     ) -> anyhow::Result<Arc<dyn DirectoryClient>> {
         let endpoint = cfg.directory_endpoint.clone().ok_or_else(|| {
             anyhow::anyhow!("gateway_proxy.enabled but directory_endpoint is unset")
         })?;
 
-        let client = if let Some(internal_auth) = &cfg.internal_auth {
+        let client = if let Some(internal_auth) = internal_auth {
             let interceptor =
                 toolkit_transport_grpc::build_internal_auth_interceptor(internal_auth).await?;
             tracing::info!("attaching platform-plane credential to edge DirectoryService polls");
@@ -1115,6 +1144,12 @@ impl toolkit::Gear for ApiGateway {
             tracing::info!("AuthN Resolver client resolved from ClientHub");
         }
 
+        // Build the inbound platform-plane authenticator (None in Profile 1).
+        // Done here so a misconfigured `internal_auth` fails init rather than
+        // surfacing later as a per-request 500 on co-hosted internal routes.
+        *self.internal_authenticator.lock() =
+            build_internal_authenticator(cfg.internal_auth.as_ref()).await?;
+
         Ok(())
     }
 }
@@ -1246,6 +1281,59 @@ impl OpenApiRegistry for ApiGateway {
     }
 }
 
+/// Build the inbound platform-plane validator from configuration.
+///
+/// Shared-secret is built directly; kube (`TokenReview`) requires the
+/// `k8s-auth` feature and uses the shared
+/// `toolkit_k8s_auth::build_cached_k8s_authenticator` (also used by `grpc-hub`
+/// and the `OoP` bootstrap) so all three agree on what `provider: kube` means
+/// and how it is cached. Without the feature, `provider: kube` is a hard error
+/// rather than a silent enforcement downgrade. `Ok(None)` only when no
+/// `internal_auth` is configured (Profile 1).
+#[cfg_attr(not(feature = "k8s-auth"), allow(clippy::unused_async))]
+async fn build_internal_authenticator(
+    cfg: Option<&InternalAuthConfig>,
+) -> Result<Option<DynInternalAuthenticator>> {
+    let Some(cfg) = cfg else {
+        return Ok(None);
+    };
+
+    // Shared-secret (and any future dependency-light provider) builds here.
+    if let Some(auth) = cfg.build_authenticator() {
+        tracing::info!("Initializing shared-secret platform-plane authenticator");
+        return Ok(Some(auth));
+    }
+
+    #[cfg(feature = "k8s-auth")]
+    {
+        if cfg.is_kube() {
+            tracing::info!("Initializing Kubernetes TokenReview platform-plane authenticator");
+            let audiences = cfg.kube_audiences().unwrap_or_default().to_vec();
+            let auth = toolkit_k8s_auth::build_cached_k8s_authenticator(
+                audiences,
+                Some(toolkit_security::DEFAULT_TOKEN_REVIEW_CACHE_TTL),
+            )
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!("failed to init Kubernetes TokenReview authenticator: {e}")
+            })?;
+            return Ok(Some(auth));
+        }
+    }
+    #[cfg(not(feature = "k8s-auth"))]
+    {
+        if cfg.is_kube() {
+            anyhow::bail!(
+                "api-gateway internal_auth provider=kube requires the `k8s-auth` feature"
+            );
+        }
+    }
+
+    anyhow::bail!(
+        "internal_auth is configured but no authenticator could be built for the selected provider"
+    )
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
@@ -1281,6 +1369,176 @@ mod tests {
 
         let api = ApiGateway::new(ApiGatewayConfig::default());
         assert_eq!(api.bound_endpoint(), None);
+    }
+
+    /// No `internal_auth` configured (Profile 1) yields no authenticator, so
+    /// the platform-plane middleware is never layered.
+    #[tokio::test]
+    async fn build_internal_authenticator_is_none_without_config() {
+        let auth = build_internal_authenticator(None).await.unwrap();
+        assert!(auth.is_none());
+    }
+
+    /// The dependency-light shared-secret provider is built in-crate (no feature
+    /// required), so a shared-secret config produces an inbound authenticator.
+    #[tokio::test]
+    async fn build_internal_authenticator_builds_shared_secret() {
+        let cfg = InternalAuthConfig::SharedSecret {
+            secret: "dev-internal-token".to_owned(),
+            peer_name: "toolkit-internal".to_owned(),
+        };
+        let auth = build_internal_authenticator(Some(&cfg)).await.unwrap();
+        assert!(auth.is_some());
+    }
+
+    /// Without the `k8s-auth` feature, `provider: kube` is a hard error rather
+    /// than a silent enforcement downgrade to an open platform plane.
+    #[cfg(not(feature = "k8s-auth"))]
+    #[tokio::test]
+    async fn build_internal_authenticator_rejects_kube_without_feature() {
+        let cfg = InternalAuthConfig::Kube {
+            audiences: vec!["toolkit-internal".to_owned()],
+            token_path: None,
+        };
+        let err = build_internal_authenticator(Some(&cfg))
+            .await
+            .expect_err("kube provider must error without the k8s-auth feature");
+        assert!(err.to_string().contains("k8s-auth"));
+    }
+
+    /// Profile 1 (no inbound authenticator): the middleware stack still builds
+    /// and simply omits the platform-plane layer.
+    #[tokio::test]
+    async fn apply_middleware_stack_skips_platform_plane_when_absent() {
+        let config = ApiGatewayConfig {
+            auth_disabled: true,
+            ..Default::default()
+        };
+        let api = ApiGateway::new(config);
+        let _router = api
+            .apply_middleware_stack(Router::new(), None)
+            .expect("stack builds without a platform-plane authenticator");
+    }
+
+    /// When an inbound authenticator is installed, the platform-plane layer is
+    /// added to the stack (`cpt-cf-adr-two-plane-auth`).
+    #[tokio::test]
+    async fn apply_middleware_stack_layers_platform_plane_when_present() {
+        let config = ApiGatewayConfig {
+            auth_disabled: true,
+            ..Default::default()
+        };
+        let api = ApiGateway::new(config);
+
+        let auth = build_internal_authenticator(Some(&InternalAuthConfig::SharedSecret {
+            secret: "dev-internal-token".to_owned(),
+            peer_name: "toolkit-internal".to_owned(),
+        }))
+        .await
+        .unwrap()
+        .expect("shared-secret authenticator");
+        *api.internal_authenticator.lock() = Some(auth);
+
+        let _router = api
+            .apply_middleware_stack(Router::new(), None)
+            .expect("stack builds with the platform-plane layer");
+    }
+
+    /// `connect_directory` fails fast (before any network attempt) when the
+    /// directory endpoint is unset.
+    #[tokio::test]
+    async fn connect_directory_errors_without_endpoint() {
+        let cfg = GatewayProxyConfig {
+            enabled: true,
+            directory_endpoint: None,
+            ..Default::default()
+        };
+        let err = ApiGateway::connect_directory(&cfg, None)
+            .await
+            .err()
+            .expect("missing directory_endpoint must error");
+        assert!(err.to_string().contains("directory_endpoint"));
+    }
+
+    /// `connect_directory` takes the credential-attach branch when an
+    /// `internal_auth` config is supplied: the shared-secret interceptor is
+    /// built and attached before the connect attempt. The endpoint is
+    /// unreachable, so the connect itself fails after exhausting retries — but
+    /// the outbound platform-plane path (`cpt-cf-adr-two-plane-auth`) is
+    /// exercised.
+    #[tokio::test]
+    async fn connect_directory_attaches_internal_auth_credential() {
+        let cfg = GatewayProxyConfig {
+            enabled: true,
+            // Loopback port 1 refuses fast — the retry budget is small
+            // (3 attempts, sub-second backoff), so this stays quick without a
+            // live directory.
+            directory_endpoint: Some("http://127.0.0.1:1".to_owned()),
+            ..Default::default()
+        };
+        let internal = InternalAuthConfig::SharedSecret {
+            secret: "dev-internal-token".to_owned(),
+            peer_name: "toolkit-internal".to_owned(),
+        };
+        let result = ApiGateway::connect_directory(&cfg, Some(&internal)).await;
+        assert!(
+            result.is_err(),
+            "connect must fail against an unreachable directory endpoint"
+        );
+    }
+
+    /// The reverse-proxy supervisor returns immediately (no connect attempt)
+    /// when `directory_endpoint` is unset, treating it as a permanent
+    /// misconfiguration rather than a transient failure.
+    #[tokio::test]
+    async fn proxy_sync_supervisor_exits_without_endpoint() {
+        let cfg = GatewayProxyConfig {
+            enabled: true,
+            directory_endpoint: None,
+            ..Default::default()
+        };
+        let registry = Arc::new(toolkit_gateway::ProxyRegistry::new());
+        ApiGateway::proxy_sync_supervisor(cfg, None, registry, CancellationToken::new()).await;
+    }
+
+    /// `start_proxy_sync` spawns the supervisor task; with no endpoint the task
+    /// exits promptly. Exercises the top-level credential-threading path.
+    #[tokio::test]
+    async fn start_proxy_sync_spawns_supervisor() {
+        let config = ApiGatewayConfig {
+            gateway_proxy: GatewayProxyConfig {
+                enabled: true,
+                directory_endpoint: None,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let api = ApiGateway::new(config.clone());
+        api.start_proxy_sync(&config, CancellationToken::new());
+        tokio::task::yield_now().await;
+    }
+
+    /// With an endpoint configured, the supervisor enters the connect path:
+    /// `connect_with_backoff` calls `connect_directory` (which fails fast
+    /// against an unreachable endpoint) and then honors the already-fired
+    /// cancellation, returning `None` so the supervisor exits without starting
+    /// the sync loop. Exercises the credential-threading connect/backoff branch
+    /// that the endpoint-less test skips over.
+    #[tokio::test]
+    async fn proxy_sync_supervisor_connect_path_exits_on_cancel() {
+        let cfg = GatewayProxyConfig {
+            enabled: true,
+            // Loopback port 1 refuses immediately; the retry budget is small so
+            // the failed connect stays quick without a live directory.
+            directory_endpoint: Some("http://127.0.0.1:1".to_owned()),
+            sync_interval_secs: 5,
+        };
+        let registry = Arc::new(toolkit_gateway::ProxyRegistry::new());
+        let cancel = CancellationToken::new();
+        // Pre-cancel so `backoff_or_cancel` returns immediately after the first
+        // failed connect attempt, keeping the test fast and deterministic.
+        cancel.cancel();
+        ApiGateway::proxy_sync_supervisor(cfg, None, registry, cancel).await;
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-level authentication for gateway requests and directory synchronization.
  * Platform authentication can now be configured once at the gateway level for inbound and outbound operations.
  * Added optional Kubernetes-based authentication support.
* **Bug Fixes**
  * Improved authentication handling for embedded edge reverse-proxy directory polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->