### PR TITLE
feat(chat-engine): accept per-turn client metadata on send

### DIFF
--- a/gears/chat-engine/chat-engine/src/api/rest/dto.rs
+++ b/gears/chat-engine/chat-engine/src/api/rest/dto.rs
@@ -350,6 +350,13 @@ pub struct SendMessageRequestDto {
     pub parent_message_id: Option<Uuid>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capabilities: Option<Vec<CapabilityValueDto>>,
+    /// Opaque per-turn client context (device, locale, active error state, …)
+    /// persisted on the user message row and echoed back on reads as the
+    /// message's `metadata`. Engine-reserved keys (`model_used`, `finish_reason`,
+    /// `temperature_used`, `usage`, `summarized_message_ids`) and payloads larger
+    /// than 8 KiB serialized are rejected with `400`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<JsonValue>,
 }
 
 /// Body for `POST /chat-engine/v1/messages/{id}/recreate`.

--- a/gears/chat-engine/chat-engine/src/api/rest/handlers/glue.rs
+++ b/gears/chat-engine/chat-engine/src/api/rest/handlers/glue.rs
@@ -80,6 +80,7 @@ pub async fn send_message_in_session(
         file_ids: body.file_ids.unwrap_or_default(),
         parent_message_id: body.parent_message_id,
         capabilities: capabilities_into_sdk(body.capabilities),
+        metadata: body.metadata,
     };
     let cancel = CancellationToken::new();
     let stream = svc.send_message(req, &ctx, cancel).await?;

--- a/gears/chat-engine/chat-engine/src/api/rest/handlers/messages.rs
+++ b/gears/chat-engine/chat-engine/src/api/rest/handlers/messages.rs
@@ -56,6 +56,11 @@ pub struct SendMessageBody {
     /// session's `enabled_capabilities`.
     #[serde(default)]
     pub capabilities: Option<Vec<CapabilityValue>>,
+    /// Optional opaque per-turn client context, persisted on the user
+    /// message row. Reserved (assistant-side) keys and payloads over
+    /// `MAX_MESSAGE_METADATA_BYTES` are rejected in the service layer.
+    #[serde(default)]
+    pub metadata: Option<JsonValue>,
 
     // ---- anti-spoof fields (PRD §7; rejected if present) ----
     pub tenant_id: Option<JsonValue>,
@@ -100,6 +105,7 @@ pub async fn send_message(
         file_ids: body.file_ids.unwrap_or_default(),
         parent_message_id: body.parent_message_id,
         capabilities: body.capabilities,
+        metadata: body.metadata,
     };
 
     let event_stream = svc.send_message(req, &ctx, cancel).await?;

--- a/gears/chat-engine/chat-engine/src/domain/message.rs
+++ b/gears/chat-engine/chat-engine/src/domain/message.rs
@@ -28,6 +28,24 @@ pub use chat_engine_sdk::models::{
     UserId, VariantInfo,
 };
 
+/// Message-metadata keys the engine writes itself on assistant rows — the
+/// `LlmMessageMetadata` fields plus the summarization bookkeeping key. A
+/// client that sets one of these on an outgoing user message is rejected, so
+/// a reader can always trust their meaning. Mirrors
+/// [`crate::domain::session::RESERVED_METADATA_KEYS`] for sessions.
+pub const RESERVED_MESSAGE_METADATA_KEYS: &[&str] = &[
+    "model_used",
+    "finish_reason",
+    "temperature_used",
+    "usage",
+    "summarized_message_ids",
+];
+
+/// Upper bound on the serialized size of client-supplied `Message.metadata`.
+/// The blob is persisted verbatim for the lifetime of the session's
+/// `retention_policy`, so it is capped rather than left client-controlled.
+pub const MAX_MESSAGE_METADATA_BYTES: usize = 8 * 1024;
+
 /// Concatenate the bodies of all `text`-typed parts of a message in `number`
 /// order, joined by newlines. Non-text parts contribute nothing. This is the
 /// canonical "plain text of a message" used by search matching, export

--- a/gears/chat-engine/chat-engine/src/domain/mod.rs
+++ b/gears/chat-engine/chat-engine/src/domain/mod.rs
@@ -49,8 +49,9 @@ pub use export::{
 };
 pub use memory_strategy::{MemoryStrategy, default_memory_strategy};
 pub use message::{
-    Message, MessageRole, StreamingChunkEvent, StreamingCompleteEvent, StreamingErrorEvent,
-    StreamingEvent, StreamingStartEvent, VariantInfo,
+    MAX_MESSAGE_METADATA_BYTES, Message, MessageRole, RESERVED_MESSAGE_METADATA_KEYS,
+    StreamingChunkEvent, StreamingCompleteEvent, StreamingErrorEvent, StreamingEvent,
+    StreamingStartEvent, VariantInfo,
 };
 pub use reaction::{MessageReaction, MessageReactionEvent, ReactionType};
 pub use retention::RetentionPolicy;

--- a/gears/chat-engine/chat-engine/src/domain/service/message_service.rs
+++ b/gears/chat-engine/chat-engine/src/domain/service/message_service.rs
@@ -61,8 +61,8 @@ use crate::domain::context::{
 use crate::domain::error::{ChatEngineError, Result};
 use crate::domain::memory_strategy::MemoryStrategy;
 use crate::domain::message::{
-    Message, StreamingChunkEvent, StreamingCompleteEvent, StreamingErrorEvent, StreamingEvent,
-    StreamingStartEvent,
+    MAX_MESSAGE_METADATA_BYTES, Message, RESERVED_MESSAGE_METADATA_KEYS, StreamingChunkEvent,
+    StreamingCompleteEvent, StreamingErrorEvent, StreamingEvent, StreamingStartEvent,
 };
 use crate::domain::ports::SessionRepo;
 use crate::domain::ports::SessionTypeRepo;
@@ -164,6 +164,12 @@ pub struct SendMessageRequest {
     pub file_ids: Vec<Uuid>,
     pub parent_message_id: Option<Uuid>,
     pub capabilities: Option<Vec<CapabilityValue>>,
+    /// Opaque per-turn client context persisted on the user message row
+    /// (device, locale, active error state, …). Unlike `capabilities` it
+    /// survives into reads, export, replay, recreate, and branching, so the
+    /// conditioning of a past turn stays reconstructable. Validated by
+    /// [`validate_message_metadata`].
+    pub metadata: Option<JsonValue>,
 }
 
 /// Outgoing event stream returned by [`MessageService::send_message`]. The
@@ -1202,6 +1208,8 @@ impl MessageService {
             ));
         }
 
