### PR TITLE
fix(authn-resolver): seconds-scale bucket boundaries for authn duration histograms

### DIFF
--- a/gears/system/authn-resolver/plugins/oidc-authn-plugin/src/domain/metrics.rs
+++ b/gears/system/authn-resolver/plugins/oidc-authn-plugin/src/domain/metrics.rs
@@ -27,6 +27,12 @@ pub(crate) use definitions::{
     TOKEN_REJECTION_REASON_MISSING_TENANT, TOKEN_REJECTION_REASON_UNTRUSTED_ISSUER,
 };
 
+/// Seconds-scale bucket boundaries for the authn duration histograms;
+/// the SDK default boundaries are millisecond-scale.
+const AUTHN_DURATION_BOUNDARIES_SECS: &[f64] = &[
+    0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0,
+];
+
 /// OpenTelemetry-backed metrics handle shared across plugin components.
 #[domain_model]
 pub struct AuthNMetrics {
@@ -100,11 +106,13 @@ impl AuthNMetrics {
                 .f64_histogram(AUTHN_JWKS_FETCH_DURATION_SECONDS)
                 .with_description("JWKS network fetch duration")
                 .with_unit("s")
+                .with_boundaries(AUTHN_DURATION_BOUNDARIES_SECS.to_vec())
                 .build(),
             request_success_duration_seconds: meter
                 .f64_histogram(AUTHN_REQUEST_SUCCESS_DURATION_SECONDS)
                 .with_description("Successful authentication request duration")
                 .with_unit("s")
+                .with_boundaries(AUTHN_DURATION_BOUNDARIES_SECS.to_vec())
                 .build(),
             request_failures_total: meter
                 .u64_counter(AUTHN_REQUEST_FAILURES_TOTAL)

--- a/gears/system/authn-resolver/plugins/oidc-authn-plugin/src/domain/metrics_tests.rs
+++ b/gears/system/authn-resolver/plugins/oidc-authn-plugin/src/domain/metrics_tests.rs
@@ -145,6 +145,30 @@ impl MetricsHarness {
 
         total
     }
+
+    /// Bucket boundaries of the named histogram, if exported.
+    #[must_use]
+    pub fn histogram_bounds(&self, name: &str) -> Option<Vec<f64>> {
+        let metrics = self
+            .exporter
+            .get_finished_metrics()
+            .expect("in-memory exporter should be readable");
+
+        for resource_metrics in &metrics {
+            for scope_metrics in resource_metrics.scope_metrics() {
+                for metric in scope_metrics.metrics() {
+                    if metric.name() == name
+                        && let AggregatedMetrics::F64(MetricData::Histogram(hist)) = metric.data()
+                        && let Some(dp) = hist.data_points().next()
+                    {
+                        return Some(dp.bounds().collect());
+                    }
+                }
+            }
+        }
+
+        None
+    }
 }
 
 impl Default for MetricsHarness {
@@ -263,4 +287,32 @@ fn production_otel_path_records_metrics() {
     assert!(harness.histogram_count(AUTHN_JWT_VALIDATION_DURATION_SECONDS, &[]) >= 1);
     assert!(harness.histogram_count(AUTHN_JWKS_FETCH_DURATION_SECONDS, &[]) >= 1);
     assert!(harness.histogram_count(AUTHN_S2S_EXCHANGE_DURATION_SECONDS, &[]) >= 1);
+}
+
+#[test]
+fn duration_histograms_use_second_scale_bucket_boundaries() {
+    let harness = MetricsHarness::new();
+    let metrics = harness.metrics();
+
+    // Record a sample so each histogram exports a data point.
+    metrics.record_request_success_duration(Duration::from_millis(3));
+    metrics.record_jwks_fetch_duration(Duration::from_millis(40));
+
+    harness.force_flush();
+
+    for name in [
+        AUTHN_REQUEST_SUCCESS_DURATION_SECONDS,
+        AUTHN_JWKS_FETCH_DURATION_SECONDS,
+    ] {
+        let bounds = harness
+            .histogram_bounds(name)
+            .expect("duration histogram should export a data point");
+        assert_eq!(
+            bounds,
+            vec![
+                0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0
+            ],
+            "{name} records seconds and must use second-scale bucket boundaries"
+        );
+    }
 }


### PR DESCRIPTION
authn.request.success.duration and authn.jwks.fetch.duration record seconds (semconv unit "s") but never set explicit boundaries, so the OTel SDK applies its legacy default set (5, 10, 25, ... 10000) — numbers designed for millisecond values. With seconds-valued observations the first finite boundary le="5" means five SECONDS, so every realistic millisecond-scale sample lands in that single bucket: the histograms carry no information about the sub-second range where authentication actually operates, and histogram_quantile() degenerates into linear interpolation inside that bucket (p95 pins to a constant 4.75 = 0.95 x 5, whatever the real latency is).

Set explicit seconds-scale boundaries on both instruments, the same way the neighbouring authn.jwt.validation.duration and authn.s2s.exchange.duration histograms in this module already do, and assert the exported boundaries in a unit test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication performance metrics by recording JWKS fetch and request success durations using appropriately scaled, seconds-based histogram boundaries.
  * Duration metrics now provide more accurate and meaningful monitoring data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->