### PR TITLE
feat(toolkit): JSON log lines carry the service identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3443,6 +3443,7 @@ dependencies = [
  "tracing-appender",
  "tracing-log",
  "tracing-opentelemetry",
+ "tracing-serde",
  "tracing-subscriber",
  "tracing-test",
  "trybuild",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -463,6 +463,7 @@ tracing-subscriber = { version = "0.3", features = [
     "local-time",
 ] }
 tracing-log = "0.2"
+tracing-serde = "0.2"
 tracing-opentelemetry = "0.33"
 tracing-appender = "0.2"
 tracing-test = "0.2"

--- a/docs/web-docs/build-with-gears/configure.md
+++ b/docs/web-docs/build-with-gears/configure.md
@@ -32,6 +32,7 @@ database:
 logging:
   default:
     console_level: info
+    console_format: text # or: json (one object per line, for container log collectors)
     file: "logs/cf-gears.log"
     file_level: info
 
@@ -52,6 +53,13 @@ gears:
 - **API gateway** — `bind_addr`, `enable_docs`, `prefix_path`, CORS, rate limits, timeouts.
 - **Deployment shape** — `gears.<name>.runtime.type: local | oop` selects in-process vs
   out-of-process. See [Run a gear out-of-process](../out-of-process/).
+- **Logging** — `logging.default.console_level` and `console_format: text | json`.
+  Every JSON line (console and file) carries top-level `service` and `version`
+  keys from `opentelemetry.resource.{service_name,service_version}`
+  (`version` falls back to an `attributes."service.version"` entry; an empty
+  `service_name` omits both keys). `text` output is for local development —
+  one known binary in a terminal — and carries no identity keys; collectors
+  parse `json`.
 - **Tracing** — a `tracing:` block points at an OTLP backend. See
   [Add observability](../add-observability/).
 - **Database** — `database.servers.<name>` connection templates (`engine`, `params`, `pool`) that gears inherit; SQLite, PostgreSQL, and MariaDB engines are supported.

--- a/libs/toolkit/Cargo.toml
+++ b/libs/toolkit/Cargo.toml
@@ -88,6 +88,7 @@ bootstrap = [
     "dep:tracing-appender",
     "dep:file-rotate",
     "dep:tracing-log",
+    "dep:tracing-serde",
     "dep:tracing-subscriber",
     "dep:chrono",
     "dep:url",
@@ -175,6 +176,7 @@ opentelemetry_sdk = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 tracing-log = { workspace = true, optional = true }
+tracing-serde = { workspace = true, optional = true }
 tracing-appender = { workspace = true, optional = true }
 supports-color = { workspace = true, optional = true }
 enable-ansi-support = { workspace = true, optional = true }

--- a/libs/toolkit/src/bootstrap/host/logging.rs
+++ b/libs/toolkit/src/bootstrap/host/logging.rs
@@ -1,4 +1,5 @@
-use super::super::config::{ConsoleFormat, LoggingConfig, Section};
+use super::super::config::{AppConfig, ConsoleFormat, LoggingConfig, Section};
+use crate::telemetry::config::OpenTelemetryResource;
 use anyhow::Context;
 use std::io::Write;
 use std::path::Path;
@@ -15,6 +16,121 @@ pub type OtelLayer = tracing_opentelemetry::OpenTelemetryLayer<
 >;
 #[cfg(not(feature = "otel"))]
 pub type OtelLayer = ();
+
+// ================= per-line service identity =================
+
+/// The gears-owned JSON line format: the same shape tracing-subscriber's
+/// `Json` emits, plus top-level `service` / `version` identity entries.
+struct GearsJsonFormat {
+    service: String,
+    version: Option<String>,
+}
+
+impl GearsJsonFormat {
+    fn new(resource: &OpenTelemetryResource) -> Self {
+        Self {
+            service: resource.service_name.clone(),
+            version: resource.effective_service_version().map(str::to_owned),
+        }
+    }
+}
+
+/// A span's `FormattedFields` (stored by the layer as a JSON object string)
+/// flattened next to its `name`, as the upstream Json format renders spans.
+struct SerializableSpan<'a, S, N>(
+    tracing_subscriber::registry::SpanRef<'a, S>,
+    std::marker::PhantomData<N>,
+)
+where
+    S: for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>;
+
+impl<S, N> serde::Serialize for SerializableSpan<'_, S, N>
+where
+    S: for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>,
+    N: for<'writer> fmt::FormatFields<'writer> + 'static,
+{
+    fn serialize<Ser>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error>
+    where
+        Ser: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+
+        let mut map = serializer.serialize_map(None)?;
+        let extensions = self.0.extensions();
+        let formatted = extensions
+            .get::<fmt::FormattedFields<N>>()
+            .map(|fields| fields.fields.as_str())
+            .unwrap_or_default();
+        match serde_json::from_str::<serde_json::Value>(formatted) {
+            Ok(serde_json::Value::Object(fields)) => {
+                for (key, value) in fields {
+                    map.serialize_entry(&key, &value)?;
+                }
+            }
+            _ => map.serialize_entry("fields", formatted)?,
+        }
+        map.serialize_entry("name", self.0.metadata().name())?;
+        map.end()
+    }
+}
+
+impl<S, N> fmt::FormatEvent<S, N> for GearsJsonFormat
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    N: for<'a> fmt::FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &fmt::FmtContext<'_, S, N>,
+        mut writer: fmt::format::Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        use serde::ser::{SerializeMap, Serializer as _};
+        use tracing_log::NormalizeEvent;
+        use tracing_serde::fields::AsMap;
+
+        let normalized = event.normalized_metadata();
+        let meta = normalized.as_ref().unwrap_or_else(|| event.metadata());
+        let span_marker: std::marker::PhantomData<N> = std::marker::PhantomData;
+
+        let serialize = || {
+            let mut buf = Vec::with_capacity(256);
+            let mut serializer = serde_json::Serializer::new(&mut buf);
+            let mut map = serializer.serialize_map(None)?;
+
+            let timestamp = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+            map.serialize_entry("timestamp", &timestamp)?;
+            map.serialize_entry("level", meta.level().as_str())?;
+            if !self.service.is_empty() {
+                map.serialize_entry("service", &self.service)?;
+                if let Some(version) = &self.version {
+                    map.serialize_entry("version", version)?;
+                }
+            }
+
+            map.serialize_entry("fields", &event.field_map())?;
+            map.serialize_entry("target", meta.target())?;
+
+            if let Some(span) = ctx.event_scope().and_then(|mut scope| scope.next()) {
+                map.serialize_entry("span", &SerializableSpan(span, span_marker))?;
+            }
+            if let Some(scope) = ctx.event_scope() {
+                let spans: Vec<_> = scope
+                    .from_root()
+                    .map(|span| SerializableSpan::<S, N>(span, span_marker))
+                    .collect();
+                map.serialize_entry("spans", &spans)?;
+            }
+
+            map.end()?;
+            Ok::<_, serde_json::Error>(buf)
+        };
+
+        let buf = serialize().map_err(|_| std::fmt::Error)?;
+        writer.write_str(std::str::from_utf8(&buf).map_err(|_| std::fmt::Error)?)?;
+        writer.write_char('\n')
+    }
+}
 
 // ================= level helpers =================
 
