### PR TITLE
docs: add Virtuozzo attribution to specs

### DIFF
--- a/gears/bss/contracts/docs/PRD.md
+++ b/gears/bss/contracts/docs/PRD.md
@@ -7,6 +7,9 @@ refs:
   - bss/prd/PRD-subscriptions-entitlements-202601120119/PRD-subscriptions-entitlements-202601120119.md
 ---
 
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 # PRD — Contracts & Agreements
 
 > **Status: first draft (2026-08-17).** Harvested from three sources: (a) the consumer-side

--- a/gears/bss/ledger/docs/ADR/0001-cpt-cf-bss-ledger-adr-book-ownership-predicate.md
+++ b/gears/bss/ledger/docs/ADR/0001-cpt-cf-bss-ledger-adr-book-ownership-predicate.md
@@ -4,6 +4,9 @@ date: 2026-06-17
 decision-makers: "@vstudzinskyi (BSS Billing Platform team)"
 ---
 
+Created:  2026-07-07 by Virtuozzo International GmbH
+Updated:  2026-07-07 by Virtuozzo International GmbH
+
 # ADR-0001: Ledger Book Ownership — Only Selling Entities Own Billing Books
 
 <!-- toc -->

--- a/gears/bss/ledger/docs/DESIGN.md
+++ b/gears/bss/ledger/docs/DESIGN.md
@@ -1,3 +1,6 @@
+Created:  2026-07-08 by Virtuozzo International GmbH
+Updated:  2026-07-08 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Billing Ledger — Technical Design (canonical index) -->
 <!-- Related: ./PRD.md, ./ADR/, ./design/ | Owners: @vstudzinskyi (BSS Billing Platform team) -->
 

--- a/gears/bss/ledger/docs/PRD.md
+++ b/gears/bss/ledger/docs/PRD.md
@@ -9,6 +9,9 @@ refs:
   - bss/prd/PRD-subscriptions-entitlements-202601120119/PRD-subscriptions-entitlements-202601120119.md
 ---
 
+Created:  2026-06-11 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- migration-note: migrated from legacy Virtuozzo PRD format to virtuozzo-sdlc kit layout (cpt-* sub-IDs, 17-section outline). Original preserved unchanged at docs/bss/prd/PRD-billing-ledger-balances-202604041200/. Confluence metadata preserved below. -->
 <!-- CONFLUENCE_TITLE: [BSS]: Billing Ledger & Balances — Double-Entry, AR, ASC 606-Compatible Posting -->
 <!-- Related: bss/prd/PRD-billing-ledger-balances-202604041200 | Upstream: Rating, Subscriptions, Catalog, Contracts | Downstream: ERP/GL, Payments -->

--- a/gears/bss/ledger/docs/design/01-repository-foundation.md
+++ b/gears/bss/ledger/docs/design/01-repository-foundation.md
@@ -1,3 +1,6 @@
+Created:  2026-07-07 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- migration-note: migrated from the legacy Virtuozzo design set to the gears-sdlc design-slice layout (cpt-* sub-IDs). This is the Repository-Foundation (shared double-entry engine); it also carries the naming/glossary-alignment discipline (§4.1) and the three ledger-wide normative statements (§4.2–4.4). Sibling slice designs 01a–07 live in this folder — see README.md for the index. Original preserved unchanged at vhp-architecture docs/bss/design/DESIGN-billing-ledger-balances-202606091200/ (files 00 naming-alignment, 01 repository-foundation). Confluence metadata preserved below. -->
 <!-- CONFLUENCE_TITLE: [BSS]: Billing Ledger — Repository-foundation (shared double-entry engine) + Naming Alignment (Design) -->
 <!-- Related: PRD.md | Upstream: Rating, Subscriptions, Catalog, Contracts, AMS provisioning | Downstream: ERP/GL, Payments | Owners: @vstudzinskyi (BSS Billing Platform team) -->

--- a/gears/bss/ledger/docs/design/01a-invoice-posting.md
+++ b/gears/bss/ledger/docs/design/01a-invoice-posting.md
@@ -1,3 +1,6 @@
+Created:  2026-07-07 by Virtuozzo International GmbH
+Updated:  2026-07-07 by Virtuozzo International GmbH
+
 <!-- migration-note: converted from the legacy Virtuozzo DESIGN slice format to the gears-sdlc design-slice layout (cpt-* sub-IDs, CDSL flows/algos/states). Original preserved unchanged at vhp-architecture: docs/bss/design/DESIGN-billing-ledger-balances-202606091200/01a-DESIGN-billing-ledger-invoice-posting-202606091200.md.. -->
 <!-- CONFLUENCE_TITLE: [BSS]: Billing Ledger — Invoice-posting handler (Design, Slice 1) -->
 <!-- Related: 01-repository-foundation.md (Repository-foundation component model), PRD.md | Upstream: PRD Billing Ledger & Balances, the Repository-foundation | Downstream: payments-allocation, adjustments-notes-refunds, asc606-recognition, fx-multicurrency, reconciliation-export, audit-immutability-observability (sibling feature slices) -->

--- a/gears/bss/ledger/docs/design/02-audit-immutability-observability.md
+++ b/gears/bss/ledger/docs/design/02-audit-immutability-observability.md
@@ -1,3 +1,6 @@
+Created:  2026-07-07 by Virtuozzo International GmbH
+Updated:  2026-07-07 by Virtuozzo International GmbH
+
 <!-- migration-note: converted from the legacy Virtuozzo DESIGN slice format to the gears-sdlc design-slice layout (cpt-* sub-IDs, CDSL flows/algos/states). Original preserved unchanged at vhp-architecture: docs/bss/design/DESIGN-billing-ledger-balances-202606091200/02-DESIGN-billing-ledger-audit-immutability-observability-202606091700.md.. -->
 <!-- CONFLUENCE_TITLE: [BSS]: Billing Ledger — Audit, Immutability & Observability (Design, Slice 6) -->
 <!-- Related: 01-repository-foundation.md (Repository-foundation component model), PRD.md | Upstream: Slices 1-5/7 (emit alarms + posted facts) | Downstream: reconciliation-export (Slice 7), Finance/Audit consumers -->