+        validate_message_metadata(req.metadata.as_ref())?;
+
         // Ownership is already enforced by the caller's parent-session PDP
         // decision (`authorize_session`); `session` is the authorized row.
 
@@ -1299,7 +1307,7 @@ impl MessageService {
             } else {
                 Some(req.file_ids.clone())
             },
-            metadata: None,
+            metadata: req.metadata.clone(),
         };
         self.messages.insert_user_and_assistant_stub(payload).await
     }
@@ -1799,6 +1807,38 @@ enum DriverOutcome {
 struct ValidatedRequest {
     session_type_id: Uuid,
     plugin_instance_id: String,
+}
+
+/// Reject client-supplied `Message.metadata` that writes an engine-reserved
+/// key or exceeds [`MAX_MESSAGE_METADATA_BYTES`] once serialized. The
+/// message-side counterpart of
+/// [`crate::domain::service::session_service::reject_reserved_metadata`]
+/// (ADR-0017), with the size cap added because the blob is persisted for the
+/// session's whole retention window.
+//
+// @cpt-cf-chat-engine-algo-message-processing-validate-request
+pub fn validate_message_metadata(metadata: Option<&JsonValue>) -> Result<()> {
+    let Some(metadata) = metadata else {
+        return Ok(());
+    };
+    if let JsonValue::Object(map) = metadata {
+        for key in RESERVED_MESSAGE_METADATA_KEYS {
+            if map.contains_key(*key) {
+                return Err(ChatEngineError::bad_request(format!(
+                    "metadata key '{key}' is reserved and cannot be set by clients"
+                )));
+            }
+        }
+    }
+    let size = serde_json::to_vec(metadata)
+        .map_err(|e| ChatEngineError::bad_request(format!("metadata is not serializable: {e}")))?
+        .len();
+    if size > MAX_MESSAGE_METADATA_BYTES {
+        return Err(ChatEngineError::bad_request(format!(
+            "metadata is {size} bytes serialized, exceeding the {MAX_MESSAGE_METADATA_BYTES}-byte limit"
+        )));
+    }
+    Ok(())
 }
 
 /// Names of capabilities currently enabled on a session, decoded from the

--- a/gears/chat-engine/chat-engine/src/domain/service/message_service_tests.rs
+++ b/gears/chat-engine/chat-engine/src/domain/service/message_service_tests.rs
@@ -411,6 +411,7 @@ fn make_request(session_id: Uuid) -> SendMessageRequest {
         file_ids: vec![],
         parent_message_id: None,
         capabilities: None,
+        metadata: None,
     }
 }
 
