### PR TITLE
fix: tolerate wall-clock sampling offset in LeaseClock virtual-advance test (#4685)

### DIFF
--- a/gears/system/cluster/cluster-sdk/src/lease_tests.rs
+++ b/gears/system/cluster/cluster-sdk/src/lease_tests.rs
@@ -289,10 +289,17 @@ async fn the_production_clock_ignores_virtual_time_but_the_test_clock_tracks_it(
     );
 
     // The injected virtual clock still fast-forwards, so TTL scenarios keep lapsing.
+    // `test_after` resolves to exactly `anchor_wall_ms + 3_600_000`, but `test_before`
+    // is sampled just after the anchor, so if the wall clock crosses a millisecond
+    // boundary in between, the observed delta undershoots the hour by up to that drift
+    // (a couple ms in practice). Assert it advanced by ~1h with the same wall-sampling
+    // tolerance the production-clock check above uses, rather than an exact bound that
+    // is flaky by construction.
     let test_after = test.now_millis();
+    let test_advanced = test_after.saturating_sub(test_before);
     assert!(
-        test_after >= test_before + 3_600_000,
-        "the injected virtual clock must still track `advance` ({test_before} -> \
-         {test_after})"
+        test_advanced.abs_diff(3_600_000) < 1_000,
+        "the injected virtual clock must still track `advance` (~1h, got \
+         {test_advanced}ms): {test_before} -> {test_after}"
     );
 }


### PR DESCRIPTION
Fixes #4685.

## Problem

`the_production_clock_ignores_virtual_time_but_the_test_clock_tracks_it` is flaky on CI, failing with a virtual-time delta of `3_599_999` ms after advancing by `3_600_000` ms.

## Root cause

`LeaseClock::virtual_clock()` records its wall anchor at construction, then `test_before` is sampled one line later. In the `Virtual` arm of `now_millis()`, `test_before` resolves to the current wall reading — which is `anchor_wall_ms + 1` if the wall clock crosses a millisecond boundary in between. After `advance(1h)`, `test_after` resolves algebraically to exactly `anchor_wall_ms + 3_600_000`, so the observed delta lands in `[3_600_000 - drift, 3_600_000]` and can only ever **undershoot**. The exact assertion `test_after >= test_before + 3_600_000` is therefore flaky by construction.

## Fix

Assert the injected clock advanced by *approximately* one hour, tolerating the sub-millisecond wall-sampling offset — reusing the same `< 1_000` tolerance the production-clock assertion directly above already uses. This still cleanly separates "virtual time tracked (~3.6M ms)" from the failure mode the test guards against (production clock barely moving), and the first assertion still catches a re-broken wiring. Test-only change; no production clock logic is touched.

## Verification

- `cargo test -p cf-gears-cluster-sdk --lib <test>` — passes
- `cargo clippy -p cf-gears-cluster-sdk --all-targets` — clean, exit 0