### PR TITLE
test(cluster): stabilize flaky gRPC + integration tests under CI load

### DIFF
--- a/gears/system/cluster/cluster/tests/consumer_wiring.rs
+++ b/gears/system/cluster/cluster/tests/consumer_wiring.rs
@@ -148,7 +148,12 @@ impl toolkit::contracts::RunnableCapability for Reservations {
         //    supply - so the number is pinned here rather than left to be
         //    rediscovered under load.
         if let Ok(cache) = resolved {
-            let outcome = tokio::time::timeout(Duration::from_secs(30), cache.get("seat/12")).await;
+            // A fail-fast backstop, not a measurement: the call itself is bounded
+            // by the connector's DNS failure plus backoff (~8s observed). One
+            // minute is generous room over that so a slow CI box cannot turn
+            // latency into an `Err(Elapsed)` the match below reads as a *wrong
+            // result*.
+            let outcome = tokio::time::timeout(Duration::from_mins(1), cache.get("seat/12")).await;
             match outcome {
                 Ok(Err(ClusterError::Provider { kind, .. })) => {
                     assert_eq!(
@@ -230,7 +235,11 @@ async fn a_consumer_resolving_in_start_finds_the_wired_remote_client() {
 
             // Wait for `start` to finish its observations, then cancel. Cancelling
             // first would return `Cancelled` from `run` before any phase executed.
-            let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+            // Strictly larger than the inner `cache.get` backstop (one minute)
+            // above: `START_COMPLETED` is set right after that call returns, so
+            // this outer wait must dominate it rather than race it to the deadline.
+            // The `is_finished` guard below still fails fast if the lifecycle returns.
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(90);
             while !START_COMPLETED.load(Ordering::SeqCst) {
                 assert!(
                     tokio::time::Instant::now() < deadline,

--- a/gears/system/cluster/cluster/tests/grpc_services.rs
+++ b/gears/system/cluster/cluster/tests/grpc_services.rs
@@ -26,13 +26,39 @@ use toolkit_transport_grpc::InternalAuthInterceptor;
 mod common;
 use common::served_gear::{ServedGear, served_gear};
 
-/// The per-unary-call deadline this test stands in for.
+/// The per-call deadline the watch tests carry on their stream.
 ///
 /// The deployed value is `GrpcClientConfig::rpc_timeout` (30 s by default), which
 /// is far too long to hold a test against. What the number has to be is *some*
 /// real RPC timeout, so that a stream held past it demonstrates the property; the
 /// magnitude is not what is being asserted.
-const RPC_TIMEOUT: Duration = Duration::from_millis(250);
+///
+/// It is deliberately **not** as short as it could be. A watch/`await_change`
+/// subscribe is a streaming call whose *response future* — the header flush that
+/// makes `.watch()` return — is governed by this deadline, so a value in the
+/// hundreds of milliseconds would race that handshake under LLVM-coverage load and
+/// flake exactly the way the unary tests did (#4695). A couple of seconds is far
+/// above any header-flush overhead, and — because the idle hold below is additive,
+/// not a multiple of this value — enlarging it costs the suite almost nothing.
+const RPC_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// How far *past* [`RPC_TIMEOUT`] a subscription is held idle before it must still
+/// deliver. Additive rather than a multiple of the deadline, so [`RPC_TIMEOUT`]
+/// can be sized for a safe handshake without inflating the real sleep. Any margin
+/// proves the property — that the stream outlives its own deadline — since the
+/// deadline's magnitude is explicitly not what is asserted.
+const HELD_PAST_DEADLINE: Duration = Duration::from_millis(750);
+
+/// The deadline a *semantic* unary assertion carries: the deployed
+/// `GrpcClientConfig::rpc_timeout` default.
+///
+/// It is not the subject of any assertion — it is a fail-fast backstop, so a test
+/// that hits a genuinely hung server fails *at the call* rather than blocking
+/// until the harness kills the whole job. Kept far above any LLVM-coverage or
+/// CI-scheduling overhead a correct call could ever incur, so — unlike
+/// [`RPC_TIMEOUT`] — it can never turn a slow-but-correct call into a spurious
+/// `Cancelled` (#4695).
+const SEMANTIC_RPC_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// A running cluster gear, serving all four services on a real port.
 struct Server_ {
@@ -46,11 +72,33 @@ impl Server_ {
         }
     }
 
-    /// A channel with the per-call deadline unary calls carry.
+    /// A channel carrying a short per-call deadline.
+    ///
+    /// Used **only** by the tests that assert a *stream outlives that deadline*
+    /// (§6.10), where the timeout is the subject of the assertion. A semantic
+    /// unary assertion must never open its channel here: the round trip would be
+    /// racing `RPC_TIMEOUT`, and under LLVM-coverage instrumentation or ordinary
+    /// CI scheduling delay a slow-but-correct call maps to `Status::cancelled`
+    /// instead of the code under test — the spurious failure #4695 reported. Those
+    /// tests use [`Server_::channel_bounded`] instead.
     async fn channel_with_rpc_timeout(&self) -> Channel {
         Channel::from_shared(self.gear.endpoint.clone())
             .expect("a valid endpoint")
             .timeout(RPC_TIMEOUT)
+            .connect()
+            .await
+            .expect("connects")
+    }
+
+    /// A channel for semantic unary assertions: a generous fail-fast deadline
+    /// ([`SEMANTIC_RPC_TIMEOUT`]) that bounds a hung server without racing a
+    /// correct call. This is the channel semantic tests use — never
+    /// [`Server_::channel_with_rpc_timeout`], whose short deadline is only for the
+    /// tests that assert a stream outlives it.
+    async fn channel_bounded(&self) -> Channel {
+        Channel::from_shared(self.gear.endpoint.clone())
+            .expect("a valid endpoint")
+            .timeout(SEMANTIC_RPC_TIMEOUT)
             .connect()
             .await
             .expect("connects")
@@ -84,7 +132,7 @@ async fn all_four_services_serve() {
     let server = Server_::start().await;
 
     let mut cache = stubs::cache::cluster_cache_api_client::ClusterCacheApiClient::with_interceptor(
-        server.channel_with_rpc_timeout().await,
+        server.channel_bounded().await,
         credential(),
     );
     cache
@@ -111,7 +159,7 @@ async fn all_four_services_serve() {
 
     let mut lock =
         stubs::lock::distributed_lock_api_client::DistributedLockApiClient::with_interceptor(
-            server.channel_with_rpc_timeout().await,
+            server.channel_bounded().await,
             credential(),
         );
     let token = lock
@@ -137,7 +185,7 @@ async fn all_four_services_serve() {
 
     let mut leader =
         stubs::leader::leader_election_api_client::LeaderElectionApiClient::with_interceptor(
-            server.channel_with_rpc_timeout().await,
+            server.channel_bounded().await,
             credential(),
         );
     let joined = leader
@@ -158,7 +206,7 @@ async fn all_four_services_serve() {
 
     let mut profiles =
         stubs::profile::cluster_profile_api_client::ClusterProfileApiClient::with_interceptor(
-            server.channel_with_rpc_timeout().await,
+            server.channel_bounded().await,
             credential(),
         );
     let described = profiles
@@ -183,7 +231,7 @@ async fn an_unknown_profile_returns_the_not_found_mapped_profile_not_bound() {
 
     let server = Server_::start().await;
     let mut cache = stubs::cache::cluster_cache_api_client::ClusterCacheApiClient::with_interceptor(
-        server.channel_with_rpc_timeout().await,
+        server.channel_bounded().await,
         credential(),
     );
 
@@ -225,7 +273,7 @@ async fn a_watch_stream_outlives_an_rpc_timeout() {
         )
     };
 
-    // 1. A channel carrying the same `rpc_timeout` the unary calls use.
+    // 1. A channel carrying an `rpc_timeout` on the stream.
     let mut on_timed_channel =
         stubs::cache::cluster_cache_api_client::ClusterCacheApiClient::with_interceptor(
             server.channel_with_rpc_timeout().await,
@@ -256,9 +304,9 @@ async fn a_watch_stream_outlives_an_rpc_timeout() {
         .expect("the watch subscribes")
         .into_inner();
 
-    // Held idle far past the deadline. Real sleeps, not virtual: this is a
-    // property of a socket and a server, and a paused clock would move neither.
-    tokio::time::sleep(RPC_TIMEOUT * 4).await;
+    // Held idle past the deadline. Real sleeps, not virtual: this is a property of
+    // a socket and a server, and a paused clock would move neither.
+    tokio::time::sleep(RPC_TIMEOUT + HELD_PAST_DEADLINE).await;
 
     let mut writer = untimed().await;
     writer
@@ -285,7 +333,7 @@ async fn a_watch_stream_outlives_an_rpc_timeout() {
         assert_eq!(
             event.kind,
             i32::from(stubs::cache::CacheWatchEventKind::Changed),
-            "{shape}: a stream held far past rpc_timeout still delivers - the server \
+            "{shape}: a stream held past rpc_timeout still delivers - the server \
              sets no deadline of its own"
         );
     }
@@ -411,9 +459,11 @@ async fn an_election_subscription_also_carries_no_rpc_timeout() {
     // then severed would be one behaving exactly as designed.
     let server = Server_::start().await;
 
+    // `join` is semantic setup, so it carries the fail-fast backstop — not the
+    // short deadline under test, which no unary call here should race.
     let mut leader =
         stubs::leader::leader_election_api_client::LeaderElectionApiClient::with_interceptor(
-            server.channel_with_rpc_timeout().await,
+            server.channel_bounded().await,
             credential(),
         );
     let joined = leader
@@ -428,7 +478,14 @@ async fn an_election_subscription_also_carries_no_rpc_timeout() {
         .expect("join succeeds")
         .into_inner();
 
-    let mut stream = leader
+    // Only `await_change` — the subscription whose survival past the deadline is
+    // the subject of this test — is opened on the short-deadline channel.
+    let mut subscriber =
+        stubs::leader::leader_election_api_client::LeaderElectionApiClient::with_interceptor(
+            server.channel_with_rpc_timeout().await,
+            credential(),
+        );
+    let mut stream = subscriber
         .await_change(stubs::leader::AwaitChangeRequest {
             profile: "orders".to_owned(),
             election_id: joined.election_id,
@@ -437,7 +494,7 @@ async fn an_election_subscription_also_carries_no_rpc_timeout() {
         .expect("the subscription opens")
         .into_inner();
 
-    tokio::time::sleep(RPC_TIMEOUT * 4).await;
+    tokio::time::sleep(RPC_TIMEOUT + HELD_PAST_DEADLINE).await;
 
     // The gear drains. Item `S5` owns the ordering; what matters here is that the
     // subscription was still there to receive it after all that idle time.
@@ -456,7 +513,7 @@ async fn an_election_subscription_also_carries_no_rpc_timeout() {
     assert_eq!(
         event.kind,
         i32::from(stubs::leader::LeaderWatchEventKind::Closed),
-        "a subscription held far past rpc_timeout still receives its terminal event"
+        "a subscription held past rpc_timeout still receives its terminal event"
     );
 
     server.stop().await;

--- a/gears/system/cluster/cluster/tests/oop_probe_ordering.rs
+++ b/gears/system/cluster/cluster/tests/oop_probe_ordering.rs
@@ -60,6 +60,16 @@ use grpc_hub as _;
 /// Released by the test to let the start phase complete.
 static START_GATE: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(0);
 
+/// Posted by the gate gear the instant its `start` has recorded its observation,
+/// before it blocks on [`START_GATE`]. The test acquires it to establish a
+/// happens-before with [`CLUSTER_WAS_STARTED_FIRST`]: without it the polling
+/// thread can reach the ordering assertion before the spawned lifecycle task has
+/// even reached the gate gear's `start`, reading the atomic's default `false`
+/// (the framework guarantees the *ordering* - `run_start_phase` awaits each gear
+/// in `gears_by_system_priority` order - so the only way the flag reads `false`
+/// is a test that reads it too early, which is what flaked under CI load).
+static GATE_REACHED_START: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(0);
+
 /// What the gate gear saw when its own `start` ran — the Profile 1 ordering
 /// observation, recorded rather than assumed (see [`StartGate`]).
 static CLUSTER_WAS_STARTED_FIRST: std::sync::atomic::AtomicBool =
@@ -110,6 +120,13 @@ impl toolkit::contracts::RunnableCapability for StartGate {
                 .is_some_and(|client| client.cache_backend("orders").is_ok());
             CLUSTER_WAS_STARTED_FIRST.store(published, std::sync::atomic::Ordering::SeqCst);
         }
+
+        // Announce that `start` has run and the observation is recorded, so the
+        // test can read `CLUSTER_WAS_STARTED_FIRST` with a happens-before rather
+        // than racing the spawned lifecycle task to it. Posted before the block
+        // below, so the test's ordering assertion is unblocked while the phase is
+        // still held open here.
+        GATE_REACHED_START.add_permits(1);
 
         // Blocks until the test grants a permit. `forget` so a second start (there
         // is none) would block again rather than inherit the permit.
@@ -364,6 +381,19 @@ async fn probes_serve_before_start_completes_and_all_four_answer_after() {
 
     let lifecycle = tokio::spawn(run_oop_serving(run, serve));
 
+    // 0. Wait until the start phase has provably reached the gate gear (and so has
+    //    already run - and awaited to completion - every earlier gear, cluster
+    //    among them, since `run_start_phase` is sequential and system-first). This
+    //    is the happens-before every "during startup" assertion below relies on:
+    //    the gate gear is now parked inside its `start`, holding the phase open, so
+    //    the probe states are a genuine mid-startup snapshot and
+    //    `CLUSTER_WAS_STARTED_FIRST` is recorded rather than still at its default.
+    tokio::time::timeout(Duration::from_secs(10), GATE_REACHED_START.acquire())
+        .await
+        .expect("the start phase must reach the gate gear within 10s")
+        .expect("the gate-reached semaphore is never closed")
+        .forget();
+
     // 1. Liveness answers while the start phase is still blocked on the gate. This
     //    is the criterion's "binds probes before `start`", and it is checked
     //    against a phase that provably has not returned rather than against a
@@ -408,7 +438,8 @@ async fn probes_serve_before_start_completes_and_all_four_answer_after() {
     //    cluster had already published its profiles by the time a non-`system`
     //    gear's `start` ran, with no `deps` edge in this process. This is what
     //    makes `deps = [cluster]` unnecessary - and it must be unnecessary, because
-    //    it is fatal in Profile 3 (`tests/consumer_wiring.rs`).
+    //    it is fatal in Profile 3 (`tests/consumer_wiring.rs`). The read is safe
+    //    because step 0 already synchronized on the gate gear having recorded it.
     assert!(
         CLUSTER_WAS_STARTED_FIRST.load(Ordering::SeqCst),
         "cluster's `start` must precede a non-system gear's `start` by tier alone; \

--- a/gears/system/cluster/cluster/tests/remote_backends.rs
+++ b/gears/system/cluster/cluster/tests/remote_backends.rs
@@ -675,13 +675,18 @@ async fn a_follower_pump_mints_one_subscription_per_renewal_interval() {
     let settled = fixture.gear.subscriptions.len();
     assert_eq!(settled, 2, "one subscription per `elect`, and no more yet");
 
-    tokio::time::sleep(FAST_RENEWAL * 5).await;
+    // Eight nominal intervals of observation against a floor of three: the pump's
+    // cadence is a real timer, so on a saturated CI box (this runs under the whole
+    // workspace's test load) it can be scheduler-starved and fire fewer times than
+    // the wall clock would suggest. A wide window keeps the *property* - that a
+    // steady-state follower keeps leaking - decidable without racing that latency.
+    tokio::time::sleep(FAST_RENEWAL * 8).await;
 
     let grown = fixture.gear.subscriptions.len();
     assert!(
         grown >= settled + 3,
         "a steady-state follower must leak one unattached subscription per renewal \
-         interval: started at {settled}, after five intervals {grown}"
+         interval: started at {settled}, after eight intervals {grown}"
     );
 
     fixture.stop().await;
@@ -1572,7 +1577,11 @@ async fn a_gate_consumer_cannot_wedge_the_remote_pump() {
 
     tokio::time::sleep(FAST_RENEWAL * 4).await;
     let renews_early = tally.get().2;
-    tokio::time::sleep(FAST_RENEWAL * 6).await;
+    // Nine nominal intervals against a floor of three renews: same reasoning as
+    // `a_follower_pump_mints...` - the renewal cadence is a real timer that a
+    // saturated runtime can starve, so the window is wide enough that genuine
+    // progress is still decidable when the pump fires slower than its cadence.
+    tokio::time::sleep(FAST_RENEWAL * 9).await;
     let renews_late = tally.get().2;
     println!("[wedge] renews {renews_early} -> {renews_late} through a full buffer");
     assert!(


### PR DESCRIPTION
## Problem

The cluster integration suite carried a family of scheduling/timing flakes that surface under CI load (LLVM coverage instrumentation and concurrent workspace-test scheduling). The first to be chased was a spurious gRPC status-code mismatch; a review of the rest of the suite found the same class elsewhere. This PR fixes all of the confirmed/high-risk ones together.

## Fixes

### 1. gRPC channel deadlines (`grpc_services.rs`) — the original flake

Under coverage, a *correct* unary round trip could exceed the test client's `250 ms` per-call deadline. Tonic 0.14 maps the client-side `TimeoutExpired` to `Status::cancelled`, so the timeout masqueraded as the wrong status code (`Cancelled` vs `NotFound`) — nothing to do with the code under test.

- **Semantic assertions** (`all_four_services_serve`, the unknown-profile test) move onto a new `channel_bounded()` carrying `SEMANTIC_RPC_TIMEOUT` (30 s, the deployed `GrpcClientConfig::rpc_timeout` default) — a fail-fast backstop that bounds a genuinely hung server without racing a correct call.
- **Watch tests** keep the short deadline (it *is* their subject), raised to `2 s` so the streaming subscribe handshake no longer races it under coverage. The idle hold is now additive (`RPC_TIMEOUT + HELD_PAST_DEADLINE`) instead of a multiple.
- Each channel constructor documents which tests may use it, so the flake cannot regress.

### 2. Start-phase ordering (`oop_probe_ordering.rs`) — the flake CI actually hit

`probes_serve_before_start_completes_and_all_four_answer_after` panicked on `assert!(CLUSTER_WAS_STARTED_FIRST)`. The framework already **guarantees** this ordering — `run_start_phase` awaits each gear sequentially in `gears_by_system_priority()` order (system-tier first), and the cluster gear publishes its `orders` backend synchronously before `start()` returns. So the atomic can only read `false` when the test reads it **before the gate gear's `start()` has run at all**, getting the atomic's default. It was a missing happens-before in the *test*, not an ordering race.

- Added a `GATE_REACHED_START` semaphore the gate gear posts the instant it records its observation (before it blocks the phase open).
- The test awaits that barrier before its "during startup" assertions, so the whole snapshot is provably mid-startup and the ordering flag is read with a happens-before rather than racing the spawned lifecycle task.

### 3. Renewal-count windows (`remote_backends.rs`)

Two lower-bound count assertions measure a **real-timer** pump that a saturated runtime can scheduler-starve, firing fewer times than the wall clock suggests. Widened the observation window (property preserved, floors unchanged):

- `a_follower_pump_mints_one_subscription_per_renewal_interval`: `FAST_RENEWAL*5` → `*8`
- `a_gate_consumer_cannot_wedge_the_remote_pump`: `FAST_RENEWAL*6` → `*9`

### 4. DNS-backoff backstops (`consumer_wiring.rs`)

`a_consumer_resolving_in_start_finds_the_wired_remote_client` drives a real `connect_lazy` against an unresolvable name (~8 s of DNS failure + backoff). Raised the fail-fast backstops so a slow CI box cannot turn that latency into an `Err(Elapsed)` the match reads as a *wrong result*: inner `cache.get` `30 s` → `1 min`, outer poll `30 s` → `90 s` (kept strictly larger so it dominates rather than races the inner).

## Scope note — deliberately not touched

Several `remote_backends.rs` timing tests were reviewed and **left as-is**: they document healthy margins (e.g. `the_restart_cycle` sits ~20× above its fixed case; `a_broken_feed` ~15×) or are constrained by design (`a_renew_that_never_answers`' bound must stay below the broken-deadline case to remain a valid mutation check). `a_slow_but_healthy_renew`'s timing is a fixed wall-clock sleep (coverage-immune). The `coordination.rs` prefix-watch polyfill diffs against an empty baseline under a virtual clock, so it is deterministic. Widening these would only erode regression sensitivity for no measured benefit. The `free_port`/`free_addr` port-reuse TOCTOU and nextest's soft "leaky" (resource-teardown) signal are separate bug classes and belong in their own follow-up.

## Verification

- `oop_probe_ordering`: **15/15** consecutive green.
- Widened `remote_backends` tests: **5/5** green.
- Full `cf-gears-cluster` suite (295 tests): **295/295** passed, and **25** high-parallelism (`--test-threads=16`) stress runs with **0** hard failures.
- Original gRPC verification: **12/12** consecutive `cargo llvm-cov --no-report -p cf-gears-cluster --test grpc_services`.
- `cargo fmt -p cf-gears-cluster -- --check` and `cargo clippy -p cf-gears-cluster --tests --all-features`: clean (exit 0, 0 warnings).

## Acceptance criteria

- [x] The suite is no longer sensitive to LLVM-coverage overhead or CI scheduling delay across the confirmed/high-risk cases.
- [x] Every test that keeps a short deadline does so because the deadline is the test's subject; everywhere else an incidental deadline was replaced with a condition-poll, a happens-before barrier, or a generous fail-fast backstop.
- [x] All original assertions are preserved (only channels/deadlines/windows/synchronization changed).

Closes #4695


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of RPC deadline behavior for streaming and unary requests.
  * Increased test reliability by separating deadline scenarios and allowing semantic service checks additional time to complete.
  * Strengthened startup-ordering checks with explicit synchronization.
  * Extended observation windows for remote backend renewal and consumer scenarios to reduce timing-related failures under load.
  * Updated assertions, comments, and timing conditions to better reflect expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->