@@ -2142,4 +2143,56 @@ async fn list_active_messages_with_parent_filter_returns_direct_replies() {
             .iter()
             .all(|m| m.parent_message_id == Some(root.assistant_message_id))
     );
+}
+
+// ----------------- validate_message_metadata -----------------
+
+#[test]
+fn message_metadata_rejects_every_reserved_key() {
+    for key in RESERVED_MESSAGE_METADATA_KEYS {
+        let metadata = serde_json::json!({ *key: "spoofed" });
+        let err =
+            validate_message_metadata(Some(&metadata)).expect_err("reserved key must be rejected");
+        assert!(
+            matches!(err, ChatEngineError::BadRequest { .. }),
+            "reserved key '{key}' must map to 400, got {err:?}",
+        );
+    }
+}
+
+#[test]
+fn message_metadata_allows_client_keys_and_absent_metadata() {
+    validate_message_metadata(None).expect("absent metadata accepted");
+    let metadata = serde_json::json!({
+        "device": "ios",
+        "active_error": {"code": "E_OFFLINE"},
+        "time_remaining_s": 42,
+    });
+    validate_message_metadata(Some(&metadata)).expect("client metadata accepted");
+}
+
+#[test]
+fn message_metadata_enforces_the_serialized_size_cap() {
+    // `{"blob":"…"}` — the payload sits just under / just over the cap once
+    // the enclosing object and quotes are counted.
+    let overhead = r#"{"blob":""}"#.len();
+    let at_limit = serde_json::json!({ "blob": "x".repeat(MAX_MESSAGE_METADATA_BYTES - overhead) });
+    validate_message_metadata(Some(&at_limit)).expect("payload at the cap is accepted");
+
+    let over_limit =
+        serde_json::json!({ "blob": "x".repeat(MAX_MESSAGE_METADATA_BYTES - overhead + 1) });
+    let err = validate_message_metadata(Some(&over_limit))
+        .expect_err("payload over the cap must be rejected");
+    assert!(
+        matches!(err, ChatEngineError::BadRequest { .. }),
+        "oversized metadata must map to 400, got {err:?}",
+    );
+}
+
+#[test]
+fn message_metadata_accepts_non_object_json() {
+    // Reserved-key filtering only applies to objects; a scalar or array is
+    // opaque client context and only the size cap governs it.
+    validate_message_metadata(Some(&serde_json::json!(["a", "b"]))).expect("array accepted");
+    validate_message_metadata(Some(&serde_json::json!("plain"))).expect("string accepted");
 }

--- a/gears/chat-engine/chat-engine/tests/persistence_test.rs
+++ b/gears/chat-engine/chat-engine/tests/persistence_test.rs
@@ -431,12 +431,24 @@ async fn send_message_persists_client_metadata_on_the_user_row_against_sqlite() 
     let session_type_id = db::seed_session_type(&harness, plugin_id).await;
     let session_id = db::seed_active_session(&harness, TENANT_ID, USER_ID, session_type_id).await;
 