--- a/gears/bss/ledger/docs/design/03-payments-allocation.md
+++ b/gears/bss/ledger/docs/design/03-payments-allocation.md
@@ -1,3 +1,6 @@
+Created:  2026-07-07 by Virtuozzo International GmbH
+Updated:  2026-07-07 by Virtuozzo International GmbH
+
 <!-- migration-note: converted from the legacy vhp-architecture design slice
      docs/bss/design/DESIGN-billing-ledger-balances-202606091200/03-DESIGN-billing-ledger-payments-allocation-202606091300.md
      to the gears-sdlc design-slice layout (cpt-* sub-IDs, CDSL flows). The original is preserved unchanged in the

--- a/gears/bss/ledger/docs/design/04-asc606-recognition.md
+++ b/gears/bss/ledger/docs/design/04-asc606-recognition.md
@@ -1,3 +1,6 @@
+Created:  2026-07-07 by Virtuozzo International GmbH
+Updated:  2026-07-07 by Virtuozzo International GmbH
+
 <!-- migration-note: converted from the legacy vhp-architecture design slice
      docs/bss/design/DESIGN-billing-ledger-balances-202606091200/04-DESIGN-billing-ledger-asc606-recognition-202606091400.md
      to the gears-sdlc design-slice layout (cpt-* sub-IDs, CDSL flows). The original is preserved unchanged in the

--- a/gears/bss/ledger/docs/design/05-adjustments-notes-refunds.md
+++ b/gears/bss/ledger/docs/design/05-adjustments-notes-refunds.md
@@ -1,3 +1,6 @@
+Created:  2026-07-07 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- migration-note: converted from the legacy VHP architecture design slice to the gears-sdlc design-slice format. Original preserved unchanged at vhp-architecture/docs/bss/design/DESIGN-billing-ledger-balances-202606091200/05-DESIGN-billing-ledger-adjustments-notes-refunds-202606091500.md (Slice 3 — Adjustments: Credit/Debit Notes & Refunds). Inherited engine mechanics (PostingService, IdempotencyGate, BalanceProjector, commit trigger, TieOutJob, outbox relay) are specified in ./01-repository-foundation.md. -->
 <!-- CONFLUENCE_TITLE: [BSS]: Billing Ledger — Credit/Debit Notes & Refunds (Design, Slice 3) -->
 

--- a/gears/bss/ledger/docs/design/06-fx-multicurrency.md
+++ b/gears/bss/ledger/docs/design/06-fx-multicurrency.md
@@ -1,3 +1,6 @@
+Created:  2026-07-07 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- migration-note: converted from the legacy VHP architecture design slice to the gears-sdlc design-slice format. Original preserved unchanged at vhp-architecture/docs/bss/design/DESIGN-billing-ledger-balances-202606091200/06-DESIGN-billing-ledger-fx-multicurrency-202606091600.md (Slice 5 — FX & Multi-Currency). Inherited engine mechanics (PostingService, IdempotencyGate, MoneyModule, BalanceProjector, dual-column commit trigger, TieOutJob, outbox relay) are specified in ./01-repository-foundation.md. -->
 <!-- CONFLUENCE_TITLE: [BSS]: Billing Ledger — FX & Multi-Currency (Design, Slice 5) -->
 

--- a/gears/bss/ledger/docs/design/07-reconciliation-export.md
+++ b/gears/bss/ledger/docs/design/07-reconciliation-export.md
@@ -1,3 +1,6 @@
+Created:  2026-07-07 by Virtuozzo International GmbH
+Updated:  2026-07-07 by Virtuozzo International GmbH
+
 <!-- migration-note: converted from the legacy Virtuozzo design format to the gears-sdlc design-slice layout (cpt-* sub-IDs, CDSL flows/algos/states). Original preserved unchanged at vhp-architecture: docs/bss/design/DESIGN-billing-ledger-balances-202606091200/07-DESIGN-billing-ledger-reconciliation-export-202606091800.md. Confluence metadata preserved below. -->
 <!-- CONFLUENCE_TITLE: [BSS]: Billing Ledger — Reconciliation & ERP Export (Design, Slice 7) -->
 <!-- Related: Slices 1-6 | Upstream: Slices 1-6 (posted facts, caches, per-slice tie-out contributions, alarm catalog), Payments (PSP settlement) | Downstream: ERP/GL (external), Finance/Revenue Assurance -->

--- a/gears/bss/orders-lifecycle/docs/PRD.md
+++ b/gears/bss/orders-lifecycle/docs/PRD.md
@@ -11,6 +11,9 @@ refs:
   - bss/prd/PRD-tariffs-pricing-logic-202604011200
 ---
 
+Created:  2026-08-21 by Virtuozzo International GmbH
+Updated:  2026-09-01 by Virtuozzo International GmbH
+
 # PRD — Orders Lifecycle
 
 <!-- toc -->

--- a/gears/bss/orders-workflow/docs/PRD.md
+++ b/gears/bss/orders-workflow/docs/PRD.md
@@ -6,6 +6,9 @@ refs:
   - bss/prd/PRD-subscriptions-entitlements-202601120119
 ---
 
+Created:  2026-08-21 by Virtuozzo International GmbH
+Updated:  2026-09-01 by Virtuozzo International GmbH
+
 # PRD — Orders Workflow
 
 <!-- toc -->

--- a/gears/bss/pricing/docs/ADR/0001-cpt-cf-bss-pricing-adr-canonical-scope-key.md
+++ b/gears/bss/pricing/docs/ADR/0001-cpt-cf-bss-pricing-adr-canonical-scope-key.md
@@ -4,6 +4,9 @@ date: 2026-07-09
 decision-makers: "BSS Product Catalog team"
 ---
 
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 # ADR-0001: Canonical Price-Row Scope Key — Extend the Manifest Key Additively
 
 <!-- toc -->

--- a/gears/bss/pricing/docs/ADR/0002-cpt-cf-bss-pricing-adr-grandfathering-cohort-axis.md
+++ b/gears/bss/pricing/docs/ADR/0002-cpt-cf-bss-pricing-adr-grandfathering-cohort-axis.md
@@ -4,6 +4,9 @@ date: 2026-07-10
 decision-makers: "BSS Product Catalog team"
 ---
 
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 # ADR-0002: Multi-Generation Grandfathering — the `cohort` Scope-Key Axis
 
 <!-- toc -->

