### PR TITLE
feat(toolkit): declare OpenAPI response headers

### DIFF
--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -43740,7 +43740,21 @@
                 }
               }
             },
-            "description": "Replay of an operation that is already terminal"
+            "description": "Replay of an operation that is already terminal",
+            "headers": {
+              "Idempotency-Replayed": {
+                "description": "Whether this submission replayed an existing operation",
+                "schema": {
+                  "type": "boolean"
+                }
+              },
+              "Location": {
+                "description": "URI of the admission operation",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "202": {
             "content": {
@@ -43750,7 +43764,27 @@
                 }
               }
             },
-            "description": "Accepted; poll the operation at the returned Location"
+            "description": "Accepted; poll the operation at the returned Location",
+            "headers": {
+              "Idempotency-Replayed": {
+                "description": "Whether this submission replayed an existing operation",
+                "schema": {
+                  "type": "boolean"
+                }
+              },
+              "Location": {
+                "description": "URI of the admission operation",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Retry-After": {
+                "description": "Suggested delay in seconds before polling the operation",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
           },
           "400": {
             "content": {

--- a/docs/toolkit_unified_system/04_rest_operation_builder.md
+++ b/docs/toolkit_unified_system/04_rest_operation_builder.md
@@ -253,6 +253,31 @@ pub async fn list_users(
 .error_500(openapi)
 ```
 
+### Response headers
+
+Declare response headers immediately after the response they belong to. Header
+types are restricted to the scalar variants supported by
+`ResponseHeaderType`, so an invalid or misspelled type cannot silently produce
+an incorrect contract.
+
+```rust
+use toolkit::api::{ResponseHeaderSpec, ResponseHeaderType};
+
+OperationBuilder::post("/jobs")
+    // ... auth, license, and handler ...
+    .json_response(StatusCode::ACCEPTED, "Job accepted")
+    .response_header(ResponseHeaderSpec::new(
+        "Location",
+        "URI of the accepted job",
+        ResponseHeaderType::String,
+    ))
+    .response_header(ResponseHeaderSpec::new(
+        "Retry-After",
+        "Delay in seconds before polling",
+        ResponseHeaderType::Integer,
+    ));
+```
+
 ### SSE schema
 
 ```rust
@@ -275,6 +300,7 @@ pub async fn list_users(
 - [ ] Add `.authenticated()` + `.require_license_features::<License>([])` for protected endpoints.
 - [ ] Add `.standard_errors(openapi)` or specific errors.
 - [ ] Use `.json_response_with_schema()` for typed responses.
+- [ ] Declare runtime response headers with `.response_header()`.
 - [ ] Use `Extension<Arc<Service>>` and attach once after all routes.
 - [ ] Use `Extension(ctx): Extension<SecurityContext>` to get `SecurityContext`.
 - [ ] Use `ApiResult<T>` and `?` for error propagation.

--- a/gears/system/types-registry/types-registry/src/api/rest/routes.rs
+++ b/gears/system/types-registry/types-registry/src/api/rest/routes.rs
@@ -7,6 +7,7 @@ use toolkit::api::OpenApiRegistry;
 use toolkit::api::canonical_prelude::StatusCode;
 use toolkit::api::operation_builder::{
     CORE_GLOBAL_BASE_LICENSE_FEATURE, LicenseFeature, OperationBuilder, ParamLocation, ParamSpec,
+    ResponseHeaderSpec, ResponseHeaderType,
 };
 
 use super::dto::{
@@ -187,11 +188,36 @@ pub fn register_routes(
             StatusCode::ACCEPTED,
             "Accepted; poll the operation at the returned Location",
         )
+        .response_header(ResponseHeaderSpec::new(
+            "Location",
+            "URI of the admission operation",
+            ResponseHeaderType::String,
+        ))
+        .response_header(ResponseHeaderSpec::new(
+            "Retry-After",
+            "Suggested delay in seconds before polling the operation",
+            ResponseHeaderType::Integer,
+        ))
+        .response_header(ResponseHeaderSpec::new(
+            "Idempotency-Replayed",
+            "Whether this submission replayed an existing operation",
+            ResponseHeaderType::Boolean,
+        ))
         .json_response_with_schema::<OperationAcceptedDto>(
             openapi,
             StatusCode::OK,
             "Replay of an operation that is already terminal",
         )
+        .response_header(ResponseHeaderSpec::new(
+            "Location",
+            "URI of the admission operation",
+            ResponseHeaderType::String,
+        ))
+        .response_header(ResponseHeaderSpec::new(
+            "Idempotency-Replayed",
+            "Whether this submission replayed an existing operation",
+            ResponseHeaderType::Boolean,
+        ))
         .problem_response(
             openapi,
             StatusCode::CONFLICT,

--- a/gears/system/types-registry/types-registry/tests/api_rest_test.rs
+++ b/gears/system/types-registry/types-registry/tests/api_rest_test.rs
@@ -19,7 +19,7 @@ use axum::Router;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use serde_json::{Value, json};
-use toolkit::api::OpenApiRegistry;
+use toolkit::api::{OpenApiRegistry, ResponseHeaderType};
 use toolkit_gts::{gts_id, gts_uri};
 use tower::ServiceExt;
 
@@ -46,6 +46,8 @@ const HTTP_REQUEST_RESOURCE_TYPE: &str = gts_id!("cf.core.http.request.v1~");
 type DeclaredParam = (String, String, bool);
 /// One response as the generated document will carry it: status and content type.
 type DeclaredResponse = (u16, String);
+/// One response header: status, name, and JSON Schema scalar type.
+type DeclaredResponseHeader = (u16, String, ResponseHeaderType);
 
 /// Records what `register_routes` declares, so the generated document is
 /// assertable instead of eyeballed in `/cf/docs`.
@@ -57,6 +59,8 @@ struct TestOpenApi {
     params: std::sync::Mutex<Vec<(String, Vec<DeclaredParam>)>>,
     /// `operation_id -> [(status, content type)]`.
     responses: std::sync::Mutex<Vec<(String, Vec<DeclaredResponse>)>>,
+    /// `operation_id -> [(status, header name, scalar type)]`.
+    response_headers: std::sync::Mutex<Vec<(String, Vec<DeclaredResponseHeader>)>>,
     /// `operation_id -> gateway visibility`.
     exposure: std::sync::Mutex<Vec<(String, bool)>>,
 }
@@ -82,6 +86,20 @@ impl OpenApiRegistry for TestOpenApi {
                 .map(|r| (r.status, r.content_type.to_owned()))
                 .collect(),
         ));
+        self.response_headers
+            .lock()
+            .expect("response headers lock")
+            .push((
+                spec.operation_id.clone().unwrap_or_default(),
+                spec.responses
+                    .iter()
+                    .flat_map(|response| {
+                        response.headers.iter().map(move |header| {
+                            (response.status, header.name.clone(), header.header_type)
+                        })
+                    })
+                    .collect(),
+            ));
         self.exposure
             .lock()
             .expect("exposure lock")
@@ -1071,6 +1089,49 @@ fn the_idempotency_key_header_is_declared_as_a_required_parameter() {
     assert!(
         submit.contains(&("Idempotency-Key".to_owned(), "Header".to_owned(), true)),
         "submit must declare a required Idempotency-Key header, got: {submit:?}",
+    );
+}
+
+#[test]
+fn submission_response_headers_are_declared() {
+    let openapi = TestOpenApi::default();
+    let config = TypesRegistryConfig::default();
+    let legacy = Arc::new(TypesRegistryService::new(
+        Arc::new(InMemoryGtsRepository::new(config.to_gts_config())),
+        config,
+    ));
+    let _router =
+        types_registry::api::rest::routes::register_routes(Router::new(), &openapi, legacy, None);
+
+    let headers = openapi
+        .response_headers
+        .lock()
+        .expect("response headers lock");
+    let submit = headers
+        .iter()
+        .find(|(id, _)| id == "types_registry.submit_entities")
+        .map(|(_, headers)| headers)
+        .expect("the submit operation is registered");
+
+    for expected in [
+        (202, "Location", ResponseHeaderType::String),
+        (202, "Retry-After", ResponseHeaderType::Integer),
+        (202, "Idempotency-Replayed", ResponseHeaderType::Boolean),
+        (200, "Location", ResponseHeaderType::String),
+        (200, "Idempotency-Replayed", ResponseHeaderType::Boolean),
+    ] {
+        assert!(
+            submit.iter().any(|actual| {
+                actual.0 == expected.0 && actual.1 == expected.1 && actual.2 == expected.2
+            }),
+            "missing response header {expected:?}: {submit:?}",
+        );
+    }
+    assert!(
+        !submit
+            .iter()
+            .any(|(status, name, _)| *status == 200 && name == "Retry-After"),
+        "terminal replay must not advertise Retry-After: {submit:?}",
     );
 }
 

--- a/libs/toolkit/src/api/mod.rs
+++ b/libs/toolkit/src/api/mod.rs
@@ -25,7 +25,7 @@ pub use error_layer::{
 pub use openapi_registry::{OpenApiInfo, OpenApiRegistry, OpenApiRegistryImpl, ensure_schema};
 pub use operation_builder::{
     Missing, OperationBuilder, OperationSpec, ParamLocation, ParamSpec, Present, RateLimitSpec,
-    ResponseSpec, state,
+    ResponseHeaderSpec, ResponseHeaderType, ResponseSpec, state,
 };
 pub use select::{apply_select, page_to_projected_json, project_json};
 

--- a/libs/toolkit/src/api/openapi_registry.rs
+++ b/libs/toolkit/src/api/openapi_registry.rs
@@ -12,13 +12,14 @@ use std::sync::Arc;
 use utoipa::openapi::{
     OpenApi, OpenApiBuilder, Ref, RefOr, Required,
     content::ContentBuilder,
+    header::HeaderBuilder,
     info::InfoBuilder,
     path::{
         HttpMethod, OperationBuilder as UOperationBuilder, ParameterBuilder, ParameterIn,
         PathItemBuilder, PathsBuilder,
     },
     request_body::RequestBodyBuilder,
-    response::{ResponseBuilder, ResponsesBuilder},
+    response::{Response, ResponsesBuilder},
     schema::{ArrayBuilder, ComponentsBuilder, ObjectBuilder, Schema, SchemaFormat, SchemaType},
     security::{HttpAuthScheme, HttpBuilder, SecurityScheme},
     server::Server,
@@ -256,43 +257,65 @@ impl OpenApiRegistryImpl {
             }
 
             // Responses
-            let mut responses = ResponsesBuilder::new();
+            let mut responses_by_status = BTreeMap::<u16, Response>::new();
             for r in &spec.responses {
+                let response = responses_by_status
+                    .entry(r.status)
+                    .or_insert_with(|| Response::new(&r.description));
+                // Preserve the historical last-declaration-wins behavior for
+                // the status-level description while merging media types.
+                response.description.clone_from(&r.description);
+
                 // Body-less response (e.g. 204 No Content) is signalled by an
                 // empty `content_type`. Emit just `description` — attaching a
                 // `content` block would make code-generators expect a body.
-                if r.content_type.is_empty() {
-                    let resp = ResponseBuilder::new().description(&r.description).build();
-                    responses = responses.response(r.status.to_string(), resp);
-                    continue;
+                if !r.content_type.is_empty() {
+                    let is_json_like = r.content_type == "application/json"
+                        || r.content_type == problem::APPLICATION_PROBLEM_JSON
+                        || r.content_type == "text/event-stream";
+                    let content = if is_json_like {
+                        // Manually build content to preserve the correct content type.
+                        ContentBuilder::new()
+                            .schema(Some(build_response_schema(r.schema.as_ref())))
+                            .build()
+                    } else {
+                        let schema = Schema::Object(
+                            ObjectBuilder::new()
+                                .schema_type(SchemaType::Type(
+                                    utoipa::openapi::schema::Type::String,
+                                ))
+                                .format(Some(SchemaFormat::Custom(r.content_type.into())))
+                                .build(),
+                        );
+                        ContentBuilder::new().schema(Some(schema)).build()
+                    };
+                    response.content.insert(r.content_type.to_owned(), content);
                 }
-                let is_json_like = r.content_type == "application/json"
-                    || r.content_type == problem::APPLICATION_PROBLEM_JSON
-                    || r.content_type == "text/event-stream";
-                let resp = if is_json_like {
-                    // Manually build content to preserve the correct content type
-                    let content = ContentBuilder::new()
-                        .schema(Some(build_response_schema(r.schema.as_ref())))
+
+                for header in &r.headers {
+                    let schema_type = match header.header_type {
+                        operation_builder::ResponseHeaderType::String => {
+                            SchemaType::Type(utoipa::openapi::schema::Type::String)
+                        }
+                        operation_builder::ResponseHeaderType::Integer => {
+                            SchemaType::Type(utoipa::openapi::schema::Type::Integer)
+                        }
+                        operation_builder::ResponseHeaderType::Boolean => {
+                            SchemaType::Type(utoipa::openapi::schema::Type::Boolean)
+                        }
+                    };
+                    let declared = HeaderBuilder::new()
+                        .description(header.description.clone())
+                        .schema(ObjectBuilder::new().schema_type(schema_type).build())
                         .build();
-                    ResponseBuilder::new()
-                        .description(&r.description)
-                        .content(r.content_type, content)
-                        .build()
-                } else {
-                    let schema = Schema::Object(
-                        ObjectBuilder::new()
-                            .schema_type(SchemaType::Type(utoipa::openapi::schema::Type::String))
-                            .format(Some(SchemaFormat::Custom(r.content_type.into())))
-                            .build(),
-                    );
-                    let content = ContentBuilder::new().schema(Some(schema)).build();
-                    ResponseBuilder::new()
-                        .description(&r.description)
-                        .content(r.content_type, content)
-                        .build()
-                };
-                responses = responses.response(r.status.to_string(), resp);
+                    response.headers.insert(header.name.clone(), declared);
+                }
             }
+            let responses = ResponsesBuilder::new().responses_from_iter(
+                responses_by_status
+                    .into_iter()
+                    .map(|(status, response)| (status.to_string(), response)),
+            );
             op = op.responses(responses.build());
 
             // Add security requirement if operation requires authentication
@@ -611,7 +634,8 @@ fn collect_refs_from_json(value: &serde_json::Value, refs: &mut HashSet<String>)
 mod tests {
     use super::*;
     use crate::api::operation_builder::{
-        OperationSpec, ParamLocation, ParamSpec, ResponseSchema, ResponseSpec, VendorExtensions,
+        OperationSpec, ParamLocation, ParamSpec, ResponseHeaderSpec, ResponseHeaderType,
+        ResponseSchema, ResponseSpec, VendorExtensions,
     };
     use http::Method;
 
@@ -635,6 +659,7 @@ mod tests {
                 content_type: "application/json",
                 description: "OK".to_owned(),
                 schema,
+                headers: vec![],
             }],
             handler_id: handler.to_owned(),
             authenticated: false,
@@ -685,6 +710,7 @@ mod tests {
                 content_type: "application/json",
                 description: "Success".to_owned(),
                 schema: None,
+                headers: vec![],
             }],
             handler_id: "get_test".to_owned(),
             authenticated: false,
@@ -697,6 +723,113 @@ mod tests {
 
         registry.register_operation(&spec);
         assert_eq!(registry.operation_specs.len(), 1);
+    }
+
+    #[test]
+    fn response_headers_are_emitted_with_their_declared_types() {
+        let registry = OpenApiRegistryImpl::new();
+        let mut spec = spec_with_response("/submit", "submit", None);
+        spec.responses[0].headers = vec![
+            ResponseHeaderSpec::new(
+                "Location",
+                "Operation resource URI",
+                ResponseHeaderType::String,
+            ),
+            ResponseHeaderSpec::new(
+                "Retry-After",
+                "Retry delay in seconds",
+                ResponseHeaderType::Integer,
+            ),
+            ResponseHeaderSpec::new(
+                "Idempotency-Replayed",
+                "Whether this is a replay",
+                ResponseHeaderType::Boolean,
+            ),
+        ];
+        registry.register_operation(&spec);
+
+        let doc = registry.build_openapi(&test_info()).unwrap();
+        let json = serde_json::to_value(doc).unwrap();
+        let headers = &json["paths"]["/submit"]["get"]["responses"]["200"]["headers"];
+        assert_eq!(headers["Location"]["schema"]["type"], "string");
+        assert_eq!(headers["Location"]["description"], "Operation resource URI");
+        assert_eq!(headers["Retry-After"]["schema"]["type"], "integer");
+        assert_eq!(headers["Idempotency-Replayed"]["schema"]["type"], "boolean");
+    }
+
+    #[test]
+    fn response_content_types_with_the_same_status_are_combined() {
+        let registry = OpenApiRegistryImpl::new();
+        let mut spec = spec_with_response("/document", "document", None);
+        spec.responses[0].content_type = "text/plain";
+        spec.responses[0].description = "Plain document".to_owned();
+        spec.responses[0].headers = vec![ResponseHeaderSpec::new(
+            "X-Plain-Document",
+            "Whether plain text is available",
+            ResponseHeaderType::Boolean,
+        )];
+        spec.responses.push(
+            ResponseSpec::new(
+                http::StatusCode::OK.as_u16(),
+                "text/html",
+                "HTML document",
+                None,
+            )
+            .with_headers([ResponseHeaderSpec::new(
+                "X-HTML-Document",
+                "Whether HTML is available",
+                ResponseHeaderType::Boolean,
+            )]),
+        );
+        registry.register_operation(&spec);
+
+        let doc = registry.build_openapi(&test_info()).unwrap();
+        let json = serde_json::to_value(doc).unwrap();
+        let response = &json["paths"]["/document"]["get"]["responses"]["200"];
+        assert_eq!(response["description"], "HTML document");
+        assert_eq!(
+            response["content"]["text/plain"]["schema"]["format"],
+            "text/plain"
+        );
+        assert_eq!(
+            response["content"]["text/html"]["schema"]["format"],
+            "text/html"
+        );
+        assert_eq!(
+            response["headers"]["X-Plain-Document"]["schema"]["type"],
+            "boolean"
+        );
+        assert_eq!(
+            response["headers"]["X-HTML-Document"]["schema"]["type"],
+            "boolean"
+        );
+    }
+
+    #[test]
+    fn bodyless_response_can_declare_headers_without_content() {
+        let registry = OpenApiRegistryImpl::new();
+        let mut spec = spec_with_response("/jobs", "jobs", None);
+        spec.responses[0].content_type = "";
+        spec.responses[0].schema = None;
+        spec.responses[0].headers = vec![ResponseHeaderSpec::without_description(
+            "Retry-After",
+            ResponseHeaderType::Integer,
+        )];
+        registry.register_operation(&spec);
+
+        let doc = registry.build_openapi(&test_info()).unwrap();
+        let json = serde_json::to_value(doc).unwrap();
+        let response = &json["paths"]["/jobs"]["get"]["responses"]["200"];
+        assert!(response.get("content").is_none());
+        assert_eq!(
+            response["headers"]["Retry-After"]["schema"]["type"],
+            "integer"
+        );
+        assert!(
+            response["headers"]["Retry-After"]
+                .get("description")
+                .is_none()
+        );
     }
 
     #[test]
@@ -750,6 +883,7 @@ mod tests {
                 content_type: "application/json",
                 description: "User found".to_owned(),
                 schema: None,
+                headers: vec![],
             }],
             handler_id: "get_users_id".to_owned(),
             authenticated: false,
@@ -810,6 +944,7 @@ mod tests {
                 content_type: "application/json",
                 description: "Upload successful".to_owned(),
                 schema: None,
+                headers: vec![],
             }],
             handler_id: "post_upload".to_owned(),
             authenticated: false,
@@ -889,6 +1024,7 @@ mod tests {
                 content_type: "application/json",
                 description: "OK".to_owned(),
                 schema: None,
+                headers: vec![],
             }],
             handler_id: "get_test".to_owned(),
             authenticated: false,
@@ -943,6 +1079,7 @@ mod tests {
                 content_type: "application/json",
                 description: "OK".to_owned(),
                 schema: None,
+                headers: vec![],
             }],
             handler_id: "get_ping".to_owned(),
             authenticated: false,

--- a/libs/toolkit/src/api/operation_builder.rs
+++ b/libs/toolkit/src/api/operation_builder.rs
@@ -237,6 +237,7 @@ impl ResponseSchema {
 }
 
 /// Response specification for API operations
+#[non_exhaustive]
 #[derive(Clone, Debug)]
 pub struct ResponseSpec {
     pub status: u16,
@@ -244,15 +245,102 @@ pub struct ResponseSpec {
     pub description: String,
     /// Schema of the response body (if any).
     pub schema: Option<ResponseSchema>,
+    /// Headers that may be returned with this response.
+    pub headers: Vec<ResponseHeaderSpec>,
 }
 
 impl ResponseSpec {
+    /// Create a response specification without declared headers.
+    #[must_use]
+    pub fn new(
+        status: u16,
+        content_type: &'static str,
+        description: impl Into<String>,
+        schema: Option<ResponseSchema>,
+    ) -> Self {
+        Self {
+            status,
+            content_type,
+            description: description.into(),
+            schema,
+            headers: Vec::new(),
+        }
+    }
+
+    /// Add headers to this response specification.
+    ///
+    /// # Panics
+    /// Panics when the response already has, or the supplied headers contain,
+    /// a header with the same case-insensitive name.
+    #[must_use]
+    pub fn with_headers(mut self, headers: impl IntoIterator<Item = ResponseHeaderSpec>) -> Self {
+        let headers: Vec<_> = headers.into_iter().collect();
+        for (index, header) in headers.iter().enumerate() {
+            assert!(
+                !self
+                    .headers
+                    .iter()
+                    .chain(headers[..index].iter())
+                    .any(|existing| existing.name.eq_ignore_ascii_case(&header.name)),
+                "response {} already declares header '{}'",
+                self.status,
+                header.name
+            );
+        }
+        self.headers.extend(headers);
+        self
+    }
+
     /// Name of the component schema this response references, if any.
     ///
     /// For an array response this is the **item** component, not the array.
     #[must_use]
     pub fn schema_name(&self) -> Option<&str> {
         self.schema.as_ref().map(ResponseSchema::schema_name)
+    }
+}
+
+/// JSON Schema scalar type of a response header.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResponseHeaderType {
+    String,
+    Integer,
+    Boolean,
+}
+
+/// Header declared on one API response.
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResponseHeaderSpec {
+    pub name: String,
+    pub description: Option<String>,
+    pub header_type: ResponseHeaderType,
+}
+
+impl ResponseHeaderSpec {
+    /// Create a response header with a description.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        header_type: ResponseHeaderType,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            description: Some(description.into()),
+            header_type,
+        }
+    }
+
+    /// Create a response header without a description.
+    #[must_use]
+    pub fn without_description(name: impl Into<String>, header_type: ResponseHeaderType) -> Self {
+        Self {
+            name: name.into(),
+            description: None,
+            header_type,
+        }
     }
 }
 
@@ -299,6 +387,28 @@ pub struct OperationSpec {
     /// `OpenAPI` vendor extensions (x-*)
     pub vendor_extensions: VendorExtensions,
     pub license_requirement: Option<LicenseReqSpec>,
+}
+
+impl OperationSpec {
+    /// Replace a response with the same status and content type while retaining
+    /// headers that were already declared for that response. The declared
+    /// response becomes the most recent response so subsequent headers attach
+    /// to it.
+    ///
+    /// Different content types for the same status are kept as separate specs;
+    /// the `OpenAPI` registry combines them into one response object.
+    fn upsert_response(&mut self, mut response: ResponseSpec) {
+        let Some(index) = self.responses.iter().position(|existing| {
+            existing.status == response.status && existing.content_type == response.content_type
+        }) else {
+            self.responses.push(response);
+            return;
+        };
+
+        let mut existing = self.responses.remove(index);
+        response.headers.append(&mut existing.headers);
+        self.responses.push(response);
+    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -1218,6 +1328,7 @@ where
             content_type: "application/json",
             description: description.into(),
             schema: None,
+            headers: Vec::new(),
         });
         OperationBuilder {
             spec: self.spec,
@@ -1247,6 +1358,7 @@ where
             content_type: "",
             description: description.into(),
             schema: None,
+            headers: Vec::new(),
         });
         OperationBuilder {
             spec: self.spec,
@@ -1275,6 +1387,7 @@ where
             content_type: "application/json",
             description: description.into(),
             schema: Some(ResponseSchema::Ref { schema_name: name }),
+            headers: Vec::new(),
         });
         OperationBuilder {
             spec: self.spec,
@@ -1313,6 +1426,7 @@ where
             content_type: "application/json",
             description: description.into(),
             schema: Some(ResponseSchema::Array { items_schema_name }),
+            headers: Vec::new(),
         });
         OperationBuilder {
             spec: self.spec,
@@ -1348,6 +1462,7 @@ where
             content_type,
             description: description.into(),
             schema: None,
+            headers: Vec::new(),
         });
         OperationBuilder {
             spec: self.spec,
@@ -1371,6 +1486,7 @@ where
             content_type: "text/html",
             description: description.into(),
             schema: None,
+            headers: Vec::new(),
         });
         OperationBuilder {
             spec: self.spec,
@@ -1399,6 +1515,7 @@ where
             schema: Some(ResponseSchema::Ref {
                 schema_name: problem_name,
             }),
+            headers: Vec::new(),
         });
         OperationBuilder {
             spec: self.spec,
@@ -1426,6 +1543,7 @@ where
             content_type: "text/event-stream",
             description: description.into(),
             schema: Some(ResponseSchema::Ref { schema_name: name }),
+            headers: Vec::new(),
         });
         OperationBuilder {
             spec: self.spec,
@@ -1448,17 +1566,49 @@ where
     A: AuthState,
     L: LicenseState,
 {
+    /// Declare a header on the most recently declared response.
+    ///
+    /// Call this immediately after the response declaration it describes.
+    /// Consecutive calls attach multiple headers to that same response.
+    ///
+    /// # Panics
+    /// Panics when the response status already has a header with the same
+    /// case-insensitive name.
+    pub fn response_header(mut self, header: ResponseHeaderSpec) -> Self {
+        let Some(response) = self.spec.responses.last() else {
+            unreachable!("Present response state guarantees a response");
+        };
+        let status = response.status;
+        assert!(
+            !self.spec.responses.iter().any(|response| {
+                response.status == status
+                    && response
+                        .headers
+                        .iter()
+                        .any(|existing| existing.name.eq_ignore_ascii_case(&header.name))
+            }),
+            "response {status} already declares header '{}'",
+            header.name
+        );
+        let Some(response) = self.spec.responses.last_mut() else {
+            unreachable!("Present response state guarantees a response");
+        };
+        response.headers.push(header);
+        self
+    }
+
     /// Add a JSON response (additional).
     pub fn json_response(
         mut self,
         status: http::StatusCode,
         description: impl Into<String>,
     ) -> Self {
-        self.spec.responses.push(ResponseSpec {
+        self.spec.upsert_response(ResponseSpec {
             status: status.as_u16(),
             content_type: "application/json",
             description: description.into(),
             schema: None,
+            headers: Vec::new(),
         });
         self
     }
@@ -1469,11 +1619,12 @@ where
         status: http::StatusCode,
         description: impl Into<String>,
     ) -> Self {
-        self.spec.responses.push(ResponseSpec {
+        self.spec.upsert_response(ResponseSpec {
             status: status.as_u16(),
             content_type: "",
             description: description.into(),
             schema: None,
+            headers: Vec::new(),
         });
         self
     }
@@ -1489,11 +1640,12 @@ where
         T: utoipa::ToSchema + utoipa::PartialSchema + api_dto::ResponseApiDto + 'static,
     {
         let name = ensure_schema::<T>(registry);
-        self.spec.responses.push(ResponseSpec {
+        self.spec.upsert_response(ResponseSpec {
             status: status.as_u16(),
             content_type: "application/json",
             description: description.into(),
             schema: Some(ResponseSchema::Ref { schema_name: name }),
+            headers: Vec::new(),
         });
         self
     }
@@ -1513,11 +1665,12 @@ where
         T: utoipa::ToSchema + utoipa::PartialSchema + api_dto::ResponseApiDto + 'static,
     {
         let items_schema_name = ensure_schema::<T>(registry);
-        self.spec.responses.push(ResponseSpec {
+        self.spec.upsert_response(ResponseSpec {
             status: status.as_u16(),
             content_type: "application/json",
             description: description.into(),
             schema: Some(ResponseSchema::Array { items_schema_name }),
+            headers: Vec::new(),
         });
         self
     }
@@ -1540,11 +1693,12 @@ where
         description: impl Into<String>,
         content_type: &'static str,
     ) -> Self {
-        self.spec.responses.push(ResponseSpec {
+        self.spec.upsert_response(ResponseSpec {
             status: status.as_u16(),
             content_type,
             description: description.into(),
             schema: None,
+            headers: Vec::new(),
         });
         self
     }
@@ -1555,11 +1709,12 @@ where
         status: http::StatusCode,
         description: impl Into<String>,
     ) -> Self {
-        self.spec.responses.push(ResponseSpec {
+        self.spec.upsert_response(ResponseSpec {
             status: status.as_u16(),
             content_type: "text/html",
             description: description.into(),
             schema: None,
+            headers: Vec::new(),
         });
         self
     }
@@ -1573,13 +1728,14 @@ where
     ) -> Self {
         // Canonical Problem schema (RFC 9457 + GTS-typed). Component name "Problem".
         let problem_name = ensure_schema::<toolkit_canonical_errors::Problem>(registry);
-        self.spec.responses.push(ResponseSpec {
+        self.spec.upsert_response(ResponseSpec {
             status: status.as_u16(),
             content_type: problem::APPLICATION_PROBLEM_JSON,
             description: description.into(),
             schema: Some(ResponseSchema::Ref {
                 schema_name: problem_name,
             }),
+            headers: Vec::new(),
         });
         self
     }
@@ -1594,11 +1750,12 @@ where
         T: utoipa::ToSchema + utoipa::PartialSchema + api_dto::ResponseApiDto + 'static,
     {
         let name = ensure_schema::<T>(openapi);
-        self.spec.responses.push(ResponseSpec {
+        self.spec.upsert_response(ResponseSpec {
             status: http::StatusCode::OK.as_u16(),
             content_type: "text/event-stream",
             description: description.into(),
             schema: Some(ResponseSchema::Ref { schema_name: name }),
+            headers: Vec::new(),
         });
         self
     }
@@ -1663,13 +1820,14 @@ where
         ];
 
         for (status, description) in standard_errors {
-            self.spec.responses.push(ResponseSpec {
+            self.spec.upsert_response(ResponseSpec {
                 status: status.as_u16(),
                 content_type: problem::APPLICATION_PROBLEM_JSON,
                 description: description.to_owned(),
                 schema: Some(ResponseSchema::Ref {
                     schema_name: problem_name.clone(),
                 }),
+                headers: Vec::new(),
             });
         }
 
@@ -1715,13 +1873,14 @@ where
     pub fn with_400_validation_error(mut self, registry: &dyn OpenApiRegistry) -> Self {
         let problem_name = ensure_schema::<toolkit_canonical_errors::Problem>(registry);
 
-        self.spec.responses.push(ResponseSpec {
+        self.spec.upsert_response(ResponseSpec {
             status: http::StatusCode::BAD_REQUEST.as_u16(),
             content_type: problem::APPLICATION_PROBLEM_JSON,
             description: "Validation Error".to_owned(),
             schema: Some(ResponseSchema::Ref {
                 schema_name: problem_name,
             }),
+            headers: Vec::new(),
         });
 
         self

--- a/libs/toolkit/src/api/operation_builder_tests.rs
+++ b/libs/toolkit/src/api/operation_builder_tests.rs
@@ -254,6 +254,138 @@ fn standard_errors() {
 }
 
 #[test]
+fn response_header_attaches_to_the_most_recent_response() {
+    let builder = OperationBuilder::<Missing, Missing, ()>::get("/tests/v1/test")
+        .anonymous()
+        .handler(test_handler)
+        .json_response(http::StatusCode::OK, "Success")
+        .json_response(http::StatusCode::ACCEPTED, "Accepted")
+        .response_header(ResponseHeaderSpec::new(
+            "Location",
+            "Resource URI",
+            ResponseHeaderType::String,
+        ));
+
+    let ok: Vec<_> = builder
+        .spec
+        .responses
+        .iter()
+        .filter(|response| response.status == 200)
+        .collect();
+    let accepted: Vec<_> = builder
+        .spec
+        .responses
+        .iter()
+        .filter(|response| response.status == 202)
+        .collect();
+    assert_eq!(ok.len(), 1);
+    assert_eq!(accepted.len(), 1);
+    assert!(ok[0].headers.is_empty());
+    assert_eq!(accepted[0].headers.len(), 1);
+    assert_eq!(accepted[0].headers[0].name, "Location");
+}
+
+#[test]
+#[should_panic(expected = "response 200 already declares header 'location'")]
+fn response_spec_with_headers_rejects_case_insensitive_duplicates_in_batch() {
+    let _response = ResponseSpec::new(200, "application/json", "Success", None).with_headers([
+        ResponseHeaderSpec::without_description("Location", ResponseHeaderType::String),
+        ResponseHeaderSpec::without_description("location", ResponseHeaderType::String),
+    ]);
+}
+
+#[test]
+#[should_panic(expected = "response 200 already declares header 'location'")]
+fn response_spec_with_headers_rejects_case_insensitive_existing_duplicate() {
+    let _response = ResponseSpec::new(200, "application/json", "Success", None)
+        .with_headers([ResponseHeaderSpec::without_description(
+            "Location",
+            ResponseHeaderType::String,
+        )])
+        .with_headers([ResponseHeaderSpec::without_description(
+            "location",
+            ResponseHeaderType::String,
+        )]);
+}
+
+#[test]
+fn redeclared_response_becomes_the_header_target() {
+    let builder = OperationBuilder::<Missing, Missing, ()>::get("/tests/v1/test")
+        .anonymous()
+        .handler(test_handler)
+        .json_response(http::StatusCode::OK, "Original")
+        .json_response(http::StatusCode::ACCEPTED, "Accepted")
+        .json_response(http::StatusCode::OK, "Replacement")
+        .response_header(ResponseHeaderSpec::new(
+            "Location",
+            "Resource URI",
+            ResponseHeaderType::String,
+        ));
+
+    assert_eq!(builder.spec.responses.len(), 2);
+    assert_eq!(builder.spec.responses.last().unwrap().status, 200);
+    assert_eq!(
+        builder.spec.responses.last().unwrap().description,
+        "Replacement"
+    );
+    assert_eq!(builder.spec.responses.last().unwrap().headers.len(), 1);
+}
+
+#[test]
+#[should_panic(expected = "response 200 already declares header 'location'")]
+fn response_header_rejects_case_insensitive_duplicates() {
+    let _builder = OperationBuilder::<Missing, Missing, ()>::get("/tests/v1/test")
+        .anonymous()
+        .handler(test_handler)
+        .json_response(http::StatusCode::OK, "Success")
+        .response_header(ResponseHeaderSpec::new(
+            "Location",
+            "Resource URI",
+            ResponseHeaderType::String,
+        ))
+        .response_header(ResponseHeaderSpec::new(
+            "location",
+            "Duplicate URI",
+            ResponseHeaderType::String,
+        ));
+}
+
+#[test]
+fn replacing_a_response_preserves_its_headers() {
+    let registry = MockRegistry::new();
+    let builder = OperationBuilder::<Missing, Missing, ()>::get("/tests/v1/test")
+        .anonymous()
+        .handler(test_handler)
+        .json_response(http::StatusCode::OK, "Success")
+        .problem_response(
+            &registry,
+            http::StatusCode::TOO_MANY_REQUESTS,
+            "Custom rate limit response",
+        )
+        .response_header(ResponseHeaderSpec::new(
+            "Retry-After",
+            "Delay before retrying",
+            ResponseHeaderType::Integer,
+        ))
+        .standard_errors(&registry);
+
+    let rate_limited: Vec<_> = builder
+        .spec
+        .responses
+        .iter()
+        .filter(|response| response.status == 429)
+        .collect();
+    assert_eq!(rate_limited.len(), 1);
+    assert_eq!(rate_limited[0].description, "Too Many Requests");
+    assert_eq!(rate_limited[0].headers.len(), 1);
+    assert_eq!(rate_limited[0].headers[0].name, "Retry-After");
+    assert_eq!(
+        rate_limited[0].headers[0].header_type,
+        ResponseHeaderType::Integer
+    );
+}
+
+#[test]
 fn error_413_is_available_for_extractor_json_operations() {
     let registry = MockRegistry::new();
     let builder = OperationBuilder::<Missing, Missing, ()>::get("/tests/v1/test")


### PR DESCRIPTION
- add typed response header declarations to OperationBuilder
- preserve headers when response statuses are redeclared
- document and test types-registry response headers
- regenerate the committed OpenAPI contract

closes #4681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for declaring response headers in REST API specifications.
  * Generated API documentation now includes `Location`, `Retry-After`, and `Idempotency-Replayed` headers where applicable.
  * OpenAPI output supports string, integer, and boolean response header types, including body-less responses.
  * Response definitions preserve headers when statuses or content types are combined or updated.

* **Documentation**
  * Added guidance and checklist coverage for documenting response headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->