+    // The plugin completes with metadata of its own, so the assistant row is
+    // finalised with a populated map — otherwise the "client keys absent"
+    // assertion below would hold trivially against a NULL column.
     let plugin = FakePlugin::new(
         plugin_id,
-        FakePluginScript::Events(vec![StreamingEvent::Chunk(StreamingChunkEvent {
-            message_id: Uuid::nil(),
-            chunk: "ok".into(),
-        })]),
+        FakePluginScript::Events(vec![
+            StreamingEvent::Chunk(StreamingChunkEvent {
+                message_id: Uuid::nil(),
+                chunk: "ok".into(),
+            }),
+            StreamingEvent::Complete(StreamingCompleteEvent {
+                message_id: Uuid::nil(),
+                metadata: Some(serde_json::json!({ "finish_reason": "stop" })),
+                file_citations: vec![],
+                link_citations: vec![],
+                references: vec![],
+            }),
+        ]),
     );
     let plugin_dyn: Arc<dyn ChatEngineBackendPlugin> = plugin;
     let svc = build_service(&harness, plugin_id, plugin_dyn);
@@ -466,18 +478,26 @@ async fn send_message_persists_client_metadata_on_the_user_row_against_sqlite() 
         "per-turn client metadata must land verbatim on the user row",
     );
 
-    let assistant = rows
-        .iter()
-        .find(|m| matches!(m.role, message::MessageRole::Assistant))
-        .expect("assistant row persisted");
-    assert!(
-        assistant
-            .metadata
-            .as_ref()
-            .and_then(|m| m.get("device"))
-            .is_none(),
-        "client metadata must not leak onto the assistant row",
+    // Read the assistant row only after the detached driver has finalised it,
+    // so its metadata column is populated rather than still NULL.
+    let assistant = db::wait_for_finalize(&harness.db, session_id, Duration::from_secs(2)).await;
+    let assistant_meta = assistant.metadata.expect("assistant metadata present");
+    assert_eq!(
+        assistant_meta["finish_reason"], "stop",
+        "the plugin's own metadata must survive finalize",
     );
+    // Driven off the payload itself so the assertion cannot drift from what
+    // the request actually sent.
+    for key in client_metadata
+        .as_object()
+        .expect("client metadata is a JSON object")
+        .keys()
+    {
+        assert!(
+            assistant_meta.get(key).is_none(),
+            "client metadata key '{key}' must not leak onto the assistant row",
+        );
+    }
 }
 
 #[tokio::test]

--- a/gears/chat-engine/chat-engine/tests/persistence_test.rs
+++ b/gears/chat-engine/chat-engine/tests/persistence_test.rs
@@ -101,6 +101,7 @@ fn make_request(session_id: Uuid) -> SendMessageRequest {
         file_ids: vec![],
         parent_message_id: None,
         capabilities: None,
+        metadata: None,
     }
 }
 
@@ -259,6 +260,7 @@ async fn multi_part_user_message_round_trips_in_order_against_sqlite() {
         file_ids: vec![],
         parent_message_id: None,
         capabilities: None,
+        metadata: None,
     };
 
     let cancel = CancellationToken::new();