--- a/gears/bss/pricing/docs/ADR/0003-cpt-cf-bss-pricing-adr-pricewindow-consolidation.md
+++ b/gears/bss/pricing/docs/ADR/0003-cpt-cf-bss-pricing-adr-pricewindow-consolidation.md
@@ -4,6 +4,9 @@ date: 2026-07-10
 decision-makers: "BSS Product Catalog team"
 ---
 
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 # ADR-0003: PriceWindow Machinery Consolidated into the Pricing Gear
 
 <!-- toc -->

--- a/gears/bss/pricing/docs/DESIGN.md
+++ b/gears/bss/pricing/docs/DESIGN.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Plan & Price Modeling — Technical Design (canonical index) -->
 <!-- Related: ./PRD.md, ./ADR/, ./design/ | Owners: BSS Product Catalog team -->
 

--- a/gears/bss/pricing/docs/PRD.md
+++ b/gears/bss/pricing/docs/PRD.md
@@ -13,6 +13,9 @@ refs:
   - bss/prd/PRD-tariffs-pricing-logic-202604011200
 ---
 
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 # PRD — Plan & Price Modeling
 
 <!-- toc -->

--- a/gears/bss/pricing/docs/design/01-foundation.md
+++ b/gears/bss/pricing/docs/design/01-foundation.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Plan & Price Modeling — Catalog Foundation (shared publish engine) (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md | Upstream: Product & SKU registry, Effective-dating PriceWindows | Downstream: Tariffs, Subscriptions, Rating, Billing, Marketplace | Owners: BSS Product Catalog team -->
 

--- a/gears/bss/pricing/docs/design/02-plan-definition.md
+++ b/gears/bss/pricing/docs/design/02-plan-definition.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Pricing — Plan Definition, Billing Cycles & Composition (Design, Slice 2) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ./01-foundation.md | Owners: BSS Product Catalog team -->
 

--- a/gears/bss/pricing/docs/design/03-price-structure.md
+++ b/gears/bss/pricing/docs/design/03-price-structure.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Pricing — Price Structure & Model Kinds (Design, Slice 3) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ./01-foundation.md | Owners: BSS Product Catalog team -->
 

--- a/gears/bss/pricing/docs/design/04-currency-tax.md
+++ b/gears/bss/pricing/docs/design/04-currency-tax.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Pricing — Multi-Currency, Regions & Tax Display (Design, Slice 4) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ./01-foundation.md | Owners: BSS Product Catalog team -->
 

--- a/gears/bss/pricing/docs/design/05-governance.md
+++ b/gears/bss/pricing/docs/design/05-governance.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Pricing — Approval, Governance & Access Control (Design, Slice 5) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ./01-foundation.md | Owners: BSS Product Catalog team -->
 

--- a/gears/bss/pricing/docs/design/06-consumer-contracts.md
+++ b/gears/bss/pricing/docs/design/06-consumer-contracts.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Pricing — Consumer Contracts (Design, Slice 6) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ./01-foundation.md | Owners: BSS Product Catalog team -->
 

--- a/gears/bss/pricing/docs/design/07-pricewindow-linkage.md
+++ b/gears/bss/pricing/docs/design/07-pricewindow-linkage.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Pricing — PriceWindow Linkage, Coverage & Grandfathering (Design, Slice 7) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ./01-foundation.md | Owners: BSS Product Catalog team -->
 

--- a/gears/bss/pricing/docs/design/08-bundles.md
+++ b/gears/bss/pricing/docs/design/08-bundles.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Pricing — Bundles & Marketplace Composition (Design, Slice 8) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ./01-foundation.md | Owners: BSS Product Catalog team -->
 

--- a/gears/bss/pricing/docs/design/09-price-overlays.md
+++ b/gears/bss/pricing/docs/design/09-price-overlays.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Pricing — Price Overlays & Customer-Group Segment Pricing (Design, Slice 9) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ./01-foundation.md | Owners: BSS Product Catalog team -->
 

--- a/gears/bss/pricing/docs/design/10-advanced-primitives.md
+++ b/gears/bss/pricing/docs/design/10-advanced-primitives.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Pricing — Advanced Pricing Primitives (Design, Slice 10) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ./01-foundation.md | Owners: BSS Product Catalog team -->
 

--- a/gears/bss/pricing/docs/design/11-lifecycle.md
+++ b/gears/bss/pricing/docs/design/11-lifecycle.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Pricing — Lifecycle: Retirement & Migration (Design, Slice 11) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ./01-foundation.md | Owners: BSS Product Catalog team -->
 

--- a/gears/bss/pricing/docs/design/12-operator-efficiency.md
+++ b/gears/bss/pricing/docs/design/12-operator-efficiency.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Pricing — Operator Efficiency (Design, Slice 12) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ./01-foundation.md | Owners: BSS Product Catalog team -->
 

--- a/gears/bss/products/docs/PRD.md
+++ b/gears/bss/products/docs/PRD.md
@@ -14,6 +14,9 @@ refs:
   - bss/prd/PRD-tariffs-pricing-logic-202604011200
 ---
 
+Created:  2026-07-03 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 # PRD — Product & SKU Management
 
 > **Provenance (2026-07-16):** vendored from `constructorfabric/gears-rust` PR **#4177**
@@ -1662,4 +1665,3 @@ Absence of a monetization-model marker on a SKU is **intentional**, not a missin
 ---
 
 *Child artifacts: ADR(s) for versioning/snapshot strategy and lifecycle/deprecation modeling; the gear's DESIGN (`gears/bss/products/docs/DESIGN.md`, pending) for entity schemas, APIs, events, and read-model design; STORY documents per scope item. The §4.1 registry↔commercial decomposition is recorded in the manifest §4.1 Decomposition (BSS realization) note, not a separate ADR.*
-

--- a/gears/bss/rate-provider/docs/DESIGN.md
+++ b/gears/bss/rate-provider/docs/DESIGN.md
@@ -1,3 +1,6 @@
+Created:  2026-07-17 by Virtuozzo International GmbH
+Updated:  2026-07-17 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: FX Rate Provider (Adapter Gear) — Technical Design -->
 <!-- Related: ../../ledger/docs/DESIGN.md, ../../ledger/docs/design/06-fx-multicurrency.md, ../../ledger/docs/PRD.md | Owners: @vstudzinskyi (BSS Billing Platform team) -->
 

--- a/gears/bss/rate-provider/docs/PRD.md
+++ b/gears/bss/rate-provider/docs/PRD.md
@@ -1,3 +1,6 @@
+Created:  2026-07-17 by Virtuozzo International GmbH
+Updated:  2026-07-17 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: FX Rate Provider (Adapter Gear) — Product Requirements -->
 <!-- Related: ./DESIGN.md, ../../ledger/docs/PRD.md, ../../ledger/docs/design/06-fx-multicurrency.md | Owners: @vstudzinskyi (BSS Billing Platform team) -->
 

--- a/gears/bss/rating/docs/ADR/0001-cpt-cf-bss-rating-adr-scope-key-adoption.md
+++ b/gears/bss/rating/docs/ADR/0001-cpt-cf-bss-rating-adr-scope-key-adoption.md
@@ -4,6 +4,9 @@ date: 2026-07-10
 decision-makers: "BSS Rating team"
 ---
 
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 # ADR-0001: Adopt the Pricing Canonical Scope Key (Do Not Define a Tariffs Key)
 
 <!-- toc -->

--- a/gears/bss/rating/docs/ADR/0002-cpt-cf-bss-rating-adr-rating-gear-consolidation.md
+++ b/gears/bss/rating/docs/ADR/0002-cpt-cf-bss-rating-adr-rating-gear-consolidation.md
@@ -4,6 +4,9 @@ date: 2026-07-11
 decision-makers: "BSS Rating/Tariffs owner (single owner for both parts)"
 ---
 
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 # ADR-0002: One `rating` Gear — Consolidate Tariffs (Evaluation Core) and the Rating Pipeline
 
 <!-- toc -->

--- a/gears/bss/rating/docs/DESIGN.md
+++ b/gears/bss/rating/docs/DESIGN.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Commercial Pricing Logic — Technical Design (canonical index) -->
 <!-- Related: ./PRD.md, ./SEAMS.md, ./ADR/, ./design/ | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/PRD.md
+++ b/gears/bss/rating/docs/PRD.md
@@ -9,6 +9,9 @@ refs:
   - bss/prd/PRD-subscriptions-lifecycle-202604021200/PRD-subscriptions-lifecycle-202604021200.md
 ---
 
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 # PRD — Rating — Usage Rating & Commercial Pricing Logic
 
 <!-- toc -->

--- a/gears/bss/rating/docs/design/01-foundation.md
+++ b/gears/bss/rating/docs/design/01-foundation.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Evaluation Foundation (pure-function core) (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Pricing (Product Catalog), Rating, Subscriptions, Finance, Promotions, Billing | Downstream: Rating | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/design/02-selection-eligibility.md
+++ b/gears/bss/rating/docs/design/02-selection-eligibility.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Base Selection & Eligibility (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Pricing (Product Catalog), Subscriptions | Downstream: Rating | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/design/03-metering-models.md
+++ b/gears/bss/rating/docs/design/03-metering-models.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Metering & Pricing Models (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Pricing (Product Catalog), Rating, Subscriptions, OSS Metering | Downstream: Rating | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/design/04-overlays-precedence.md
+++ b/gears/bss/rating/docs/design/04-overlays-precedence.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Overlays & Precedence (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Pricing (Product Catalog), Contracts & Agreements, OSS/AMS | Downstream: Rating | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/design/05-commitments-reservations.md
+++ b/gears/bss/rating/docs/design/05-commitments-reservations.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Commitments & Reservations (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Contracts & Agreements, Pricing (Product Catalog), OSS (reservation entitlement), Subscriptions | Downstream: Rating, Billing (obligation execution) | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/design/06-coupons.md
+++ b/gears/bss/rating/docs/design/06-coupons.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Coupons (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Promotions (frozen coupon snapshots), Finance (fxTableVersion for the billing-currency pass) | Downstream: Rating, Billing/Tax (discount lineage) | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/design/07-currency-fx.md
+++ b/gears/bss/rating/docs/design/07-currency-fx.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Multi-Currency & FX (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Finance (FX), Pricing (Product Catalog), Subscriptions, Promotions | Downstream: Rating, Billing | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/design/08-retroactivity-corrections.md
+++ b/gears/bss/rating/docs/design/08-retroactivity-corrections.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Retroactivity & Corrections (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Rating, Billing, Pricing (Product Catalog), Contracts | Downstream: Rating, Billing | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/design/09-period-plan-change.md
+++ b/gears/bss/rating/docs/design/09-period-plan-change.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Period & Plan-Change Obligations (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Pricing (Product Catalog), Subscriptions, Billing, Rating | Downstream: Billing, Rating | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/design/10-governance-asc606.md
+++ b/gears/bss/rating/docs/design/10-governance-asc606.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Governance & ASC 606 (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Pricing (Product Catalog), Contracts, Finance | Downstream: Pricing (publish pipeline), Billing, Finance | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/design/11-consumer-contracts.md
+++ b/gears/bss/rating/docs/design/11-consumer-contracts.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Consumer & Integration Contracts (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Pricing (Product Catalog), Subscriptions, Finance, Promotions, Billing, Rating | Downstream: Rating | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/design/12-usage-ingestion-normalization.md
+++ b/gears/bss/rating/docs/design/12-usage-ingestion-normalization.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Usage Ingestion & Normalization (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: OSS Metering, Subscriptions | Downstream: 13-q-store-attribution, rating-core | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/design/13-q-store-attribution.md
+++ b/gears/bss/rating/docs/design/13-q-store-attribution.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Windowed Q Store & Attribution (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: 12-usage-ingestion-normalization | Downstream: 14-unit-synthesis-period-tick, rating-core | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/design/14-unit-synthesis-period-tick.md
+++ b/gears/bss/rating/docs/design/14-unit-synthesis-period-tick.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Unit Synthesis & Period Tick (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: 12/13 (pipeline), Pricing, Subscriptions, Finance, Promotions, Billing, Contracts | Downstream: rating-core, 15-rated-output-balance-effects | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/design/15-rated-output-balance-effects.md
+++ b/gears/bss/rating/docs/design/15-rated-output-balance-effects.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Rated Output, Delta Dedup & Balance Effects (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: rating-core, 14-unit-synthesis-period-tick | Downstream: 16-billing-handoff-operations, Contracts | Owners: BSS Rating team -->
 

--- a/gears/bss/rating/docs/design/16-billing-handoff-operations.md
+++ b/gears/bss/rating/docs/design/16-billing-handoff-operations.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Rating — Billing Handoff & Operations (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: 15-rated-output-balance-effects | Downstream: Billing | Owners: BSS Rating team -->
 

--- a/gears/bss/subscriptions/docs/ADR/0001-cpt-cf-bss-subscriptions-adr-manifest-closed-status-machine.md
+++ b/gears/bss/subscriptions/docs/ADR/0001-cpt-cf-bss-subscriptions-adr-manifest-closed-status-machine.md
@@ -4,6 +4,9 @@ date: 2026-07-15
 decision-makers: "BSS Subscriptions team"
 ---
 
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 # ADR-0001: Keep the Manifest Status Enum Closed (Trials, Pause, and Intents Are Attributes)
 
 <!-- toc -->

--- a/gears/bss/subscriptions/docs/ADR/0002-cpt-cf-bss-subscriptions-adr-when-not-math-split.md
+++ b/gears/bss/subscriptions/docs/ADR/0002-cpt-cf-bss-subscriptions-adr-when-not-math-split.md
@@ -4,6 +4,9 @@ date: 2026-07-15
 decision-makers: "BSS Subscriptions team"
 ---
 
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 # ADR-0002: Subscriptions Owns the Change Boundary; Rating Owns the Math
 
 <!-- toc -->

--- a/gears/bss/subscriptions/docs/ADR/0003-cpt-cf-bss-subscriptions-adr-scheduled-intents-on-aggregate.md
+++ b/gears/bss/subscriptions/docs/ADR/0003-cpt-cf-bss-subscriptions-adr-scheduled-intents-on-aggregate.md
@@ -4,6 +4,9 @@ date: 2026-07-15
 decision-makers: "BSS Subscriptions team"
 ---
 
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 # ADR-0003: Scheduled Intents Live on the Aggregate (Not Portal-Side Automation)
 
 <!-- toc -->

--- a/gears/bss/subscriptions/docs/DESIGN.md
+++ b/gears/bss/subscriptions/docs/DESIGN.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Subscriptions — End-to-End Lifecycle — Technical Design (canonical index) -->
 <!-- Related: ./PRD.md, ./SEAMS.md, ./DECISIONS.md, ./ADR/, ./design/ | Owners: BSS Subscriptions team -->
 

--- a/gears/bss/subscriptions/docs/PRD.md
+++ b/gears/bss/subscriptions/docs/PRD.md
@@ -12,6 +12,9 @@ refs:
   - bss/prd/PRD-tariffs-pricing-logic-202604011200
 ---
 
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 # PRD — Subscriptions — End-to-End Lifecycle (Multi-Tenant Revenue Object)
 
 <!-- CONFLUENCE_TITLE: [BSS]: Subscriptions — End-to-End Lifecycle (Multi-Tenant Revenue Object) -->

--- a/gears/bss/subscriptions/docs/design/01-foundation-lifecycle.md
+++ b/gears/bss/subscriptions/docs/design/01-foundation-lifecycle.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Subscriptions — Lifecycle Foundation (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md, ../DECISIONS.md | Upstream: Policy Engine (fail-closed gate), OSS Provisioning (work-order confirm), AMS (tenant identity) | Downstream: every capability slice, Rating, Billing | Owners: BSS Subscriptions team -->
 

--- a/gears/bss/subscriptions/docs/design/02-composition-versioning.md
+++ b/gears/bss/subscriptions/docs/design/02-composition-versioning.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Subscriptions — Composition & Versioning (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Pricing (published Plan/Price/PriceWindow), Registry (skuId/PlanTier/CatalogVersion) | Downstream: Rating (composition read-model), Billing (snapshot refs) | Owners: BSS Subscriptions team -->
 

--- a/gears/bss/subscriptions/docs/design/03-plan-changes.md
+++ b/gears/bss/subscriptions/docs/design/03-plan-changes.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Subscriptions — Plan & Quantity Changes (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Pricing (plan-change classification), Contracts (ramps), Registry (overlap key) | Downstream: Rating (proration math + usage slicing), Billing (proration artifacts) | Owners: BSS Subscriptions team -->
 

--- a/gears/bss/subscriptions/docs/design/04-suspension-renewal-grace.md
+++ b/gears/bss/subscriptions/docs/design/04-suspension-renewal-grace.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Subscriptions — Suspension, Renewal & Grace (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Contracts (renewal/grace SoR), Payments (pre-check/retry-exhaustion), OSS (pause) | Downstream: Billing (dunning, collection artifacts), Notifications (notice delivery) | Owners: BSS Subscriptions team -->
 

--- a/gears/bss/subscriptions/docs/design/05-entitlements.md
+++ b/gears/bss/subscriptions/docs/design/05-entitlements.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Subscriptions — Entitlement Lifecycle (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Pricing (grant-set templates, incl. per-phase map), Rating (usage aggregates) | Downstream: OSS (enforcement), Billing/Rating (prepaid drawdown) | Owners: BSS Subscriptions team -->
 

--- a/gears/bss/subscriptions/docs/design/06-trials.md
+++ b/gears/bss/subscriptions/docs/design/06-trials.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Subscriptions — Trial Runtime & Conversion (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Pricing (trial offer, phase, convertsToPhaseId, grant set), Payments (conversion authorization) | Downstream: Rating (phase boundary), Notifications (win-back) | Owners: BSS Subscriptions team -->
 

--- a/gears/bss/subscriptions/docs/design/07-tenancy-transfer.md
+++ b/gears/bss/subscriptions/docs/design/07-tenancy-transfer.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Subscriptions — Multi-Tenant Ownership & Transfer (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: AMS (tenant identity, delegation proofs), Policy Engine (transfer gate) | Downstream: Rating/Billing (tenant axes), Analytics (roll-ups) | Owners: BSS Subscriptions team -->
 

--- a/gears/bss/subscriptions/docs/design/08-events-billing.md
+++ b/gears/bss/subscriptions/docs/design/08-events-billing.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Subscriptions — Event Model & Billing Alignment (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Contracts (PriceOverride) | Downstream: Rating, Billing, OSS, Policy Engine, Analytics | Owners: BSS Subscriptions team -->
 

--- a/gears/bss/subscriptions/docs/design/09-consumer-contracts.md
+++ b/gears/bss/subscriptions/docs/design/09-consumer-contracts.md
@@ -1,3 +1,6 @@
+Created:  2026-08-24 by Virtuozzo International GmbH
+Updated:  2026-08-24 by Virtuozzo International GmbH
+
 <!-- CONFLUENCE_TITLE: [BSS]: Subscriptions — Consumer & Integration Contracts (Design) -->
 <!-- Related: ../PRD.md, ../DESIGN.md, ../SEAMS.md | Upstream: Contracts, Policy Engine, Payments, Registry | Downstream: Rating, Billing, OSS | Owners: BSS Subscriptions team -->
 

--- a/gears/credstore/docs/ADR/0001-cpt-cf-credstore-adr-stateful-gear.md
+++ b/gears/credstore/docs/ADR/0001-cpt-cf-credstore-adr-stateful-gear.md
@@ -2,6 +2,10 @@
 status: accepted
 date: 2026-07-04
 ---
+
+Created:  2026-07-07 by Virtuozzo International GmbH
+Updated:  2026-07-07 by Virtuozzo International GmbH
+
 # ADR-0001: Stateful Gear with Gear-Owned Secret Metadata
 
 

--- a/gears/credstore/docs/ADR/0002-cpt-cf-credstore-adr-deprovisioning-saga.md
+++ b/gears/credstore/docs/ADR/0002-cpt-cf-credstore-adr-deprovisioning-saga.md
@@ -2,6 +2,10 @@
 status: accepted
 date: 2026-07-04
 ---
+
+Created:  2026-07-07 by Virtuozzo International GmbH
+Updated:  2026-07-07 by Virtuozzo International GmbH
+
 # ADR-0002: Status-Driven Deprovisioning Saga with Name Retention
 
 

--- a/gears/credstore/docs/ADR/0003-cpt-cf-credstore-adr-value-fingerprint-fence.md
+++ b/gears/credstore/docs/ADR/0003-cpt-cf-credstore-adr-value-fingerprint-fence.md
@@ -2,6 +2,10 @@
 status: accepted
 date: 2026-07-08
 ---
+
+Created:  2026-07-07 by Virtuozzo International GmbH
+Updated:  2026-07-07 by Virtuozzo International GmbH
+
 # ADR-0003: Value-Fingerprint Fence for the Metadata/Value Dual Write
 
 <!-- toc -->

--- a/gears/credstore/docs/DESIGN.md
+++ b/gears/credstore/docs/DESIGN.md
@@ -1,3 +1,5 @@
+Updated:  2026-07-07 by Virtuozzo International GmbH
+
 # Technical Design — CredStore
 
 

--- a/gears/credstore/docs/PRD.md
+++ b/gears/credstore/docs/PRD.md
@@ -1,3 +1,5 @@
+Updated:  2026-07-07 by Virtuozzo International GmbH
+
 # PRD — CredStore
 
 

--- a/gears/infrastructure-resource-manager/docs/DESIGN.md
+++ b/gears/infrastructure-resource-manager/docs/DESIGN.md
@@ -1,3 +1,6 @@
+Created:  2026-08-11 by Virtuozzo International GmbH
+Updated:  2026-09-01 by Virtuozzo International GmbH
+
 # Technical Design — Infrastructure Resource Manager (IRM)
 
 <!-- toc -->

--- a/gears/infrastructure-resource-manager/docs/PRD.md
+++ b/gears/infrastructure-resource-manager/docs/PRD.md
@@ -2,6 +2,9 @@
 refs: []
 ---
 
+Created:  2026-08-04 by Virtuozzo International GmbH
+Updated:  2026-09-01 by Virtuozzo International GmbH
+
 # PRD — Infrastructure Resource Manager (IRM)
 
 

--- a/gears/settings-service/docs/DESIGN-activation.md
+++ b/gears/settings-service/docs/DESIGN-activation.md
@@ -1,3 +1,6 @@
+Created:  2026-07-28 by Virtuozzo International GmbH
+Updated:  2026-08-30 by Virtuozzo International GmbH
+
 # Technical Design — Settings Activation
 
 <!-- toc -->

--- a/gears/settings-service/docs/DESIGN.md
+++ b/gears/settings-service/docs/DESIGN.md
@@ -1,3 +1,6 @@
+Created:  2026-07-28 by Virtuozzo International GmbH
+Updated:  2026-08-30 by Virtuozzo International GmbH
+
 # Technical Design — Settings Service
 
 <!-- toc -->

--- a/gears/settings-service/docs/PRD.md
+++ b/gears/settings-service/docs/PRD.md
@@ -1,3 +1,6 @@
+Created:  2026-07-20 by Virtuozzo International GmbH
+Updated:  2026-08-30 by Virtuozzo International GmbH
+
 # PRD — Settings Service
 
 
@@ -977,4 +980,3 @@ Links to related specification artifacts.
 - **Design**: [DESIGN.md](./DESIGN.md) — TBD, not yet authored for this gear
 - **ADRs**: [ADR/](./ADR/) — TBD, not yet authored for this gear
 - **Features**: [features/](./features/) — TBD, not yet authored for this gear
-

--- a/gears/system/account-management/docs/ADR/0005-cpt-cf-account-management-adr-idp-user-identity-source-of-truth.md
+++ b/gears/system/account-management/docs/ADR/0005-cpt-cf-account-management-adr-idp-user-identity-source-of-truth.md
@@ -4,6 +4,9 @@ date: 2026-04-09
 decision-makers: Constructor Fabric Steering Committee
 ---
 
+Created:  2026-03-31 by Virtuozzo International GmbH
+Updated:  2026-07-22 by Virtuozzo International GmbH
+
 # ADR-0005: IdP as the Single Source of Truth for User Identity Data
 
 

--- a/gears/system/account-management/docs/ADR/0008-cpt-cf-account-management-adr-user-attribute-update.md
+++ b/gears/system/account-management/docs/ADR/0008-cpt-cf-account-management-adr-user-attribute-update.md
@@ -4,6 +4,9 @@ date: 2026-07-21
 decision-makers: Constructor Fabric Steering Committee
 ---
 
+Created:  2026-07-22 by Virtuozzo International GmbH
+Updated:  2026-07-22 by Virtuozzo International GmbH
+
 # ADR-0008: Tenant-Scoped User Attribute Update as an IdP Pass-Through
 
 <!-- toc -->

--- a/gears/system/account-management/docs/DESIGN.md
+++ b/gears/system/account-management/docs/DESIGN.md
@@ -1,4 +1,5 @@
-Created:  2026-04-01 by Diffora
+Created:  2026-04-01 by Virtuozzo International GmbH
+Updated:  2026-08-17 by Virtuozzo International GmbH
 
 # Technical Design — Account Management (AM)
 

--- a/gears/system/account-management/docs/PRD.md
+++ b/gears/system/account-management/docs/PRD.md
@@ -1,4 +1,5 @@
-Created:  2026-03-30 by Virtuozzo
+Created:  2026-03-30 by Virtuozzo International GmbH
+Updated:  2026-08-17 by Virtuozzo International GmbH
 
 # PRD - Account Management (AM)
 

--- a/gears/system/account-management/docs/tr-plugin/DESIGN.md
+++ b/gears/system/account-management/docs/tr-plugin/DESIGN.md
@@ -1,4 +1,4 @@
-Created: 2026-04-21 by Diffora
+Created:  2026-04-21 by Virtuozzo International GmbH
 
 # Technical Design — Tenant Resolver Plugin (AM-backed)
 

--- a/gears/system/account-management/docs/tr-plugin/PRD.md
+++ b/gears/system/account-management/docs/tr-plugin/PRD.md
@@ -1,4 +1,4 @@
-Created: 2026-04-21 by Diffora
+Created:  2026-04-21 by Virtuozzo International GmbH
 
 # PRD — Tenant Resolver Plugin (AM-backed)
 

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/DESIGN.md
@@ -7,6 +7,9 @@ refs:
   - ../../../docs/ADR/0006-cpt-cf-account-management-adr-idp-user-tenant-binding.md
 ---
 
+Created:  2026-08-17 by Virtuozzo International GmbH
+Updated:  2026-08-17 by Virtuozzo International GmbH
+
 # Technical Design — Keycloak IdP Plugin
 
 - [ ] `p3` - **ID**: `cpt-cf-keycloak-idp-plugin-design-keycloak-idp-plugin`

--- a/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
+++ b/gears/system/account-management/plugins/keycloak-idp-plugin/docs/PRD.md
@@ -1,3 +1,6 @@
+Created:  2026-08-17 by Virtuozzo International GmbH
+Updated:  2026-08-17 by Virtuozzo International GmbH
+
 # PRD — Keycloak IdP Plugin
 
 <!-- toc -->

--- a/gears/system/authn-resolver/plugins/oidc-authn-plugin/docs/DESIGN.md
+++ b/gears/system/authn-resolver/plugins/oidc-authn-plugin/docs/DESIGN.md
@@ -1,4 +1,5 @@
-Created:  2026-04-09 by Diffora
+Created:  2026-04-09 by Virtuozzo International GmbH
+Updated:  2026-07-24 by Virtuozzo International GmbH
 
 # Technical Design — OIDC AuthN Resolver Plugin
 

--- a/gears/system/authn-resolver/plugins/oidc-authn-plugin/docs/PRD.md
+++ b/gears/system/authn-resolver/plugins/oidc-authn-plugin/docs/PRD.md
@@ -1,4 +1,5 @@
-Created:  2026-04-09 by Diffora
+Created:  2026-04-09 by Virtuozzo International GmbH
+Updated:  2026-07-24 by Virtuozzo International GmbH
 
 # PRD — OIDC AuthN Resolver Plugin
 

--- a/gears/system/usage-collector/docs/ADR/0001-pdp-centric-authorization.md
+++ b/gears/system/usage-collector/docs/ADR/0001-pdp-centric-authorization.md
@@ -3,6 +3,9 @@ status: accepted
 date: 2026-05-24
 ---
 
+Created:  2026-05-22 by Virtuozzo International GmbH
+Updated:  2026-07-06 by Virtuozzo International GmbH
+
 # PDP-centric authorization for Usage Collector
 
 <!-- toc -->

--- a/gears/system/usage-collector/docs/ADR/0002-pluggable-storage.md
+++ b/gears/system/usage-collector/docs/ADR/0002-pluggable-storage.md
@@ -3,6 +3,9 @@ status: accepted
 date: 2026-05-24
 ---
 
+Created:  2026-05-22 by Virtuozzo International GmbH
+Updated:  2026-06-10 by Virtuozzo International GmbH
+
 # Pluggable storage via Plugin SPI for Usage Collector
 
 <!-- toc -->

--- a/gears/system/usage-collector/docs/ADR/0003-caller-supplied-attribution.md
+++ b/gears/system/usage-collector/docs/ADR/0003-caller-supplied-attribution.md
@@ -3,6 +3,9 @@ status: accepted
 date: 2026-05-24
 ---
 
+Created:  2026-05-22 by Virtuozzo International GmbH
+Updated:  2026-06-10 by Virtuozzo International GmbH
+
 # Caller-supplied attribution for ingestion records
 
 <!-- toc -->

--- a/gears/system/usage-collector/docs/ADR/0004-mandatory-idempotency.md
+++ b/gears/system/usage-collector/docs/ADR/0004-mandatory-idempotency.md
@@ -3,6 +3,9 @@ status: accepted
 date: 2026-05-24
 ---
 
+Created:  2026-05-22 by Virtuozzo International GmbH
+Updated:  2026-07-20 by Virtuozzo International GmbH
+
 # Mandatory idempotency key on every ingestion record
 
 <!-- toc -->

--- a/gears/system/usage-collector/docs/ADR/0005-monotonic-deactivation.md
+++ b/gears/system/usage-collector/docs/ADR/0005-monotonic-deactivation.md
@@ -3,6 +3,9 @@ status: accepted
 date: 2026-05-24
 ---
 
+Created:  2026-05-22 by Virtuozzo International GmbH
+Updated:  2026-06-10 by Virtuozzo International GmbH
+
 # Monotonic deactivation as the cross-kind error retraction primitive
 
 <!-- toc -->

--- a/gears/system/usage-collector/docs/ADR/0006-contract-stability.md
+++ b/gears/system/usage-collector/docs/ADR/0006-contract-stability.md
@@ -3,6 +3,9 @@ status: accepted
 date: 2026-05-24
 ---
 
+Created:  2026-05-22 by Virtuozzo International GmbH
+Updated:  2026-06-10 by Virtuozzo International GmbH
+
 # Independent major-version stability for REST, SDK, and Plugin SPI
 
 <!-- toc -->

--- a/gears/system/usage-collector/docs/ADR/0008-usage-compensation.md
+++ b/gears/system/usage-collector/docs/ADR/0008-usage-compensation.md
@@ -4,6 +4,9 @@ date: 2026-05-29
 decision-makers: usage-collector spec owners
 ---
 
+Created:  2026-05-22 by Virtuozzo International GmbH
+Updated:  2026-06-10 by Virtuozzo International GmbH
+
 # Usage compensation as a signed negative entry on the unified ingestion path
 
 <!-- toc -->

--- a/gears/system/usage-collector/docs/ADR/0011-consistency-contract.md
+++ b/gears/system/usage-collector/docs/ADR/0011-consistency-contract.md
@@ -3,6 +3,9 @@ status: accepted
 date: 2026-05-31
 ---
 
+Created:  2026-05-22 by Virtuozzo International GmbH
+Updated:  2026-07-20 by Virtuozzo International GmbH
+
 # Consistency contract for usage-collector read/write paths
 
 <!-- toc -->

--- a/gears/system/usage-collector/docs/ADR/0012-unified-plugin-catalog-and-gts-id-reference.md
+++ b/gears/system/usage-collector/docs/ADR/0012-unified-plugin-catalog-and-gts-id-reference.md
@@ -4,6 +4,9 @@ date: 2026-06-02
 decision-makers: Usage Collector gear owners
 ---
 
+Created:  2026-05-22 by Virtuozzo International GmbH
+Updated:  2026-08-11 by Virtuozzo International GmbH
+
 # Unified plugin-DB usage-type catalog and gts_id reference model
 
 <!-- toc -->

--- a/gears/system/usage-collector/docs/ADR/0013-deterministic-usage-record-id.md
+++ b/gears/system/usage-collector/docs/ADR/0013-deterministic-usage-record-id.md
@@ -3,6 +3,9 @@ status: accepted
 date: 2026-07-07
 ---
 
+Created:  2026-07-07 by Virtuozzo International GmbH
+Updated:  2026-07-20 by Virtuozzo International GmbH
+
 # Deterministic gateway-derived usage-record id (UUIDv5 of the dedup key)
 
 <!-- toc -->

--- a/gears/system/usage-collector/docs/ADR/0014-created-at-in-dedup-identity.md
+++ b/gears/system/usage-collector/docs/ADR/0014-created-at-in-dedup-identity.md
@@ -3,6 +3,9 @@ status: accepted
 date: 2026-07-17
 ---
 
+Created:  2026-07-20 by Virtuozzo International GmbH
+Updated:  2026-07-20 by Virtuozzo International GmbH
+
 # `created_at` as part of the usage-record dedup identity (4-tuple)
 
 

--- a/gears/system/usage-collector/docs/DESIGN.md
+++ b/gears/system/usage-collector/docs/DESIGN.md
@@ -1,3 +1,6 @@
+Created:  2026-02-25 by Virtuozzo International GmbH
+Updated:  2026-08-11 by Virtuozzo International GmbH
+
 # Usage Collector — DESIGN
 
 <!-- toc -->
@@ -1221,4 +1224,3 @@ major-version bump on REST v1 or SDK v1.
 - **SDK trait reference**: [sdk-trait.md](./sdk-trait.md)
 - **Plugin SPI reference**: [plugin-spi.md](./plugin-spi.md)
 - **ADRs**: [ADR/](./ADR/)
-

--- a/gears/system/usage-collector/docs/PRD.md
+++ b/gears/system/usage-collector/docs/PRD.md
@@ -1,3 +1,6 @@
+Created:  2026-02-25 by Virtuozzo International GmbH
+Updated:  2026-08-21 by Virtuozzo International GmbH
+
 # PRD — Usage Collector
 
 <!-- toc -->

--- a/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/docs/DESIGN.md
+++ b/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/docs/DESIGN.md
@@ -1,3 +1,6 @@
+Created:  2026-07-20 by Virtuozzo International GmbH
+Updated:  2026-07-20 by Virtuozzo International GmbH
+
 # Technical Design — TimescaleDB Usage Collector Storage Plugin
 
 <!-- toc -->

--- a/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/docs/PRD.md
+++ b/gears/system/usage-collector/plugins/timescaledb-usage-collector-plugin/docs/PRD.md
@@ -1,4 +1,5 @@
-Created: 2026-07-21
+Created:  2026-07-21 by Virtuozzo International GmbH
+Updated:  2026-07-21 by Virtuozzo International GmbH
 
 # PRD — TimescaleDB Usage Collector Storage Plugin
 


### PR DESCRIPTION
## Description

Adds an attribution notice to PRD, ADR and DESIGN specs written by Virtuozzo authors.

The format matches the notice already used in `gears/chat-engine/docs/DESIGN.md`:

```
Created:  2026-08-24 by Virtuozzo International GmbH
Updated:  2026-09-02 by Virtuozzo International GmbH
```

103 files changed:

- 99 specs get both lines
- 2 credstore specs (`PRD.md`, `DESIGN.md`) get only the `Updated` line
- 2 tr-plugin specs said `by Diffora` and now use the company name

How files were picked: authors were matched to GitHub logins through the commits API. A spec is attributed when most of its commits come from Virtuozzo authors. Dates come from git history — `Created` is the commit that added the file, `Updated` is the last commit that changed it.

Not touched: feature and decomposition docs, spec templates, and specs already attributed to Constructor Tech.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing

Docs only, no code changes. CI does not run for PRs that touch `*.md` files only.

- [ ] Unit tests pass — n/a
- [ ] Integration tests pass — n/a
- [x] Manual testing completed — checked that every notice sits above the title, no file got a duplicate notice, YAML frontmatter is still valid, and no `Updated` date is earlier than its `Created` date
- [ ] New tests added for new functionality — n/a

## Documentation
- [ ] Code is documented with rustdoc comments — n/a
- [ ] README updated (if applicable) — n/a
- [ ] API documentation updated (if applicable) — n/a

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] No linting errors (`cargo clippy`) — n/a
- [ ] Code is properly formatted (`cargo fmt`) — n/a
- [ ] Tests pass (`cargo test`) — n/a

## Related Issues

None.