@@ -193,9 +309,14 @@ fn create_rotating_writer_at_path(
 // the background flush thread and silently loses buffered log output.
 static CONSOLE_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 
-/// Unified initializer used by both functions above.
+/// Unified initializer: logging config, home dir and the per-line service
+/// identity all come from the app config.
 #[allow(unknown_lints, de1301_no_print_macros)] // runs before tracing subscriber is installed
-pub fn init_logging_unified(cfg: &LoggingConfig, base_dir: &Path, otel_layer: Option<OtelLayer>) {
+pub fn init_logging_unified(config: &AppConfig, otel_layer: Option<OtelLayer>) {
+    let cfg = &config.logging;
+    let base_dir: &Path = &config.server.home_dir;
+    let resource = &config.opentelemetry.resource;
+
     CONSOLE_GUARD.get_or_init(|| {
         // Bridge `log` → `tracing` *before* installing the subscriber
         if let Err(e) = tracing_log::LogTracer::init() {
@@ -226,6 +347,7 @@ pub fn init_logging_unified(cfg: &LoggingConfig, base_dir: &Path, otel_layer: Op
             file_router,
             console_format,
             otel_layer,
+            resource,
         )
     });
 }
@@ -393,6 +515,7 @@ fn install_subscriber(
     file_router: MultiFileRouter,
     console_format: ConsoleFormat,
     #[cfg_attr(not(feature = "otel"), allow(unused_variables))] otel_layer: Option<OtelLayer>,
+    resource: &OpenTelemetryResource,
 ) -> WorkerGuard {
     use tracing_subscriber::{EnvFilter, Registry, fmt, layer::SubscriberExt};
 
@@ -425,9 +548,7 @@ fn install_subscriber(
                     .json()
                     .with_writer(nb_stderr)
                     .with_ansi(false)
-                    .with_target(true)
-                    .with_level(true)
-                    .with_timer(fmt::time::UtcTime::rfc_3339())
+                    .event_format(GearsJsonFormat::new(resource))
                     .with_filter(console_targets.clone()),
             ),
         ),
@@ -441,10 +562,8 @@ fn install_subscriber(
             fmt::layer()
                 .json()
                 .with_ansi(false)
-                .with_target(true)
-                .with_level(true)
-                .with_timer(fmt::time::UtcTime::rfc_3339())
                 .with_writer(file_router)
+                .event_format(GearsJsonFormat::new(resource))
                 .with_filter(file_targets.clone()),
         )
     };
@@ -761,5 +880,152 @@ mod tests {
             content.contains("fallback"),
             "expected write to land in default log, got: {content:?}"
         );
+    }
+
+    // ===== per-line service identity =====
+
+    #[derive(Clone, Default)]
+    struct Buf(Arc<std::sync::Mutex<Vec<u8>>>);
+    impl Write for Buf {
+        fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(b);
+            Ok(b.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    impl<'a> fmt::MakeWriter<'a> for Buf {
+        type Writer = Buf;
+        fn make_writer(&'a self) -> Buf {
+            self.clone()
+        }
+    }
+
+    fn capture_json_line(
+        resource: &OpenTelemetryResource,
+        emit: impl FnOnce(),
+    ) -> serde_json::Value {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let buf = Buf::default();
+        let layer = fmt::layer()
+            .json()
+            .with_writer(buf.clone())
+            .with_ansi(false)
+            .event_format(GearsJsonFormat::new(resource));
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+
+        tracing::subscriber::with_default(subscriber, emit);
+
+        let captured = buf.0.lock().unwrap().clone();
+        let line = String::from_utf8(captured).expect("utf8 log line");
+        serde_json::from_str(line.lines().next().expect("one line")).expect("valid JSON line")
+    }
+
+    #[test]
+    fn json_lines_carry_service_and_version_at_top_level() {
+        let resource = OpenTelemetryResource {
+            service_name: "probe-service".to_owned(),
+            service_version: Some("1.2.3".to_owned()),
+            ..OpenTelemetryResource::default()
+        };
+
+        let line = capture_json_line(&resource, || tracing::info!("identity probe"));
+
+        assert_eq!(line["service"], "probe-service");
+        assert_eq!(line["version"], "1.2.3");
+        assert_eq!(line["fields"]["message"], "identity probe");
+        assert_eq!(line["level"], "INFO");
+        assert!(line["timestamp"].is_string(), "timestamp survives: {line}");
+    }
+
+    #[test]
+    fn identity_values_are_json_escaped() {
+        let resource = OpenTelemetryResource {
+            service_name: "probe \"quoted\" service".to_owned(),
+            service_version: None,
+            ..OpenTelemetryResource::default()
+        };
+
+        let line = capture_json_line(&resource, || tracing::info!("escape probe"));
+
+        assert_eq!(line["service"], "probe \"quoted\" service");
+        assert!(line.get("version").is_none(), "no version key when unset");
+    }
+
+    #[test]
+    fn span_fields_render_in_the_span_chain() {
+        let resource = OpenTelemetryResource {
+            service_name: "probe-service".to_owned(),
+            ..OpenTelemetryResource::default()
+        };
+
+        let line = capture_json_line(&resource, || {
+            tracing::info_span!("outer", request_id = "rid-1")
+                .in_scope(|| tracing::info!("span probe"));
+        });
+
+        assert_eq!(line["span"]["name"], "outer");
+        assert_eq!(line["span"]["request_id"], "rid-1");
+        assert_eq!(line["spans"][0]["name"], "outer");
+        assert_eq!(line["spans"][0]["request_id"], "rid-1");
+    }
+
+    #[test]
+    fn the_version_falls_back_to_the_resource_attribute() {
+        let mut attributes = std::collections::BTreeMap::new();
+        attributes.insert("service.version".to_owned(), "from-attr".to_owned());
+        let resource = OpenTelemetryResource {
+            service_name: "probe-service".to_owned(),
+            service_version: None,
+            attributes,
+        };
+
+        let line = capture_json_line(&resource, || tracing::info!("fallback probe"));
+
+        assert_eq!(line["version"], "from-attr");
+    }
+
+    #[test]
+    fn non_json_span_fields_render_as_a_raw_string() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let buf = Buf::default();
+        let resource = OpenTelemetryResource {
+            service_name: "probe-service".to_owned(),
+            ..OpenTelemetryResource::default()
+        };
+        let layer = fmt::layer()
+            .fmt_fields(fmt::format::DefaultFields::new())
+            .with_writer(buf.clone())
+            .with_ansi(false)
+            .event_format(GearsJsonFormat::new(&resource));
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info_span!("outer", request_id = "rid-1")
+                .in_scope(|| tracing::info!("raw span probe"));
+        });
+
+        let captured = buf.0.lock().unwrap().clone();
+        let line: serde_json::Value =
+            serde_json::from_str(String::from_utf8(captured).unwrap().lines().next().unwrap())
+                .unwrap();
+        assert_eq!(line["span"]["name"], "outer");
+        assert_eq!(line["span"]["fields"], "request_id=\"rid-1\"");
+    }
+
+    #[test]
+    fn an_empty_identity_injects_nothing() {
+        let resource = OpenTelemetryResource {
+            service_name: String::new(),
+            ..OpenTelemetryResource::default()
+        };
+
+        let line = capture_json_line(&resource, || tracing::info!("plain probe"));
+
+        assert!(line.get("service").is_none(), "no service key: {line}");
+        assert_eq!(line["fields"]["message"], "plain probe");
     }
 }