@@ -412,6 +414,116 @@ async fn send_message_stamps_tenant_and_author_against_sqlite() {
     assert_eq!(
         assistant.user_id, None,
         "assistant message has no human author",
+    );
+}
+
+// ===========================================================================
+// 1c. Per-turn client metadata — persisted on the user row, absent from the
+//     assistant stub, and rejected when reserved or oversized
+// ===========================================================================
+
+#[tokio::test]
+async fn send_message_persists_client_metadata_on_the_user_row_against_sqlite() {
+    use chat_engine::infra::db::entity::message;
+
+    let harness = db::setup_sqlite().await;
+    let plugin_id = "message-metadata-plugin";
+    let session_type_id = db::seed_session_type(&harness, plugin_id).await;
+    let session_id = db::seed_active_session(&harness, TENANT_ID, USER_ID, session_type_id).await;
+
+    let plugin = FakePlugin::new(
+        plugin_id,
+        FakePluginScript::Events(vec![StreamingEvent::Chunk(StreamingChunkEvent {
+            message_id: Uuid::nil(),
+            chunk: "ok".into(),
+        })]),
+    );
+    let plugin_dyn: Arc<dyn ChatEngineBackendPlugin> = plugin;
+    let svc = build_service(&harness, plugin_id, plugin_dyn);
+
+    let client_metadata = serde_json::json!({
+        "device": "ios",
+        "skill_level": "beginner",
+        "time_remaining_s": 42,
+    });
+    let mut req = make_request(session_id);
+    req.metadata = Some(client_metadata.clone());
+
+    let mut stream = svc
+        .send_message(req, &make_ctx(), CancellationToken::new())
+        .await
+        .expect("send_message dispatch");
+    while stream.next().await.is_some() {}
+
+    let rows = db::list_messages(&harness.db, session_id).await;
+    let user = rows
+        .iter()
+        .find(|m| matches!(m.role, message::MessageRole::User))
+        .expect("user message persisted");
+    assert_eq!(
+        user.metadata.as_ref(),
+        Some(&client_metadata),
+        "per-turn client metadata must land verbatim on the user row",
+    );
+
+    let assistant = rows
+        .iter()
+        .find(|m| matches!(m.role, message::MessageRole::Assistant))
+        .expect("assistant row persisted");
+    assert!(
+        assistant
+            .metadata
+            .as_ref()
+            .and_then(|m| m.get("device"))
+            .is_none(),
+        "client metadata must not leak onto the assistant row",
+    );
+}
+
+#[tokio::test]
+async fn send_message_rejects_reserved_and_oversized_metadata_against_sqlite() {
+    let harness = db::setup_sqlite().await;
+    let plugin_id = "message-metadata-reject-plugin";
+    let session_type_id = db::seed_session_type(&harness, plugin_id).await;
+    let session_id = db::seed_active_session(&harness, TENANT_ID, USER_ID, session_type_id).await;
+
+    let plugin = FakePlugin::new(plugin_id, FakePluginScript::Events(vec![]));
+    let plugin_dyn: Arc<dyn ChatEngineBackendPlugin> = plugin;
+    let svc = build_service(&harness, plugin_id, plugin_dyn);
+
+    let mut reserved = make_request(session_id);
+    reserved.metadata = Some(serde_json::json!({"model_used": "spoofed"}));
+    let err = svc
+        .send_message(reserved, &make_ctx(), CancellationToken::new())
+        .await
+        .err()
+        .expect("reserved key must be rejected");
+    assert!(
+        matches!(
+            err,
+            chat_engine::domain::error::ChatEngineError::BadRequest { .. }
+        ),
+        "reserved metadata key must map to 400, got {err:?}",
+    );
+
+    let mut oversized = make_request(session_id);
+    oversized.metadata = Some(serde_json::json!({"blob": "x".repeat(9 * 1024)}));
+    let err = svc
+        .send_message(oversized, &make_ctx(), CancellationToken::new())
+        .await
+        .err()
+        .expect("oversized metadata must be rejected");
+    assert!(
+        matches!(
+            err,
+            chat_engine::domain::error::ChatEngineError::BadRequest { .. }
+        ),
+        "oversized metadata must map to 400, got {err:?}",
+    );
+
+    assert!(
+        db::list_messages(&harness.db, session_id).await.is_empty(),
+        "a rejected send must not persist any message row",
     );
 }
 

--- a/gears/chat-engine/docs/openapi.json
+++ b/gears/chat-engine/docs/openapi.json
@@ -456,6 +456,17 @@
               "null"
             ]
           },
+          "metadata": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Value",
+                "description": "Opaque per-turn client context (device, locale, active error state, …)\npersisted on the user message row and echoed back on reads as the\nmessage's `metadata`. Engine-reserved keys (`model_used`, `finish_reason`,\n`temperature_used`, `usage`, `summarized_message_ids`) and payloads larger\nthan 8 KiB serialized are rejected with `400`."
+              }
+            ]
+          },
           "parent_message_id": {
             "format": "uuid",
             "type": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-turn metadata to chat messages.
  * Metadata is persisted on user messages and returned when messages are read.
* **Bug Fixes**
  * Added validation that rejects engine-reserved metadata keys and serialized payloads exceeding 8 KiB with a 400 error.
* **Documentation**
  * Updated the OpenAPI documentation to describe metadata support, persistence, and validation limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->