--- a/libs/toolkit/src/bootstrap/oop.rs
+++ b/libs/toolkit/src/bootstrap/oop.rs
@@ -143,11 +143,11 @@ fn build_oop_config_and_db(
     local_config: &AppConfig,
     gear_name: &str,
     rendered_config: Option<&RenderedGearConfig>,
-) -> Result<(AppConfig, LoggingConfig, DbOptions)> {
+) -> Result<(AppConfig, DbOptions)> {
     let home_dir = PathBuf::from(&local_config.server.home_dir);
 
     // Build final_config for gear's "config" section
-    let final_config = if let Some(rendered) = rendered_config {
+    let mut final_config = if let Some(rendered) = rendered_config {
         // TOOLKIT_MODULE_CONFIG exists: use rendered config as BASE, local config as OVERRIDE
         let mut config = local_config.clone();
 
@@ -185,10 +185,16 @@ fn build_oop_config_and_db(
     };
 
     // Merge logging: master logging (base) + local logging (override by key)
-    let final_logging = merge_logging_configs(
+    final_config.logging = merge_logging_configs(
         rendered_config.as_ref().and_then(|r| r.logging.as_ref()),
         &local_config.logging,
     );
+
+    // Telemetry comes from master when rendered (the same section init_tracing
+    // reads), so the log identity cannot diverge from the OTel resource.
+    if let Some(otel) = rendered_config.and_then(|r| r.opentelemetry.as_ref()) {
+        final_config.opentelemetry = otel.clone();
+    }
 
     // Build DbOptions using Figment merge + DbManager
     // This allows field-by-field merge: master db config (base) -> local db config (override)
@@ -199,7 +205,7 @@ fn build_oop_config_and_db(
         local_config,
     )?;
 
-    Ok((final_config, final_logging, db_options))
+    Ok((final_config, db_options))
 }
 
 /// Merges logging configurations: master as base, local as override (by key).
@@ -463,7 +469,7 @@ pub async fn run_oop_with_options(opts: OopRunOptions) -> Result<()> {
     // 1. Rendered config from master host (base)
     // 2. Local config file (override)
     // This also merges logging configuration for proper initialization
-    let (final_config, merged_logging, db_options) =
+    let (final_config, db_options) =
         build_oop_config_and_db(&config, &opts.gear_name, rendered_config.as_ref())?;
 
     // Use OpenTelemetry config from rendered (master) config only.
@@ -491,7 +497,7 @@ pub async fn run_oop_with_options(opts: OopRunOptions) -> Result<()> {
         .and_then(|cfg| crate::telemetry::init::init_metrics_provider(cfg).err());
 
     // Initialize logging with MERGED config (master base + local override)
-    init_logging_unified(&merged_logging, &config.server.home_dir, otel_layer);
+    init_logging_unified(&final_config, otel_layer);
 
     // Now that logging is available, report deferred metrics init error
     #[cfg(feature = "otel")]

--- a/libs/toolkit/src/bootstrap/oop_tests.rs
+++ b/libs/toolkit/src/bootstrap/oop_tests.rs
@@ -598,16 +598,16 @@ mod full_oop_config {
         let result = build_oop_config_and_db(&local_config, "test_gear", None);
 
         assert!(result.is_ok());
-        let (final_config, merged_logging, db_options) = result.unwrap();
+        let (final_config, db_options) = result.unwrap();
 
         // Config should be from local
         let gear_config = final_config.gears.get("test_gear").unwrap();
         assert_eq!(gear_config["config"]["setting"], "local_value");
 
         // Logging should be from local
-        assert_eq!(merged_logging.len(), 1);
+        assert_eq!(final_config.logging.len(), 1);
         assert_eq!(
-            merged_logging.get("default").unwrap().console_level,
+            final_config.logging.get("default").unwrap().console_level,
             Some(Level::DEBUG)
         );
 
@@ -636,7 +636,8 @@ mod full_oop_config {
         let result = build_oop_config_and_db(&local_config, "test_gear", Some(&rendered));
 
         assert!(result.is_ok());
-        let (final_config, merged_logging, _) = result.unwrap();
+        let (final_config, _) = result.unwrap();
+        let merged_logging = &final_config.logging;
 
         // Config should be from master (local has no config section)
         let gear_config = final_config.gears.get("test_gear").unwrap();
@@ -675,7 +676,7 @@ mod full_oop_config {
         let result = build_oop_config_and_db(&local_config, "test_gear", Some(&rendered));
 
         assert!(result.is_ok());
-        let (final_config, _, _) = result.unwrap();
+        let (final_config, _) = result.unwrap();
 
         // Config should be from LOCAL (full replacement)
         let gear_config = final_config.gears.get("test_gear").unwrap();
@@ -722,7 +723,8 @@ mod full_oop_config {
         let result = build_oop_config_and_db(&local_config, "test_gear", Some(&rendered));
 
         assert!(result.is_ok());
-        let (_, merged_logging, _) = result.unwrap();
+        let (final_config, _) = result.unwrap();
+        let merged_logging = &final_config.logging;
 
         // 3 keys total: default (overridden), sqlx (from master), new_key (from local)
         assert_eq!(merged_logging.len(), 3);
@@ -771,7 +773,7 @@ mod full_oop_config {
         let result = build_oop_config_and_db(&local_config, "test_gear", Some(&rendered));
 
         assert!(result.is_ok());
-        let (final_config, _, _) = result.unwrap();
+        let (final_config, _) = result.unwrap();
 
         // Config should be from master since local is null
         let gear_config = final_config.gears.get("test_gear").unwrap();
@@ -799,7 +801,7 @@ mod full_oop_config {
         let result = build_oop_config_and_db(&local_config, "test_gear", Some(&rendered));
 
         assert!(result.is_ok());
-        let (final_config, _, _) = result.unwrap();
+        let (final_config, _) = result.unwrap();
 
         // Config should be from master
         let gear_config = final_config.gears.get("test_gear").unwrap();

--- a/libs/toolkit/src/bootstrap/run.rs
+++ b/libs/toolkit/src/bootstrap/run.rs
@@ -312,7 +312,7 @@ pub fn init_procedure(config: &AppConfig) -> Result<()> {
     let otel_layer = None;
 
     // Initialize logging + otel in one Registry
-    init_logging_unified(&config.logging, &config.server.home_dir, otel_layer);
+    init_logging_unified(config, otel_layer);
 
     // Register custom panic hook to reroute panic backtrace into tracing.
     init_panic_tracing();

--- a/libs/toolkit/src/telemetry/config.rs
+++ b/libs/toolkit/src/telemetry/config.rs
@@ -42,6 +42,9 @@ pub struct OpenTelemetryResource {
     /// Logical service name.
     #[serde(default = "default_service_name")]
     pub service_name: String,
+    /// Release version (`service.version` semconv); also on every JSON log line.
+    #[serde(default)]
+    pub service_version: Option<String>,
     /// Extra resource attributes added to every span and metric data point.
     #[serde(default)]
     pub attributes: BTreeMap<String, String>,
@@ -52,10 +55,21 @@ fn default_service_name() -> String {
     "cf-gears".to_owned()
 }
 
+impl OpenTelemetryResource {
+    /// `service_version`, falling back to an `attributes["service.version"]` entry.
+    #[must_use]
+    pub fn effective_service_version(&self) -> Option<&str> {
+        self.service_version
+            .as_deref()
+            .or_else(|| self.attributes.get("service.version").map(String::as_str))
+    }
+}
+
 impl Default for OpenTelemetryResource {
     fn default() -> Self {
         Self {
             service_name: default_service_name(),
+            service_version: None,
             attributes: BTreeMap::default(),
         }
     }

--- a/libs/toolkit/src/telemetry/init.rs
+++ b/libs/toolkit/src/telemetry/init.rs
@@ -40,12 +40,15 @@ pub(crate) fn build_resource(cfg: &OpenTelemetryResource) -> Resource {
         cfg.service_name
     );
     let mut attrs = vec![KeyValue::new("service.name", cfg.service_name.clone())];
+    if let Some(version) = cfg.effective_service_version() {
+        attrs.push(KeyValue::new("service.version", version.to_owned()));
+    }
 
     for (k, v) in &cfg.attributes {
-        // Skip any caller-supplied "service.name" entry: the dedicated field
-        // cfg.service_name already seeds attrs above and a duplicate key would
+        // Skip caller-supplied "service.name" / "service.version" entries: the
+        // dedicated seeds above already carry them and a duplicate key would
         // create ambiguity in the resource attributes.
-        if k == "service.name" {
+        if k == "service.name" || k == "service.version" {
             continue;
         }
         attrs.push(KeyValue::new(k.clone(), v.clone()));
@@ -545,6 +548,34 @@ mod tests {
 
     #[test]
     #[cfg(feature = "otel")]
+    fn build_resource_carries_the_effective_service_version_once() {
+        let mut attrs = BTreeMap::new();
+        attrs.insert("service.version".to_owned(), "from-attr".to_owned());
+
+        let from_field = build_resource(&OpenTelemetryResource {
+            service_name: "svc".to_owned(),
+            service_version: Some("1.2.3".to_owned()),
+            attributes: attrs.clone(),
+        });
+        let from_attr = build_resource(&OpenTelemetryResource {
+            service_name: "svc".to_owned(),
+            service_version: None,
+            attributes: attrs,
+        });
+
+        let versions = |resource: &Resource| {
+            resource
+                .iter()
+                .filter(|(k, _)| k.as_str() == "service.version")
+                .map(|(_, v)| v.to_string())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(versions(&from_field), ["1.2.3"]);
+        assert_eq!(versions(&from_attr), ["from-attr"]);
+    }
+
+    #[test]
+    #[cfg(feature = "otel")]
     fn test_init_tracing_with_resource_attributes() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let _guard = rt.enter();
@@ -556,6 +587,7 @@ mod tests {
         let otel = OpenTelemetryConfig {
             resource: OpenTelemetryResource {
                 service_name: "test-service".to_owned(),
+                service_version: None,
                 attributes: attrs,
             },
             tracing: TracingConfig {


### PR DESCRIPTION
**Why.** A log collector cannot tell which service or release wrote a JSON line — the fmt subscriber emits no resource identity, and tracing-subscriber's layer has no way to add static fields to every line.

**What changed.** `GearsJsonFormat` — a gears-owned `FormatEvent` — produces the JSON line in the same shape tracing-subscriber's `Json` emits, plus top-level `service` and `version` entries serialized like every other key (fields via `tracing-serde`, spans via `FormattedFields`, one serialization pass). Identity comes from `OpenTelemetryResource::effective_service_version()` — the new `service_version` field, falling back to `attributes."service.version"` — the same value `build_resource` exports, so logs and the OTel resource cannot diverge; the OoP path folds the rendered master telemetry section into `final_config` for the same reason. Text output is local-dev and carries no identity keys; an empty `service_name` omits both keys — documented in configure.md.

**One entry point: `init_logging_unified(&AppConfig, otel_layer)`.** It derives logging config, home dir and identity itself — a breaking signature change for direct callers. `build_oop_config_and_db` now folds merged logging and rendered telemetry into `final_config`, so the OoP host uses the same function.

**Verified.** 7 new unit tests (identity keys, JSON-escape round-trip, span chain, attribute fallback, non-JSON span fields, empty identity, `build_resource` version once from either source); full toolkit lib suite (508) passes; `cargo check --workspace --all-features`, clippy pedantic, rustfmt clean.
