### PR TITLE
Types Registry: P0-3 perf optimizations

### DIFF
--- a/gears/system/types-registry/docs/p0/todo.md
+++ b/gears/system/types-registry/docs/p0/todo.md
@@ -757,7 +757,7 @@ the first row lands in that state.
 - [x] The compare-and-swap returns `Some(next_resource_version)` from the repository and `None` on a lost race. The repository computes `next` with `checked_add` and writes that exact value; the domain never reconstructs the database result or saturates at the numeric ceiling
 - [x] A positive precondition on a minor-bearing Type Schema is refused during acceptance: ADR-0004 makes that published contract content-immutable, so a change is registered as the next minor rather than appended as a revision
 - [x] Equal authored content yields `unchanged`, creating no revision and not advancing `resource_version`. Both kinds: the rule is shared, the tables are not
-- [x] `unchanged` is impossible for a create or a delete, enforced in code as well as by the CHECK. In code it is **structural**: `commit_creation` returns `CommittedUnit` and only `commit_revision` returns `RevisionCommit`, whose `Unchanged` variant is the sole way to reach `mark_item_unchanged`. A creation of existing content is `already_exists`, whatever the content
+- [x] `unchanged` is impossible for a create or a delete, enforced in code as well as by the CHECK. In code it is **structural**: `commit_creation` returns `CommittedUnit` and both revision commit paths return `RevisionCommit`; the early `unchanged` proof is constructed only for `Precondition::Version`. A creation of existing content is `already_exists`, whatever the content
 - [x] Content hash is a prefilter only; effective artifacts are excluded from equality. `CurrentDocument` and `CurrentInstanceValue` gained `content_hash` so the digest and the bytes travel together, and the decision is `hash == hash && bytes == bytes` — the digest alone would let a collision swallow a real edit
 
 **The concurrency shape, because it is not the obvious one.** The commit transaction runs at
@@ -1135,7 +1135,7 @@ have had.
 
 **The `unchanged` branch is not guarded, and that is the decision, not an oversight.** It
 writes no revision, moves no version and refreshes no dependent, and the one thing it
-decides is decided from rows read inside its own transaction. Guarding it could only turn a
+decides concerns the current authored document. Guarding it could only turn a
 genuine no-op re-submission into a revalidation because a *neighbour* moved, and after
 `max_revalidation_attempts` of those, into a failure.
 
@@ -1145,7 +1145,25 @@ fresh snapshot, a fresh transient store, fresh validation. Re-running the same t
 would compare the same stale vector and drift identically, which is why
 `RevalidationRequired` reads as `None` to `retryable_db_err`.
 
-**`limits.activation_write_set` is now asked twice**, because the vector's reverse-impact
+**Early `unchanged` check.** Before evaluation, revision submissions compare the current
+canonical authored bytes and content hash in a short read-only snapshot. A match produces
+an internal proof carrying the entity ID and expected `resource_version`, without loading
+the dependency closure, deriving a vector, validating, or materializing artifacts. Its
+commit still claims `entity_write_order` as the first SQL statement, then checks that the
+same entity exists, is live, and has the recorded version before CAS-terminalizing the item.
+Every authored-content write advances that version; dependency refreshes do not change the
+bytes, so their fingerprints need no guard here. A concurrent edit fails the precondition;
+a concurrent deletion reports `entity_deleted`. The proof cannot be constructed for a
+creation. A probe miss releases its snapshot and runs the ordinary evaluation/commit path;
+this adds one small read-only transaction to genuine revisions.
+
+This fixes the case where an identical submission was refused during evaluation because
+its dependents exceeded `activation_write_set`. No-op submissions also bypass resolution
+and materialization budgets, since they perform neither operation. Real edits retain all
+those bounds. Tests cover bounded no-ops, a changed conforming type for an unchanged instance,
+and concurrent edits, deletion, and dependency refresh between the probe and commit.
+
+**`limits.activation_write_set` is asked twice for evaluated edits**, because the vector's reverse-impact
 read is the refresh's read. An over-bound candidate is refused at *evaluation* under the
 same `activation_write_set_exceeded` reason — earlier, cheaper, and invisible to a client;
 T14's refusal stays as the backstop for a set that grew in between.

--- a/gears/system/types-registry/docs/p0/todo.md
+++ b/gears/system/types-registry/docs/p0/todo.md
@@ -1222,16 +1222,19 @@ rollback_and_one_retry`. "One rollback" is read off the versions (revision 2, no
 
 **Added:** `TR/src/domain/admission/vector.rs` + `vector_tests.rs` (10 tests over the pure
 comparison), `TR/tests/revalidation_test.rs` (9 tests),
-`current_schemas_reads_every_named_entity_that_has_one` in `repo_backends_test.rs`,
+`current_projections_read_every_named_entity_that_has_one` in `repo_backends_test.rs`,
 `a_zero_revalidation_budget_fails_startup` in `config_test.rs`,
 `PausePoint::RevisionEntityRead` in `tests/common/mod.rs`.
 
-**One new port, `current_schemas`** — the batched sibling of `find_current_schema`. T14
-declined to add it because *"the alternative is a second batched port whose only caller is
-this loop"*; T15 is the second caller, twice over, and both of its reads run inside a
-transaction. `refresh_dependents` keeps its per-dependent read: moving it would reorder
-reads and writes in tested code for no criterion of this task, and the comment there now
-names T15 as the caller that gave the port its reason.
+**Batched state checks use `current_schema_projections`.** The port returns only
+`entity_id`, `revision_no`, and `resolution_fingerprint`; vector derivation and refresh
+do not load the three materialized documents merely to compare state. Instance evaluation
+uses the same projection to record its conforming type's revision. `current_documents`
+uses this narrow SQL projection for its pointer read and selects only identity, authored
+text, and content hash from the revision table. `find_current_schema` retains the full
+artifacts for entity reads. Transaction boundaries and CAS checks remain unchanged.
+`schema_projection_test.rs` checks the executed SQL excludes unused payload columns;
+the repository backend suite verifies projection values on PostgreSQL and MySQL.
 
 **Clippy-driven extractions, worth naming because they are also better shapes.**
 `process_item` passed the cognitive-complexity bound once the revalidation loop went in, so

--- a/gears/system/types-registry/types-registry/src/domain/admission/mod.rs
+++ b/gears/system/types-registry/types-registry/src/domain/admission/mod.rs
@@ -17,9 +17,11 @@ mod bounds;
 mod drift;
 mod errors;
 mod reasons;
+mod unchanged;
 
 pub mod fingerprint;
 pub mod refresh;
+pub mod revision;
 pub mod unit;
 pub mod vector;
 pub mod worker;

--- a/gears/system/types-registry/types-registry/src/domain/admission/refresh.rs
+++ b/gears/system/types-registry/types-registry/src/domain/admission/refresh.rs
@@ -16,7 +16,8 @@ use crate::domain::artifacts::MaterializedArtifacts;
 use crate::domain::enums::{EntityKind, LifecycleStatus};
 use crate::domain::gts_store::{UnitDocument, load_unit_store};
 use crate::domain::ports::{
-    CurrentSchemaCas, CurrentTypeSchemaRow, EntityRow, NewCurrentTypeSchema, ReverseImpact, Stores,
+    CurrentSchemaCas, CurrentSchemaProjection, EntityRow, NewCurrentTypeSchema, ReverseImpact,
+    Stores,
 };
 
 /// What one refresh wrote.
@@ -154,9 +155,9 @@ pub async fn refresh_dependents(
         }
     };
 
-    // Batch the read to minimize time holding the candidate and family locks.
-    let mut current: HashMap<i64, CurrentTypeSchemaRow> = stores
-        .current_schemas(tx, scope, &subject_ids)
+    // Read only revision numbers and fingerprints while holding the write-order claim.
+    let mut current: HashMap<i64, CurrentSchemaProjection> = stores
+        .current_schema_projections(tx, scope, &subject_ids)
         .await?
         .into_iter()
         .map(|row| (row.entity_id, row))

--- a/gears/system/types-registry/types-registry/src/domain/admission/refresh.rs
+++ b/gears/system/types-registry/types-registry/src/domain/admission/refresh.rs
@@ -179,8 +179,7 @@ pub async fn refresh_dependents(
                 entity_id,
             });
         };
-        let moved = expected.revision_no != current.revision_no
-            || expected.resolution_fingerprint != current.resolution_fingerprint;
+        let moved = expected != current.cas;
         if moved {
             return Err(WorkerError::RevalidationRequired(
                 VectorDrift::CurrentProjectionMoved {
@@ -188,7 +187,7 @@ pub async fn refresh_dependents(
                 },
             ));
         }
-        if current.resolution_fingerprint == artifacts.resolution_fingerprint {
+        if current.cas.resolution_fingerprint == artifacts.resolution_fingerprint {
             continue;
         }
 
@@ -199,7 +198,7 @@ pub async fn refresh_dependents(
                 scope,
                 NewCurrentTypeSchema {
                     entity_id,
-                    revision_no: current.revision_no,
+                    revision_no: current.cas.revision_no,
                     resolved_schema: artifacts.resolved_schema,
                     effective_traits: artifacts.effective_traits,
                     effective_traits_schema: artifacts.effective_traits_schema,

--- a/gears/system/types-registry/types-registry/src/domain/admission/revision.rs
+++ b/gears/system/types-registry/types-registry/src/domain/admission/revision.rs
@@ -1,0 +1,210 @@
+//! The revision vocabulary shared by the two paths that can end in an
+//! *unchanged* outcome: full evaluation ([`super::unit`]) and the pre-evaluation
+//! probe (the private `unchanged` module).
+//!
+//! It holds no policy of its own — the commit result types, the current-content
+//! read, the precondition guard and the terminal `unchanged` write. Both callers
+//! depend on this module and neither on the other, so the fast path cannot drift
+//! from the outcome the slow path records.
+
+use time::OffsetDateTime;
+use toolkit_db::DbTx;
+use toolkit_db::secure::AccessScope;
+use toolkit_macros::domain_model;
+use uuid::Uuid;
+
+use super::errors::{ItemFailure, WorkerError};
+use crate::domain::admission::AdmissionFailureReason;
+use crate::domain::enums::{EntityKind, LifecycleStatus};
+use crate::domain::ports::{CurrentSchemaCas, EntityRow, Stores};
+
+/// The commit's result for one item that wrote a revision.
+#[domain_model]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CommittedUnit {
+    pub gts_uuid: Uuid,
+    pub revision_no: i32,
+    pub resource_version: i64,
+}
+
+/// What committing a *revision* produced. The outcome is the variant: an
+/// `unchanged` candidate allocates no revision number (ADR-0005), and
+/// [`super::unit::commit_creation`] cannot reach that outcome at all.
+#[domain_model]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RevisionCommit {
+    /// A new immutable revision, the current pointer moved onto it, and
+    /// `resource_version` advanced.
+    Admitted(CommittedUnit),
+    /// The authored content already equalled the current revision: no revision, no
+    /// version move. `resource_version` is the one that did not move.
+    Unchanged {
+        gts_uuid: Uuid,
+        resource_version: i64,
+    },
+}
+
+/// Current authored content; Type Schemas also carry their mandatory artifact CAS token.
+#[domain_model]
+#[derive(Clone, Debug)]
+pub(super) enum CurrentContent {
+    TypeSchema {
+        revision_no: i32,
+        body: String,
+        hash: Vec<u8>,
+        /// The compare-and-swap token for the artifact write the caller makes next.
+        cas: CurrentSchemaCas,
+    },
+    Instance {
+        revision_no: i32,
+        body: String,
+        hash: Vec<u8>,
+    },
+}
+
+impl CurrentContent {
+    /// The current revision's number, whichever kind the candidate is: the next
+    /// revision is allocated from it before the outcome kind picks the write.
+    pub(super) fn revision_no(&self) -> i32 {
+        match self {
+            Self::TypeSchema { revision_no, .. } | Self::Instance { revision_no, .. } => {
+                *revision_no
+            }
+        }
+    }
+
+    /// Whether the current content still equals the candidate's authored content —
+    /// the `unchanged` test.
+    pub(super) fn matches_authored(&self, hash: &[u8], body: &str) -> bool {
+        let (current_hash, current_body) = match self {
+            Self::TypeSchema { hash, body, .. } | Self::Instance { hash, body, .. } => (hash, body),
+        };
+        current_hash == hash && current_body == body
+    }
+}
+
+/// The current revision's number, authored content and digest, whichever kind the
+/// candidate is.
+///
+/// The **authored** content, never the effective artifacts: those move when a
+/// dependency moves while the authored document stands still, so including them
+/// would report a revision for a document nobody edited.
+///
+/// # Errors
+/// [`WorkerError::CurrentStateMissing`] when the entity row has no current-state
+/// row of its kind — corruption, since one transaction writes both (D3).
+pub(super) async fn read_current_content(
+    stores: &dyn Stores,
+    tx: &DbTx<'_>,
+    scope: &AccessScope,
+    gts_id: &str,
+    kind: EntityKind,
+    entity_id: i64,
+) -> Result<CurrentContent, WorkerError> {
+    let missing = || WorkerError::CurrentStateMissing {
+        gts_id: gts_id.to_owned(),
+        entity_id,
+    };
+    Ok(match kind {
+        EntityKind::TypeSchema => {
+            let current = stores
+                .current_documents(tx, scope, &[entity_id])
+                .await?
+                .pop()
+                .ok_or_else(missing)?;
+            CurrentContent::TypeSchema {
+                revision_no: current.revision_no,
+                body: current.raw_schema,
+                hash: current.content_hash,
+                cas: current.projection,
+            }
+        }
+        EntityKind::Instance => {
+            let current = stores
+                .current_values(tx, scope, &[entity_id])
+                .await?
+                .pop()
+                .ok_or_else(missing)?;
+            CurrentContent::Instance {
+                revision_no: current.revision_no,
+                body: current.canonical_value,
+                hash: current.content_hash,
+            }
+        }
+    })
+}
+
+/// Check the revision precondition after acquiring the entity write order.
+pub(super) async fn revision_entity(
+    stores: &dyn Stores,
+    tx: &DbTx<'_>,
+    scope: &AccessScope,
+    gts_id: &str,
+    expected_resource_version: i64,
+) -> Result<Result<EntityRow, ItemFailure>, WorkerError> {
+    let Some(entity) = stores.find_by_gts_id(tx, scope, gts_id).await? else {
+        return Ok(Err(ItemFailure::new(
+            AdmissionFailureReason::PreconditionFailed,
+            format!(
+                "'{gts_id}' does not exist; expected_resource_version {expected_resource_version} \
+                 requires it to exist at that version"
+            ),
+        )));
+    };
+    // Before the version, because a tombstone is not a stale version: reporting
+    // `precondition_failed` would send the caller to retry against a row that will
+    // never accept a revision. Both revision paths use this check; the lookup
+    // returns tombstones because the family rules need them.
+    if entity.lifecycle_status == LifecycleStatus::Deleted {
+        return Ok(Err(ItemFailure::new(
+            AdmissionFailureReason::EntityDeleted,
+            format!("'{gts_id}' is deleted; a revision cannot be admitted onto a withdrawn entity"),
+        )));
+    }
+    if entity.resource_version != expected_resource_version {
+        return Ok(Err(stale_precondition(
+            gts_id,
+            expected_resource_version,
+            entity.resource_version,
+        )));
+    }
+
+    Ok(Ok(entity))
+}
+
+/// Record the shared terminal outcome after the caller's entity guards pass.
+pub(super) async fn terminalize_unchanged(
+    stores: &dyn Stores,
+    tx: &DbTx<'_>,
+    scope: &AccessScope,
+    entity: &EntityRow,
+    operation_item_id: i64,
+    now: OffsetDateTime,
+) -> Result<Result<RevisionCommit, ItemFailure>, WorkerError> {
+    if !stores
+        .mark_item_unchanged(tx, scope, operation_item_id, entity.resource_version, now)
+        .await?
+    {
+        return Err(WorkerError::ItemAlreadyTerminal {
+            item_id: operation_item_id,
+        });
+    }
+    Ok(Ok(RevisionCommit::Unchanged {
+        gts_uuid: entity.gts_uuid,
+        resource_version: entity.resource_version,
+    }))
+}
+
+/// The refusal for a precondition that was already wrong when read — the entry
+/// check and the `unchanged` re-read. The lost compare-and-swap words it
+/// differently on purpose, knowing only that the version *moved*, not what to; both
+/// carry the same `reason`, so a client branching on it sees one outcome.
+pub(super) fn stale_precondition(gts_id: &str, expected: i64, found: i64) -> ItemFailure {
+    ItemFailure::new(
+        AdmissionFailureReason::PreconditionFailed,
+        format!(
+            "'{gts_id}' is at resource_version {found}, not the expected {expected}; a revision \
+             is never rebased onto the current version"
+        ),
+    )
+}

--- a/gears/system/types-registry/types-registry/src/domain/admission/unchanged.rs
+++ b/gears/system/types-registry/types-registry/src/domain/admission/unchanged.rs
@@ -1,0 +1,100 @@
+//! Recognize unchanged revisions before loading or resolving their dependencies.
+
+use time::OffsetDateTime;
+use toolkit_db::DbTx;
+use toolkit_db::secure::AccessScope;
+use toolkit_macros::domain_model;
+
+use super::errors::{ItemFailure, WorkerError};
+use super::revision::{
+    RevisionCommit, read_current_content, revision_entity, terminalize_unchanged,
+};
+use crate::domain::admission::{AdmissionFailureReason, Precondition};
+use crate::domain::artifacts::content_hash;
+use crate::domain::enums::LifecycleStatus;
+use crate::domain::ports::{OperationItemRow, Stores};
+
+/// Proof that the submitted bytes equal the current authored document in one
+/// snapshot. Private fields keep callers from constructing an unverified proof.
+#[domain_model]
+#[derive(Clone, Debug)]
+pub struct UnchangedCandidate {
+    gts_id: String,
+    entity_id: i64,
+    resource_version: i64,
+    operation_item_id: i64,
+}
+
+/// A read-only probe, restricted to revisions. A miss falls through to ordinary
+/// evaluation; it neither claims the write order nor records an item outcome.
+pub(super) async fn probe(
+    stores: &dyn Stores,
+    tx: &DbTx<'_>,
+    scope: &AccessScope,
+    item: &OperationItemRow,
+    payload: &str,
+) -> Result<Option<UnchangedCandidate>, WorkerError> {
+    let Precondition::Version(expected) = item.precondition else {
+        return Ok(None);
+    };
+    let Some(entity) = stores.find_by_gts_id(tx, scope, &item.gts_id).await? else {
+        return Ok(None);
+    };
+    if entity.lifecycle_status == LifecycleStatus::Deleted || entity.resource_version != expected {
+        return Ok(None);
+    }
+    let current = read_current_content(
+        stores,
+        tx,
+        scope,
+        &item.gts_id,
+        entity.entity_kind,
+        entity.id,
+    )
+    .await?;
+    // A digest is only a prefilter: collisions must not swallow edits.
+    Ok(current
+        .matches_authored(&content_hash(payload), payload)
+        .then_some(UnchangedCandidate {
+            gts_id: item.gts_id.clone(),
+            entity_id: entity.id,
+            resource_version: expected,
+            operation_item_id: item.id,
+        }))
+}
+
+/// Commit a snapshot proof only if the same live entity still has that version.
+/// Every authored-content write advances `resource_version` under this same lock;
+/// dependency refreshes may change artifacts, but cannot change authored content.
+pub(super) async fn commit(
+    stores: &dyn Stores,
+    tx: &DbTx<'_>,
+    scope: &AccessScope,
+    candidate: &UnchangedCandidate,
+    now: OffsetDateTime,
+) -> Result<Result<RevisionCommit, ItemFailure>, WorkerError> {
+    // Must remain the first SQL statement, including on transaction retry.
+    stores.claim_entity_write_order(tx, scope, now).await?;
+    let entity = match revision_entity(
+        stores,
+        tx,
+        scope,
+        &candidate.gts_id,
+        candidate.resource_version,
+    )
+    .await?
+    {
+        Ok(entity) => entity,
+        Err(failure) => return Ok(Err(failure)),
+    };
+    if entity.id != candidate.entity_id {
+        return Ok(Err(ItemFailure::new(
+            AdmissionFailureReason::PreconditionFailed,
+            format!(
+                "'{}' was replaced after the content comparison",
+                candidate.gts_id
+            ),
+        )));
+    }
+    terminalize_unchanged(stores, tx, scope, &entity, candidate.operation_item_id, now).await
+}

--- a/gears/system/types-registry/types-registry/src/domain/admission/unit.rs
+++ b/gears/system/types-registry/types-registry/src/domain/admission/unit.rs
@@ -215,8 +215,9 @@ pub async fn evaluate(
                         let entity = stores.find_by_gts_id(tx, &scope, &type_id).await?;
                         match entity {
                             Some(row) => stores
-                                .find_current_schema(tx, &scope, row.id)
+                                .current_schema_projections(tx, &scope, &[row.id])
                                 .await?
+                                .pop()
                                 .map(|current| (row.id, current.revision_no)),
                             None => None,
                         }

--- a/gears/system/types-registry/types-registry/src/domain/admission/unit.rs
+++ b/gears/system/types-registry/types-registry/src/domain/admission/unit.rs
@@ -28,18 +28,23 @@ use super::bounds::{check_closure, materialize_bounded};
 use super::errors::{ItemFailure, WorkerError};
 use super::fingerprint::canonical_text;
 use super::refresh::refresh_dependents;
+use super::revision::{
+    CommittedUnit, CurrentContent, RevisionCommit, read_current_content, revision_entity,
+    stale_precondition, terminalize_unchanged,
+};
+use super::unchanged::{self, UnchangedCandidate};
 use super::vector::{self, RevisionVector, VectorDrift};
 use crate::config::Limits;
 use crate::domain::admission::AdmissionFailureReason;
 use crate::domain::artifacts::{MaterializedArtifacts, content_hash};
 use crate::domain::dependency::{DependencyEdge, extract_edges};
-use crate::domain::enums::{DependencyKind, EntityKind, LifecycleStatus, OwnershipScope};
+use crate::domain::enums::{DependencyKind, EntityKind, OwnershipScope};
 use crate::domain::family::{FamilyKey, admits_new_member, family_key};
 use crate::domain::gts_store::{UnitDocument, UnitStore, load_unit_store};
 use crate::domain::ports::metrics::AdmissionMetrics;
 use crate::domain::ports::{
-    CurrentSchemaCas, NewCurrentInstance, NewCurrentTypeSchema, NewEntity, NewInstanceRevision,
-    NewRevision, Stores, snapshot_read,
+    NewCurrentInstance, NewCurrentTypeSchema, NewEntity, NewInstanceRevision, NewRevision,
+    OperationItemRow, Stores, snapshot_read,
 };
 
 /// The owning gear recorded on a P0 admission.
@@ -110,33 +115,28 @@ async fn claim_entity_write_order(
     Ok(stores.claim_entity_write_order(tx, scope, now).await?)
 }
 
-/// The commit's result for one item that wrote a revision.
+/// The snapshot either proves equality or supplies everything evaluation needs.
 #[domain_model]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct CommittedUnit {
-    pub gts_uuid: Uuid,
-    pub revision_no: i32,
-    pub resource_version: i64,
-}
-
-/// What committing a *revision* produced. The outcome is the variant: an
-/// `unchanged` candidate allocates no revision number (ADR-0005), and
-/// [`commit_creation`] cannot reach that outcome at all.
-#[domain_model]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum RevisionCommit {
-    /// A new immutable revision, the current pointer moved onto it, and
-    /// `resource_version` advanced.
-    Admitted(CommittedUnit),
-    /// The authored content already equalled the current revision: no revision, no
-    /// version move. `resource_version` is the one that did not move.
-    Unchanged {
-        gts_uuid: Uuid,
-        resource_version: i64,
+enum EvaluationSnapshot {
+    Unchanged(UnchangedCandidate),
+    Loaded {
+        store: Box<UnitStore>,
+        schema_pair: Option<(i64, i32)>,
+        vector: RevisionVector,
+        edges: Vec<DependencyEdge>,
     },
 }
 
-/// Evaluate one candidate. **No transaction is open here.**
+/// A revision may prove equality without evaluating any effective content.
+#[domain_model]
+#[derive(Clone, Debug)]
+pub enum PreparedUnit {
+    Evaluated(Arc<EvaluatedUnit>),
+    Unchanged(Arc<UnchangedCandidate>),
+}
+
+/// Probe once when requested, then evaluate a miss from the same snapshot.
+/// Validation and artifact materialization run after the snapshot closes.
 ///
 /// Builds the unit's transient store from the database (D2), asks `gts-rust` to
 /// validate the candidate, and materializes D3's artifacts. The store is dropped
@@ -149,6 +149,7 @@ pub enum RevisionCommit {
 /// [`WorkerError`] for an infrastructure failure, which the outbox handler must
 /// retry. A content failure is an [`ItemFailure`] in the `Ok(Err(..))` position: an
 /// *outcome*, not a fault, and retrying it would answer the same forever.
+#[allow(clippy::too_many_arguments)]
 pub async fn evaluate(
     stores: &Arc<dyn Stores>,
     db: &DBProvider<WorkerError>,
@@ -157,7 +158,8 @@ pub async fn evaluate(
     canonical_body: &str,
     operation_item_id: i64,
     limits: &Limits,
-) -> Result<Result<EvaluatedUnit, ItemFailure>, WorkerError> {
+    probe_item: Option<&OperationItemRow>,
+) -> Result<Result<PreparedUnit, ItemFailure>, WorkerError> {
     let limits = *limits;
     let id = match GtsId::try_new(gts_id) {
         Ok(id) => id,
@@ -170,43 +172,51 @@ pub async fn evaluate(
             )));
         }
     };
-    let content: Value = match serde_json::from_str(canonical_body) {
-        Ok(content) => content,
-        Err(e) => {
-            return Ok(Err(ItemFailure::new(
-                AdmissionFailureReason::InvalidDocument,
-                format!("stored request payload is not valid JSON: {e}"),
-            )));
-        }
-    };
-
-    // Extracted here, where the document is parsed and no transaction is open.
-    let edges = match extract_edges(&id, &content) {
-        Ok(edges) => edges,
-        Err(e) => {
-            return Ok(Err(ItemFailure::new(
-                AdmissionFailureReason::InvalidSchema,
-                e.to_string(),
-            )));
-        }
-    };
-
-    // The store's reads are one snapshot, and the transaction ends with the load:
-    // everything after it runs with no transaction open (see the module header).
-    let candidates = vec![UnitDocument {
-        gts_id: id.id().to_owned(),
-        content,
-    }];
     // The conforming type's `(entity_id, revision_no)` is read in the same snapshot as
     // the store: the recorded revision must be the one that validated the value.
     let conforming_type = (!id.is_type()).then(|| id.get_type_id()).flatten();
     let candidate_id = id.id().to_owned();
-    let (store, schema_pair, vector) = {
+    let snapshot = {
         let stores = Arc::clone(stores);
         let scope = scope.clone();
         let conforming_type = conforming_type.clone();
+        let probe_item = probe_item.cloned();
+        let canonical_body = canonical_body.to_owned();
+        let id = id.clone();
         db.transaction_with_config(snapshot_read(&db.db()), move |tx| {
             Box::pin(async move {
+                if let Some(item) = probe_item
+                    && let Some(candidate) =
+                        unchanged::probe(stores.as_ref(), tx, &scope, &item, &canonical_body)
+                            .await?
+                {
+                    return Ok(Ok(EvaluationSnapshot::Unchanged(candidate)));
+                }
+                let content: Value = match serde_json::from_str(&canonical_body) {
+                    Ok(content) => content,
+                    Err(e) => {
+                        return Ok(Err(ItemFailure::new(
+                            AdmissionFailureReason::InvalidDocument,
+                            format!("stored request payload is not valid JSON: {e}"),
+                        )));
+                    }
+                };
+
+                // Extract only after a probe miss, before loading the dependency store.
+                let edges = match extract_edges(&id, &content) {
+                    Ok(edges) => edges,
+                    Err(e) => {
+                        return Ok(Err(ItemFailure::new(
+                            AdmissionFailureReason::InvalidSchema,
+                            e.to_string(),
+                        )));
+                    }
+                };
+
+                let candidates = vec![UnitDocument {
+                    gts_id: id.id().to_owned(),
+                    content,
+                }];
                 let store = load_unit_store(stores.as_ref(), tx, &scope, candidates)
                     .await
                     .map_err(WorkerError::StoreBuild)?;
@@ -217,8 +227,9 @@ pub async fn evaluate(
                             Some(row) => stores
                                 .current_schema_projections(tx, &scope, &[row.id])
                                 .await?
-                                .pop()
-                                .map(|current| (row.id, current.revision_no)),
+                                .into_iter()
+                                .find(|current| current.entity_id == row.id)
+                                .map(|current| (row.id, current.cas.revision_no)),
                             None => None,
                         }
                     }
@@ -235,20 +246,37 @@ pub async fn evaluate(
                     limits.activation_write_set,
                 )
                 .await?;
-                Ok((store, pair, vector))
+                let vector = match vector {
+                    Ok(vector) => vector,
+                    Err(failure) => return Ok(Err(failure)),
+                };
+                Ok(Ok(EvaluationSnapshot::Loaded {
+                    store: Box::new(store),
+                    schema_pair: pair,
+                    vector,
+                    edges,
+                }))
             })
         })
         .await?
     };
-    let vector = match vector {
-        Ok(vector) => vector,
+    let (store, schema_pair, vector, edges) = match snapshot {
+        Ok(EvaluationSnapshot::Loaded {
+            store,
+            schema_pair,
+            vector,
+            edges,
+        }) => (store, schema_pair, vector, edges),
+        Ok(EvaluationSnapshot::Unchanged(candidate)) => {
+            return Ok(Ok(PreparedUnit::Unchanged(Arc::new(candidate))));
+        }
         Err(failure) => return Ok(Err(failure)),
     };
 
     let canonical_body = canonical_body.to_owned();
     tokio::task::spawn_blocking(move || {
         evaluate_loaded(
-            store,
+            *store,
             &id,
             conforming_type,
             schema_pair,
@@ -261,6 +289,7 @@ pub async fn evaluate(
     })
     .await
     .map_err(WorkerError::EvaluationTask)?
+    .map(|result| result.map(|unit| PreparedUnit::Evaluated(Arc::new(unit))))
 }
 
 /// Run the CPU-heavy `gts-rust` validation and artifact materialization away from
@@ -621,100 +650,6 @@ pub async fn commit_creation(
     }))
 }
 
-/// The current revision's number, authored content and digest, whichever kind the
-/// candidate is.
-///
-/// The **authored** content, never the effective artifacts: those move when a
-/// dependency moves while the authored document stands still, so including them
-/// would report a revision for a document nobody edited.
-///
-/// TODO(toolkit): a genuine edit fails the `content_hash` prefilter and never
-/// compares the bytes, so the body travels for nothing. Fetching it only on a hash
-/// match needs a column projection `SecureSelect` does not expose — no
-/// `select_only` / `into_tuple`.
-///
-/// # Errors
-/// [`WorkerError::CurrentStateMissing`] when the entity row has no current-state
-/// row of its kind — corruption, since one transaction writes both (D3).
-async fn read_current_content(
-    stores: &dyn Stores,
-    tx: &DbTx<'_>,
-    scope: &AccessScope,
-    unit: &EvaluatedUnit,
-    entity_id: i64,
-) -> Result<CurrentContent, WorkerError> {
-    let missing = || WorkerError::CurrentStateMissing {
-        gts_id: unit.gts_id.clone(),
-        entity_id,
-    };
-    Ok(match &unit.outcome {
-        EvaluatedOutcome::TypeSchema { .. } => {
-            let current = stores
-                .current_documents(tx, scope, &[entity_id])
-                .await?
-                .pop()
-                .ok_or_else(missing)?;
-            CurrentContent::TypeSchema {
-                revision_no: current.revision_no,
-                body: current.raw_schema,
-                hash: current.content_hash,
-                cas: current.projection,
-            }
-        }
-        EvaluatedOutcome::Instance { .. } => {
-            let current = stores
-                .current_values(tx, scope, &[entity_id])
-                .await?
-                .pop()
-                .ok_or_else(missing)?;
-            CurrentContent::Instance {
-                revision_no: current.revision_no,
-                body: current.canonical_value,
-                hash: current.content_hash,
-            }
-        }
-    })
-}
-
-/// Current authored content; Type Schemas also carry their mandatory artifact CAS token.
-#[domain_model]
-#[derive(Clone, Debug)]
-enum CurrentContent {
-    TypeSchema {
-        revision_no: i32,
-        body: String,
-        hash: Vec<u8>,
-        /// The compare-and-swap token for the artifact write below.
-        cas: CurrentSchemaCas,
-    },
-    Instance {
-        revision_no: i32,
-        body: String,
-        hash: Vec<u8>,
-    },
-}
-
-impl CurrentContent {
-    /// The current revision's number, whichever kind the candidate is: the next
-    /// revision is allocated from it before the outcome kind picks the write.
-    fn revision_no(&self) -> i32 {
-        match self {
-            Self::TypeSchema { revision_no, .. } | Self::Instance { revision_no, .. } => {
-                *revision_no
-            }
-        }
-    }
-
-    /// Whether the current content still equals the candidate's authored content —
-    /// the `unchanged` test.
-    fn matches_authored(&self, hash: &[u8], body: &str) -> bool {
-        let (current_hash, current_body) = match self {
-            Self::TypeSchema { hash, body, .. } | Self::Instance { hash, body, .. } => (hash, body),
-        };
-        current_hash == hash && current_body == body
-    }
-}
-
 /// Record an unchanged candidate without creating a revision.
 async fn commit_unchanged(
     stores: &dyn Stores,
@@ -740,24 +675,7 @@ async fn commit_unchanged(
             still.resource_version,
         )));
     }
-    if !stores
-        .mark_item_unchanged(
-            tx,
-            scope,
-            unit.operation_item_id,
-            still.resource_version,
-            now,
-        )
-        .await?
-    {
-        return Err(WorkerError::ItemAlreadyTerminal {
-            item_id: unit.operation_item_id,
-        });
-    }
-    Ok(Ok(RevisionCommit::Unchanged {
-        gts_uuid: unit.gts_uuid,
-        resource_version: still.resource_version,
-    }))
+    terminalize_unchanged(stores, tx, scope, &still, unit.operation_item_id, now).await
 }
 
 /// Commit an evaluated unit as a revision with compare-and-swap protection.
@@ -778,41 +696,22 @@ pub async fn commit_revision(
     metrics: &Arc<dyn AdmissionMetrics>,
 ) -> Result<Result<RevisionCommit, ItemFailure>, WorkerError> {
     claim_entity_write_order(stores, tx, scope, now).await?;
-    let Some(entity) = stores.find_by_gts_id(tx, scope, &unit.gts_id).await? else {
-        return Ok(Err(ItemFailure::new(
-            AdmissionFailureReason::PreconditionFailed,
-            format!(
-                "'{}' does not exist; expected_resource_version {expected_resource_version} \
-                 requires it to exist at that version",
-                unit.gts_id
-            ),
-        )));
-    };
-    // Before the version, because a tombstone is not a stale version: reporting
-    // `precondition_failed` would send the caller to retry against a row that will
-    // never accept a revision. This is the only write path that reaches a `DELETED`
-    // row — `find_by_gts_id` returns tombstones because the family rules need them.
-    // The compare-and-swap below carries the same clause for the race this read
-    // cannot see.
-    if entity.lifecycle_status == LifecycleStatus::Deleted {
-        return Ok(Err(ItemFailure::new(
-            AdmissionFailureReason::EntityDeleted,
-            format!(
-                "'{}' is deleted; a revision cannot be admitted onto a withdrawn entity",
-                unit.gts_id
-            ),
-        )));
-    }
-    if entity.resource_version != expected_resource_version {
-        return Ok(Err(stale_precondition(
-            &unit.gts_id,
-            expected_resource_version,
-            entity.resource_version,
-        )));
-    }
+    let entity =
+        match revision_entity(stores, tx, scope, &unit.gts_id, expected_resource_version).await? {
+            Ok(entity) => entity,
+            Err(failure) => return Ok(Err(failure)),
+        };
 
     // Keep the artifact CAS token with the content that supplied it.
-    let current = read_current_content(stores, tx, scope, unit, entity.id).await?;
+    let current = read_current_content(
+        stores,
+        tx,
+        scope,
+        &unit.gts_id,
+        unit.outcome.entity_kind(),
+        entity.id,
+    )
+    .await?;
 
     // The hash is a prefilter and the bytes are the decision (ADR-0012): a digest
     // collision would otherwise silently swallow a real edit. Equality against an
@@ -1028,20 +927,6 @@ async fn refresh_reverse_impact(
         }
         Err(failure) => Err(WorkerError::RefusedAfterWrite(failure)),
     }
-}
-
-/// The refusal for a precondition that was already wrong when read — the entry
-/// check and the `unchanged` re-read. The lost compare-and-swap words it
-/// differently on purpose, knowing only that the version *moved*, not what to; both
-/// carry the same `reason`, so a client branching on it sees one outcome.
-fn stale_precondition(gts_id: &str, expected: i64, found: i64) -> ItemFailure {
-    ItemFailure::new(
-        AdmissionFailureReason::PreconditionFailed,
-        format!(
-            "'{gts_id}' is at resource_version {found}, not the expected {expected}; a revision \
-             is never rebased onto the current version"
-        ),
-    )
 }
 
 /// Canonicalize a document the way acceptance did, for a caller that has a `Value`

--- a/gears/system/types-registry/types-registry/src/domain/admission/vector.rs
+++ b/gears/system/types-registry/types-registry/src/domain/admission/vector.rs
@@ -201,7 +201,7 @@ pub async fn derive_from(
         .current_schema_projections(tx, scope, &artifact_bearing)
         .await?
         .into_iter()
-        .map(|row| (row.entity_id, row.resolution_fingerprint))
+        .map(|row| (row.entity_id, row.cas.resolution_fingerprint))
         .collect();
 
     for row in &dependents {

--- a/gears/system/types-registry/types-registry/src/domain/admission/vector.rs
+++ b/gears/system/types-registry/types-registry/src/domain/admission/vector.rs
@@ -198,7 +198,7 @@ pub async fn derive_from(
         .map(|row| row.id)
         .collect();
     let mut fingerprints: HashMap<i64, Vec<u8>> = stores
-        .current_schemas(tx, scope, &artifact_bearing)
+        .current_schema_projections(tx, scope, &artifact_bearing)
         .await?
         .into_iter()
         .map(|row| (row.entity_id, row.resolution_fingerprint))

--- a/gears/system/types-registry/types-registry/src/domain/admission/worker.rs
+++ b/gears/system/types-registry/types-registry/src/domain/admission/worker.rs
@@ -39,9 +39,9 @@ use tracing::{Instrument, Span};
 use uuid::Uuid;
 
 pub use super::errors::{ItemFailure, WorkerError};
-use super::unit::{
-    CommittedUnit, EvaluatedUnit, RevisionCommit, commit_creation, commit_revision, evaluate,
-};
+use super::revision::{CommittedUnit, RevisionCommit};
+use super::unchanged;
+use super::unit::{PreparedUnit, commit_creation, commit_revision, evaluate};
 use super::vector::VectorDrift;
 use crate::config::{Limits, WorkerSettings};
 use crate::domain::admission::AdmissionFailureReason;
@@ -180,10 +180,37 @@ const fn retryable_db_err(e: &WorkerError) -> Option<&sea_orm::DbErr> {
     }
 }
 
+async fn prepare(
+    stores: &Arc<dyn Stores>,
+    db: &DBProvider<WorkerError>,
+    scope: &AccessScope,
+    item: &OperationItemRow,
+    payload: &str,
+    tuning: Tuning<'_>,
+) -> Result<Result<PreparedUnit, ItemFailure>, WorkerError> {
+    let prepared = evaluate(
+        stores,
+        db,
+        scope,
+        &item.gts_id,
+        payload,
+        item.id,
+        tuning.limits,
+        Some(item),
+    )
+    .await?;
+    let hit = matches!(&prepared, Ok(PreparedUnit::Unchanged(_)));
+    tuning.metrics.unchanged_probe(hit);
+    if hit {
+        tracing::debug!(operation_item_id = item.id, gts_id = %item.gts_id, "types_registry unchanged probe hit");
+    }
+    Ok(prepared)
+}
+
 /// Groups the per-item commit inputs so the transaction boundary stays readable
 /// without crossing Clippy's argument-count threshold.
 struct CommitRequest<'a> {
-    evaluated: &'a Arc<EvaluatedUnit>,
+    prepared: &'a PreparedUnit,
     item: &'a OperationItemRow,
     now: OffsetDateTime,
     limits: Limits,
@@ -193,14 +220,14 @@ struct CommitRequest<'a> {
 /// Run the serialized commit transaction (SPEC step 4b).
 ///
 /// Its first statement claims `entity_write_order`, replacing the former family locks.
-async fn commit_evaluated(
+async fn commit_prepared(
     db: &DBProvider<WorkerError>,
     stores: &Arc<dyn Stores>,
     scope: &AccessScope,
     request: CommitRequest<'_>,
 ) -> Result<Result<RevisionCommit, ItemFailure>, WorkerError> {
     let CommitRequest {
-        evaluated,
+        prepared,
         item,
         now,
         limits,
@@ -228,28 +255,36 @@ async fn commit_evaluated(
     let tx_limits = limits;
     db.db()
         .transaction_with_retry(commit_write(&db.db()), retryable_db_err, |tx| {
-            let unit = Arc::clone(evaluated);
+            let prepared = prepared.clone();
             let tx_scope = tx_scope.clone();
             let tx_stores = Arc::clone(&tx_stores);
             let tx_metrics = Arc::clone(&tx_metrics);
             Box::pin(async move {
+                let unit = match &prepared {
+                    PreparedUnit::Unchanged(candidate) => {
+                        return unchanged::commit(
+                            tx_stores.as_ref(),
+                            tx,
+                            &tx_scope,
+                            candidate,
+                            now,
+                        )
+                        .await;
+                    }
+                    PreparedUnit::Evaluated(unit) => unit,
+                };
                 match precondition {
-                    Precondition::MustNotExist => commit_creation(
-                        tx_stores.as_ref(),
-                        tx,
-                        &tx_scope,
-                        unit.as_ref(),
-                        &tx_limits,
-                        now,
-                    )
-                    .await
-                    .map(|r| r.map(RevisionCommit::Admitted)),
+                    Precondition::MustNotExist => {
+                        commit_creation(tx_stores.as_ref(), tx, &tx_scope, unit, &tx_limits, now)
+                            .await
+                            .map(|r| r.map(RevisionCommit::Admitted))
+                    }
                     Precondition::Version(expected) => {
                         commit_revision(
                             tx_stores.as_ref(),
                             tx,
                             &tx_scope,
-                            unit.as_ref(),
+                            unit,
                             expected,
                             &tx_limits,
                             now,
@@ -285,21 +320,33 @@ async fn process_item(
 
     let attempts = tuning.worker.max_revalidation_attempts;
     let mut last_drift: Option<VectorDrift> = None;
+    // Probe once in the initial evaluation snapshot. A miss stays on ordinary
+    // evaluation even if a concurrent write makes the authored content identical.
+    let mut initial = if attempts > 0 {
+        Some(prepare(stores, db, scope, item, payload, tuning).await?)
+    } else {
+        None
+    };
     // Log attempts using one-based numbering.
     for attempt in 1..=attempts {
-        // Step 3: evaluation releases its snapshot before CPU-heavy validation.
-        let evaluated = match evaluate(
-            stores,
-            db,
-            scope,
-            &item.gts_id,
-            payload,
-            item.id,
-            tuning.limits,
-        )
-        .await?
-        {
-            Ok(evaluated) => Arc::new(evaluated),
+        let prepared = match initial.take() {
+            Some(prepared) => prepared,
+            None => {
+                evaluate(
+                    stores,
+                    db,
+                    scope,
+                    &item.gts_id,
+                    payload,
+                    item.id,
+                    tuning.limits,
+                    None,
+                )
+                .await?
+            }
+        };
+        let prepared = match prepared {
+            Ok(prepared) => prepared,
             Err(failure) => {
                 return record_failure(
                     stores,
@@ -315,12 +362,12 @@ async fn process_item(
             }
         };
 
-        let committed = match commit_evaluated(
+        let committed = match commit_prepared(
             db,
             stores,
             scope,
             CommitRequest {
-                evaluated: &evaluated,
+                prepared: &prepared,
                 item,
                 now,
                 limits: *tuning.limits,

--- a/gears/system/types-registry/types-registry/src/domain/ports/metrics.rs
+++ b/gears/system/types-registry/types-registry/src/domain/ports/metrics.rs
@@ -62,6 +62,9 @@ impl TryFrom<OperationItemStatus> for TerminalStatus {
 
 /// The admission path's instrument set.
 pub trait AdmissionMetrics: std::fmt::Debug + Send + Sync {
+    /// Count initial unchanged probes by hit or miss.
+    fn unchanged_probe(&self, hit: bool);
+
     /// Count candidates terminalized by this pass, by status.
     fn candidate_terminalized(&self, status: TerminalStatus);
 
@@ -84,6 +87,8 @@ pub trait AdmissionMetrics: std::fmt::Debug + Send + Sync {
 pub struct NoopMetrics;
 
 impl AdmissionMetrics for NoopMetrics {
+    fn unchanged_probe(&self, _hit: bool) {}
+
     fn candidate_terminalized(&self, _status: TerminalStatus) {}
 
     fn refused(&self, _stage: RefusalStage, _reason: &'static str) {}

--- a/gears/system/types-registry/types-registry/src/domain/ports/mod.rs
+++ b/gears/system/types-registry/types-registry/src/domain/ports/mod.rs
@@ -271,8 +271,7 @@ pub struct CurrentTypeSchemaRow {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CurrentSchemaProjection {
     pub entity_id: i64,
-    pub revision_no: i32,
-    pub resolution_fingerprint: Vec<u8>,
+    pub cas: CurrentSchemaCas,
 }
 
 /// The current authored document of one entity.
@@ -362,7 +361,7 @@ pub struct NewRevision {
 
 /// The revision and fingerprint a current-schema write expects to replace.
 #[domain_model]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CurrentSchemaCas {
     pub revision_no: i32,
     pub resolution_fingerprint: Vec<u8>,

--- a/gears/system/types-registry/types-registry/src/domain/ports/mod.rs
+++ b/gears/system/types-registry/types-registry/src/domain/ports/mod.rs
@@ -265,6 +265,16 @@ pub struct CurrentTypeSchemaRow {
     pub updated_at: OffsetDateTime,
 }
 
+/// Current revision and artifact identity, without the materialized documents.
+/// Used by admission guards and refresh to compare state without loading artifacts.
+#[domain_model]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CurrentSchemaProjection {
+    pub entity_id: i64,
+    pub revision_no: i32,
+    pub resolution_fingerprint: Vec<u8>,
+}
+
 /// The current authored document of one entity.
 ///
 /// This is the *authored* document on the revision, never the materialized
@@ -595,13 +605,14 @@ pub trait TypeSchemaStore: Send + Sync {
         entity_id: i64,
     ) -> Result<Option<CurrentTypeSchemaRow>, ScopeError>;
 
-    /// The current-state rows of many entities in one read, `entity_id`-sorted.
-    async fn current_schemas(
+    /// Current revision numbers and fingerprints, `entity_id`-sorted, without artifacts.
+    /// Entities with no current row are simply absent.
+    async fn current_schema_projections(
         &self,
         tx: &DbTx<'_>,
         scope: &AccessScope,
         entity_ids: &[i64],
-    ) -> Result<Vec<CurrentTypeSchemaRow>, ScopeError>;
+    ) -> Result<Vec<CurrentSchemaProjection>, ScopeError>;
 
     async fn insert_schema_revision(
         &self,

--- a/gears/system/types-registry/types-registry/src/infra/metrics.rs
+++ b/gears/system/types-registry/types-registry/src/infra/metrics.rs
@@ -34,6 +34,8 @@ const fn drift_label(drift: &VectorDrift) -> &'static str {
 /// The OpenTelemetry rendering of [`AdmissionMetrics`].
 #[derive(Debug)]
 pub struct AdmissionMetricsMeter {
+    /// Initial unchanged probes, by hit or miss.
+    unchanged_probes: Counter<u64>,
     /// Candidates terminalized by this pass, by status.
     candidates: Counter<u64>,
     /// `types_registry_refusals_total{stage,reason}`.
@@ -51,6 +53,10 @@ impl AdmissionMetricsMeter {
     #[must_use]
     pub fn new(meter: &Meter, prefix: &str) -> Self {
         Self {
+            unchanged_probes: meter
+                .u64_counter(format!("{prefix}_unchanged_probes_total"))
+                .with_description("Initial unchanged probes, by hit or miss")
+                .build(),
             candidates: meter
                 .u64_counter(format!("{prefix}_candidates_total"))
                 .with_description(
@@ -87,6 +93,10 @@ impl AdmissionMetricsMeter {
 }
 
 impl AdmissionMetrics for AdmissionMetricsMeter {
+    fn unchanged_probe(&self, hit: bool) {
+        self.unchanged_probes.add(1, &[KeyValue::new("hit", hit)]);
+    }
+
     fn candidate_terminalized(&self, status: TerminalStatus) {
         self.candidates
             .add(1, &[KeyValue::new("status", status.label())]);

--- a/gears/system/types-registry/types-registry/src/infra/metrics_tests.rs
+++ b/gears/system/types-registry/types-registry/src/infra/metrics_tests.rs
@@ -136,6 +136,33 @@ fn histogram_count(exporter: &InMemoryMetricExporter, name: &str) -> u64 {
 }
 
 #[test]
+fn unchanged_probes_are_counted_separately_by_hit_and_miss() {
+    let (provider, exporter, metrics) = recorder();
+    metrics.unchanged_probe(true);
+    metrics.unchanged_probe(false);
+    metrics.unchanged_probe(false);
+    provider.force_flush().unwrap();
+
+    assert_eq!(
+        counter_sum_where(
+            &exporter,
+            "types_registry_unchanged_probes_total",
+            &[("hit", "true")]
+        ),
+        1
+    );
+    assert_eq!(
+        counter_sum_where(
+            &exporter,
+            "types_registry_unchanged_probes_total",
+            &[("hit", "false")]
+        ),
+        2
+    );
+    assert_eq!(counter_sum(&exporter, "types_registry_candidates_total"), 0);
+}
+
+#[test]
 fn candidates_are_counted_by_their_terminal_status() {
     let (provider, exporter, metrics) = recorder();
 

--- a/gears/system/types-registry/types-registry/src/infra/storage/repo/type_schema_repo.rs
+++ b/gears/system/types-registry/types-registry/src/infra/storage/repo/type_schema_repo.rs
@@ -4,14 +4,18 @@
 use std::collections::HashMap;
 
 use sea_orm::sea_query::Expr;
-use sea_orm::{ActiveValue::Set, ColumnTrait, Condition, EntityTrait, QueryFilter};
+use sea_orm::{
+    ActiveValue::Set, ColumnTrait, Condition, EntityTrait, FromQueryResult, QueryFilter,
+    QuerySelect,
+};
 use toolkit_db::secure::{
     AccessScope, DBRunner, ScopeError, SecureEntityExt, SecureUpdateExt, secure_insert,
 };
 
 use super::IN_CHUNK;
 use crate::domain::ports::{
-    CurrentDocument, CurrentSchemaCas, CurrentTypeSchemaRow, NewCurrentTypeSchema, NewRevision,
+    CurrentDocument, CurrentSchemaCas, CurrentSchemaProjection, CurrentTypeSchemaRow,
+    NewCurrentTypeSchema, NewRevision,
 };
 use crate::infra::storage::entity::{type_schema, type_schema_revision};
 
@@ -21,6 +25,23 @@ use crate::infra::storage::entity::{type_schema, type_schema_revision};
 /// expression — because each pair contributes two bound parameters rather than
 /// one.
 const PAIR_CHUNK: usize = 100;
+
+/// SQL projection used by the document loader, revision vector, and refresh guards.
+#[derive(FromQueryResult)]
+struct SchemaProjection {
+    entity_id: i64,
+    revision_no: i32,
+    resolution_fingerprint: Vec<u8>,
+}
+
+/// Authored content without revision provenance, which resolution does not consume.
+#[derive(FromQueryResult)]
+struct AuthoredDocument {
+    entity_id: i64,
+    revision_no: i32,
+    raw_schema: String,
+    content_hash: Vec<u8>,
+}
 
 /// One current-state row as the domain names it. See `entity_repo::row` for why
 /// the mapper sits beside the repository rather than on the entity.
@@ -65,39 +86,35 @@ impl TypeSchemaRepo {
         entity_ids: &[i64],
     ) -> Result<Vec<CurrentDocument>, ScopeError> {
         // Capture the projection that selected each immutable document for the later CAS.
-        let mut pointers: Vec<(i64, i32, Vec<u8>)> = Vec::with_capacity(entity_ids.len());
-        for chunk in entity_ids.chunks(IN_CHUNK) {
-            let rows = type_schema::Entity::find()
-                .filter(type_schema::Column::EntityId.is_in(chunk.iter().copied()))
-                .secure()
-                .scope_with(scope)
-                .all(runner)
-                .await?;
-            pointers.extend(
-                rows.into_iter()
-                    .map(|r| (r.entity_id, r.revision_no, r.resolution_fingerprint)),
-            );
-        }
+        let pointers = Self::current_projections(runner, scope, entity_ids).await?;
         let projections: HashMap<i64, Vec<u8>> = pointers
             .iter()
-            .map(|(entity_id, _, fingerprint)| (*entity_id, fingerprint.clone()))
+            .map(|row| (row.entity_id, row.resolution_fingerprint.clone()))
             .collect();
 
         let mut out = Vec::with_capacity(pointers.len());
         for chunk in pointers.chunks(PAIR_CHUNK) {
             let mut pairs = Condition::any();
-            for (entity_id, revision_no, _) in chunk {
+            for row in chunk {
                 pairs = pairs.add(
                     Condition::all()
-                        .add(type_schema_revision::Column::EntityId.eq(*entity_id))
-                        .add(type_schema_revision::Column::RevisionNo.eq(*revision_no)),
+                        .add(type_schema_revision::Column::EntityId.eq(row.entity_id))
+                        .add(type_schema_revision::Column::RevisionNo.eq(row.revision_no)),
                 );
             }
             let rows = type_schema_revision::Entity::find()
                 .filter(pairs)
                 .secure()
                 .scope_with(scope)
-                .all(runner)
+                .project_all(runner, |query| {
+                    query
+                        .select_only()
+                        .column(type_schema_revision::Column::EntityId)
+                        .column(type_schema_revision::Column::RevisionNo)
+                        .column(type_schema_revision::Column::RawSchema)
+                        .column(type_schema_revision::Column::ContentHash)
+                        .into_model::<AuthoredDocument>()
+                })
                 .await?;
             for r in rows {
                 let fingerprint = projections.get(&r.entity_id).cloned().ok_or_else(|| {
@@ -140,21 +157,32 @@ impl TypeSchemaRepo {
             .map(current_row))
     }
 
-    /// The current-state rows of many entities in one read, `entity_id`-sorted.
-    pub async fn current_states(
+    /// Current revision numbers and fingerprints, `entity_id`-sorted, without artifacts.
+    pub async fn current_projections(
         runner: &impl DBRunner,
         scope: &AccessScope,
         entity_ids: &[i64],
-    ) -> Result<Vec<CurrentTypeSchemaRow>, ScopeError> {
+    ) -> Result<Vec<CurrentSchemaProjection>, ScopeError> {
         let mut out = Vec::with_capacity(entity_ids.len());
         for chunk in entity_ids.chunks(IN_CHUNK) {
             let rows = type_schema::Entity::find()
                 .filter(type_schema::Column::EntityId.is_in(chunk.iter().copied()))
                 .secure()
                 .scope_with(scope)
-                .all(runner)
+                .project_all(runner, |query| {
+                    query
+                        .select_only()
+                        .column(type_schema::Column::EntityId)
+                        .column(type_schema::Column::RevisionNo)
+                        .column(type_schema::Column::ResolutionFingerprint)
+                        .into_model::<SchemaProjection>()
+                })
                 .await?;
-            out.extend(rows.into_iter().map(current_row));
+            out.extend(rows.into_iter().map(|row| CurrentSchemaProjection {
+                entity_id: row.entity_id,
+                revision_no: row.revision_no,
+                resolution_fingerprint: row.resolution_fingerprint,
+            }));
         }
         // Sorted here rather than left to the chunk order, so a caller comparing two reads of the
         // same set compares two identically-ordered sequences.

--- a/gears/system/types-registry/types-registry/src/infra/storage/repo/type_schema_repo.rs
+++ b/gears/system/types-registry/types-registry/src/infra/storage/repo/type_schema_repo.rs
@@ -89,7 +89,7 @@ impl TypeSchemaRepo {
         let pointers = Self::current_projections(runner, scope, entity_ids).await?;
         let projections: HashMap<i64, Vec<u8>> = pointers
             .iter()
-            .map(|row| (row.entity_id, row.resolution_fingerprint.clone()))
+            .map(|row| (row.entity_id, row.cas.resolution_fingerprint.clone()))
             .collect();
 
         let mut out = Vec::with_capacity(pointers.len());
@@ -99,7 +99,7 @@ impl TypeSchemaRepo {
                 pairs = pairs.add(
                     Condition::all()
                         .add(type_schema_revision::Column::EntityId.eq(row.entity_id))
-                        .add(type_schema_revision::Column::RevisionNo.eq(row.revision_no)),
+                        .add(type_schema_revision::Column::RevisionNo.eq(row.cas.revision_no)),
                 );
             }
             let rows = type_schema_revision::Entity::find()
@@ -180,8 +180,10 @@ impl TypeSchemaRepo {
                 .await?;
             out.extend(rows.into_iter().map(|row| CurrentSchemaProjection {
                 entity_id: row.entity_id,
-                revision_no: row.revision_no,
-                resolution_fingerprint: row.resolution_fingerprint,
+                cas: CurrentSchemaCas {
+                    revision_no: row.revision_no,
+                    resolution_fingerprint: row.resolution_fingerprint,
+                },
             }));
         }
         // Sorted here rather than left to the chunk order, so a caller comparing two reads of the

--- a/gears/system/types-registry/types-registry/src/infra/storage/store.rs
+++ b/gears/system/types-registry/types-registry/src/infra/storage/store.rs
@@ -27,9 +27,9 @@ use crate::domain::enums::{DependencyKind, EntityKind, OwnershipScope};
 use crate::domain::family::FamilyKey;
 use crate::domain::ports::{
     CurrentDocument, CurrentInstanceRow, CurrentInstanceValue, CurrentSchemaCas,
-    CurrentTypeSchemaRow, DependencyClosure, DependencyStore, EntityRow, EntityStore,
-    EntityWriteOrderStore, InstanceStore, NewCurrentInstance, NewCurrentTypeSchema, NewEntity,
-    NewInstanceRevision, NewOperation, NewOperationItem, NewRevision, OperationItemRow,
+    CurrentSchemaProjection, CurrentTypeSchemaRow, DependencyClosure, DependencyStore, EntityRow,
+    EntityStore, EntityWriteOrderStore, InstanceStore, NewCurrentInstance, NewCurrentTypeSchema,
+    NewEntity, NewInstanceRevision, NewOperation, NewOperationItem, NewRevision, OperationItemRow,
     OperationRow, OperationStore, ReverseImpact, TypeSchemaStore, VersionFamilyRow,
     VersionFamilyStore,
 };
@@ -159,13 +159,13 @@ impl TypeSchemaStore for Repos {
         TypeSchemaRepo::find_current(tx, scope, entity_id).await
     }
 
-    async fn current_schemas(
+    async fn current_schema_projections(
         &self,
         tx: &DbTx<'_>,
         scope: &AccessScope,
         entity_ids: &[i64],
-    ) -> Result<Vec<CurrentTypeSchemaRow>, ScopeError> {
-        TypeSchemaRepo::current_states(tx, scope, entity_ids).await
+    ) -> Result<Vec<CurrentSchemaProjection>, ScopeError> {
+        TypeSchemaRepo::current_projections(tx, scope, entity_ids).await
     }
 
     async fn insert_schema_revision(

--- a/gears/system/types-registry/types-registry/tests/admission_worker_test.rs
+++ b/gears/system/types-registry/types-registry/tests/admission_worker_test.rs
@@ -336,10 +336,15 @@ async fn a_pass_that_loses_the_item_cas_writes_nothing_at_all() {
         &payload,
         item.id,
         &common::limits(),
+        None,
     )
     .await
     .expect("evaluation")
     .expect("the candidate is valid");
+    let types_registry::domain::admission::unit::PreparedUnit::Evaluated(evaluated) = evaluated
+    else {
+        panic!("the probe was disabled");
+    };
 
     // Meanwhile the other pass terminalizes the item.
     let recorded = provider

--- a/gears/system/types-registry/types-registry/tests/common/mod.rs
+++ b/gears/system/types-registry/types-registry/tests/common/mod.rs
@@ -342,9 +342,9 @@ use types_registry::domain::enums::{DependencyKind, EntityKind, OwnershipScope};
 use types_registry::domain::family::FamilyKey;
 use types_registry::domain::ports::{
     CurrentDocument, CurrentInstanceRow, CurrentInstanceValue, CurrentSchemaCas,
-    CurrentTypeSchemaRow, DependencyClosure, DependencyStore, EntityRow, EntityStore,
-    EntityWriteOrderStore, InstanceStore, NewCurrentInstance, NewCurrentTypeSchema, NewEntity,
-    NewInstanceRevision, NewOperation, NewOperationItem, NewRevision, OperationItemRow,
+    CurrentSchemaProjection, CurrentTypeSchemaRow, DependencyClosure, DependencyStore, EntityRow,
+    EntityStore, EntityWriteOrderStore, InstanceStore, NewCurrentInstance, NewCurrentTypeSchema,
+    NewEntity, NewInstanceRevision, NewOperation, NewOperationItem, NewRevision, OperationItemRow,
     OperationRow, OperationStore, ReverseImpact, TypeSchemaStore, VersionFamilyRow,
     VersionFamilyStore,
 };
@@ -556,13 +556,15 @@ impl TypeSchemaStore for PausingStores {
         Ok(out)
     }
 
-    async fn current_schemas(
+    async fn current_schema_projections(
         &self,
         tx: &DbTx<'_>,
         scope: &AccessScope,
         entity_ids: &[i64],
-    ) -> Result<Vec<CurrentTypeSchemaRow>, ScopeError> {
-        self.inner.current_schemas(tx, scope, entity_ids).await
+    ) -> Result<Vec<CurrentSchemaProjection>, ScopeError> {
+        self.inner
+            .current_schema_projections(tx, scope, entity_ids)
+            .await
     }
 
     async fn find_current_schema(
@@ -934,13 +936,15 @@ impl TypeSchemaStore for ClaimSignallingStores {
         Ok(out)
     }
 
-    async fn current_schemas(
+    async fn current_schema_projections(
         &self,
         tx: &DbTx<'_>,
         scope: &AccessScope,
         entity_ids: &[i64],
-    ) -> Result<Vec<CurrentTypeSchemaRow>, ScopeError> {
-        self.inner.current_schemas(tx, scope, entity_ids).await
+    ) -> Result<Vec<CurrentSchemaProjection>, ScopeError> {
+        self.inner
+            .current_schema_projections(tx, scope, entity_ids)
+            .await
     }
 
     async fn find_current_schema(
@@ -1302,13 +1306,15 @@ impl TypeSchemaStore for CasMissStores {
         self.inner.current_documents(tx, scope, entity_ids).await
     }
 
-    async fn current_schemas(
+    async fn current_schema_projections(
         &self,
         tx: &DbTx<'_>,
         scope: &AccessScope,
         entity_ids: &[i64],
-    ) -> Result<Vec<CurrentTypeSchemaRow>, ScopeError> {
-        self.inner.current_schemas(tx, scope, entity_ids).await
+    ) -> Result<Vec<CurrentSchemaProjection>, ScopeError> {
+        self.inner
+            .current_schema_projections(tx, scope, entity_ids)
+            .await
     }
 
     async fn find_current_schema(

--- a/gears/system/types-registry/types-registry/tests/migration_backends_test.rs
+++ b/gears/system/types-registry/types-registry/tests/migration_backends_test.rs
@@ -1,6 +1,6 @@
 //! Real up/down of the P0 initial migration on `PostgreSQL` and `MySQL`.
 //!
-//! Covers backend-specific schema behavior unavailable in SQLite, including an
+//! Covers backend-specific schema behavior unavailable in `SQLite`, including an
 //! idempotent coordination-state seed, then rolls the migration back.
 //!
 //! `constraint-multi-backend` makes this a correctness requirement: the CHECK

--- a/gears/system/types-registry/types-registry/tests/observability_test.rs
+++ b/gears/system/types-registry/types-registry/tests/observability_test.rs
@@ -377,6 +377,14 @@ async fn a_redundant_resubmission_counts_an_unchanged_candidate() {
 
     assert_eq!(outcome.items[0].status, OperationItemStatus::Unchanged);
     assert_eq!(
+        counter_sum_where("types_registry_unchanged_probes_total", &[("hit", "true")]),
+        1
+    );
+    assert_eq!(
+        counter_sum_where("types_registry_unchanged_probes_total", &[("hit", "false")]),
+        0
+    );
+    assert_eq!(
         counter_sum_where(
             "types_registry_candidates_total",
             &[("status", "unchanged")],
@@ -733,6 +741,11 @@ async fn a_revalidation_retry_is_counted_by_its_drift_shape() {
         counter_sum_where("types_registry_revalidations_total", &[("drift", "moved")]),
         1,
         "one rollback, counted under the drift that caused it",
+    );
+    assert_eq!(
+        counter_sum_where("types_registry_unchanged_probes_total", &[("hit", "false")]),
+        2,
+        "one miss for each operation, with no extra probe on revalidation"
     );
 }
 

--- a/gears/system/types-registry/types-registry/tests/refresh/resolution_limits.rs
+++ b/gears/system/types-registry/types-registry/tests/refresh/resolution_limits.rs
@@ -27,6 +27,78 @@ async fn no_entity(db: &Provider, id: &str) {
 }
 
 #[tokio::test]
+async fn unchanged_does_not_spend_the_activation_write_set_budget() {
+    let db = test_db().await;
+    seed_base_and_dependents(&db).await;
+    let before_base = current(&db, BASE).await;
+    let before_derived = current(&db, DERIVED).await;
+    let before_referrer = current(&db, REFERRER).await;
+    let before_entity = entity(&db, BASE).await;
+    let limits = Limits {
+        activation_write_set: 1,
+        ..Limits::default()
+    };
+
+    let outcome = admit_with(
+        &db,
+        &limits,
+        &common::worker_settings(),
+        "same",
+        BASE,
+        base_schema("name"),
+        Some(1),
+    )
+    .await;
+    let item = &outcome.items[0];
+    assert_eq!(item.status, OperationItemStatus::Unchanged, "{item:?}");
+    assert_eq!(item.resource_version, Some(1));
+    assert_eq!(item.revision_no, None);
+    assert_eq!(entity(&db, BASE).await, before_entity);
+    assert_eq!(current(&db, DERIVED).await, before_derived);
+    assert_revision_rolled_back(&db, before_base, before_referrer).await;
+
+    // A real edit with the same dependents must still obey the bound.
+    let changed = admit_with(
+        &db,
+        &limits,
+        &common::worker_settings(),
+        "changed",
+        BASE,
+        base_schema("label"),
+        Some(1),
+    )
+    .await;
+    refused(
+        &changed,
+        &AdmissionFailureReason::ActivationWriteSetExceeded,
+    );
+}
+
+#[tokio::test]
+async fn unchanged_schema_does_not_resolve_or_materialize_again() {
+    let db = test_db().await;
+    seed_base_and_dependents(&db).await;
+    let before = current(&db, DERIVED).await;
+    let limits = Limits {
+        resolution_closure: 1,
+        resolved_document: ByteSize::from_bytes(1),
+        ..Limits::default()
+    };
+    let outcome = admit_with(
+        &db,
+        &limits,
+        &common::worker_settings(),
+        "same-derived",
+        DERIVED,
+        derived_schema(),
+        Some(1),
+    )
+    .await;
+    assert_eq!(outcome.items[0].status, OperationItemStatus::Unchanged);
+    assert_eq!(current(&db, DERIVED).await, before);
+}
+
+#[tokio::test]
 async fn closure_counts_the_candidate_and_deduplicates_ref_and_derivation_targets() {
     let db = test_db().await;
     let mut limits = Limits {

--- a/gears/system/types-registry/types-registry/tests/repo_backends_test.rs
+++ b/gears/system/types-registry/types-registry/tests/repo_backends_test.rs
@@ -454,12 +454,22 @@ async fn current_documents_reads_the_current_revision_only(
         revised_doc.raw_schema, second,
         "a document past any varchar bound must round-trip byte-identically on {backend}"
     );
+    assert_eq!(
+        revised_doc.content_hash,
+        vec![2],
+        "revision 2 digest on {backend}"
+    );
     assert!(revised_doc.raw_schema.len() > 60_000);
     let single_doc = docs
         .iter()
         .find(|d| d.entity_id == single.id)
         .expect("the single-revision entity's document");
     assert_eq!(single_doc.raw_schema, only);
+    assert_eq!(
+        single_doc.content_hash,
+        vec![1],
+        "revision 1 digest on {backend}"
+    );
 }
 
 async fn current_projections_read_every_named_entity_that_has_one(
@@ -503,7 +513,7 @@ async fn current_projections_read_every_named_entity_that_has_one(
     );
     for row in &states {
         assert_eq!(
-            row.resolution_fingerprint,
+            row.cas.resolution_fingerprint,
             vec![0x11],
             "the fingerprint must round-trip byte-identically on {backend}: the \
              guard compares it for equality and nothing else"

--- a/gears/system/types-registry/types-registry/tests/repo_backends_test.rs
+++ b/gears/system/types-registry/types-registry/tests/repo_backends_test.rs
@@ -462,7 +462,7 @@ async fn current_documents_reads_the_current_revision_only(
     assert_eq!(single_doc.raw_schema, only);
 }
 
-async fn current_schemas_reads_every_named_entity_that_has_one(
+async fn current_projections_read_every_named_entity_that_has_one(
     db: &Provider,
     family_id: i64,
     backend: &str,
@@ -491,7 +491,7 @@ async fn current_schemas_reads_every_named_entity_that_has_one(
     }
 
     let ids: Vec<i64> = inserted.iter().map(|row| row.id).collect();
-    let states = TypeSchemaRepo::current_states(&conn, &scope, &ids)
+    let states = TypeSchemaRepo::current_projections(&conn, &scope, &ids)
         .await
         .expect("current states");
 
@@ -511,7 +511,7 @@ async fn current_schemas_reads_every_named_entity_that_has_one(
     }
 
     assert!(
-        TypeSchemaRepo::current_states(&conn, &scope, &[])
+        TypeSchemaRepo::current_projections(&conn, &scope, &[])
             .await
             .expect("empty read")
             .is_empty(),
@@ -898,7 +898,7 @@ async fn assert_repo_primitives_behave(db: &Provider, backend: &str) {
     closure_walks_a_chain(db, family.id, backend).await;
     reverse_impact_walks_back_up_a_chain(db, family.id, backend).await;
     current_documents_reads_the_current_revision_only(db, family.id, backend).await;
-    current_schemas_reads_every_named_entity_that_has_one(db, family.id, backend).await;
+    current_projections_read_every_named_entity_that_has_one(db, family.id, backend).await;
     a_revision_moves_the_pointer_and_can_report_unchanged(db, family.id, backend).await;
     snapshot_read_does_not_see_a_mid_read_commit(db, family.id, backend).await;
 

--- a/gears/system/types-registry/types-registry/tests/revalidation_test.rs
+++ b/gears/system/types-registry/types-registry/tests/revalidation_test.rs
@@ -22,8 +22,9 @@ use common::{
 use types_registry::config::{TypesRegistryConfig, WorkerSettings};
 use types_registry::domain::admission::AdmissionFailureReason;
 use types_registry::domain::admission::acceptance::{AcceptanceContext, AcceptanceError, accept};
+use types_registry::domain::admission::revision::RevisionCommit;
 use types_registry::domain::admission::unit::{
-    EvaluatedUnit, RevisionCommit, commit_creation, commit_revision, evaluate,
+    EvaluatedUnit, commit_creation, commit_revision, evaluate,
 };
 use types_registry::domain::admission::vector::{VectorDrift, VectorRole};
 use types_registry::domain::admission::worker::{
@@ -212,10 +213,15 @@ async fn submitted(
         &payload,
         item.id,
         &common::limits(),
+        None,
     )
     .await
     .expect("evaluation must not fail on infrastructure")
     .expect("the candidate is valid");
+    let types_registry::domain::admission::unit::PreparedUnit::Evaluated(unit) = unit else {
+        panic!("the probe was disabled");
+    };
+    let unit = Arc::unwrap_or_clone(unit);
     (operation_id, unit)
 }
 
@@ -578,6 +584,166 @@ where
     pass.await
         .expect("the pass task must not panic")
         .expect("the worker must not fail on infrastructure")
+}
+
+#[tokio::test]
+async fn unchanged_probe_cannot_hide_a_concurrent_content_revision() {
+    let dir = TestDir::new("types-registry-unchanged-race");
+    let db = test_db_file(&dir.path().join("registry.db")).await;
+    admit(&db, "base", BASE, base_schema("name"), None).await;
+    let operation_id = submit(&db, "same", BASE, base_schema("name"), Some(1))
+        .await
+        .expect("acceptance");
+    let mutating = Arc::clone(&db);
+    let outcome = admit_with_a_mutation_in_the_gap(
+        &db,
+        worker_settings(),
+        operation_id,
+        move || async move {
+            admit(&mutating, "changed", BASE, base_schema("label"), Some(1)).await;
+        },
+    )
+    .await;
+    let item = &outcome.items[0];
+    assert_eq!(item.status, OperationItemStatus::Failed);
+    assert_eq!(
+        item.failure.as_ref().expect("refusal").reason,
+        AdmissionFailureReason::PreconditionFailed
+    );
+    assert_eq!(item.revision_no, None);
+    assert_eq!(entity(&db, BASE).await.resource_version, 2);
+    assert_eq!(current(&db, BASE).await.revision_no, 2);
+    assert!(current(&db, BASE).await.resolved_schema.contains("label"));
+}
+
+#[tokio::test]
+async fn unchanged_probe_refuses_an_entity_replaced_at_the_same_version() {
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+    use toolkit_db::secure::SecureDeleteExt;
+    use types_registry::infra::storage::entity::entity as entity_row;
+
+    let dir = TestDir::new("types-registry-unchanged-replaced");
+    let db = test_db_file(&dir.path().join("registry.db")).await;
+    admit(&db, "base", BASE, base_schema("name"), None).await;
+    let before = entity(&db, BASE).await;
+    let operation_id = submit(&db, "same", BASE, base_schema("name"), Some(1))
+        .await
+        .expect("acceptance");
+    let mutating = Arc::clone(&db);
+    let outcome = admit_with_a_mutation_in_the_gap(
+        &db,
+        worker_settings(),
+        operation_id,
+        move || async move {
+            // Simulate purge and re-registration while the proof holds no lock.
+            worker(&mutating)
+                .transaction(move |tx| {
+                    Box::pin(async move {
+                        CoordinationStateRepo::claim_entity_write_order(tx, &allow_all(), LATER)
+                            .await?;
+                        let deleted = entity_row::Entity::delete_many()
+                            .filter(entity_row::Column::Id.eq(before.id))
+                            .secure()
+                            .scope_with(&allow_all())
+                            .exec(tx)
+                            .await?;
+                        assert_eq!(deleted.rows_affected, 1);
+                        Ok(())
+                    })
+                })
+                .await
+                .expect("purge");
+            let replacement =
+                admit(&mutating, "replacement", BASE, base_schema("label"), None).await;
+            assert_eq!(replacement.items[0].status, OperationItemStatus::Succeeded);
+            let after = entity(&mutating, BASE).await;
+            assert_ne!(after.id, before.id);
+            assert_eq!(after.resource_version, before.resource_version);
+        },
+    )
+    .await;
+    let item = &outcome.items[0];
+    assert_eq!(item.status, OperationItemStatus::Failed);
+    assert_eq!(
+        item.failure.as_ref().expect("refusal").reason,
+        AdmissionFailureReason::PreconditionFailed
+    );
+    assert_eq!(item.revision_no, None);
+    assert_eq!(entity(&db, BASE).await.resource_version, 1);
+    assert_eq!(current(&db, BASE).await.revision_no, 1);
+    assert!(current(&db, BASE).await.resolved_schema.contains("label"));
+}
+
+#[tokio::test]
+async fn unchanged_probe_survives_a_concurrent_dependency_refresh() {
+    let dir = TestDir::new("types-registry-unchanged-refresh");
+    let db = test_db_file(&dir.path().join("registry.db")).await;
+    seed_base_and_dependents(&db).await;
+    let operation_id = submit(&db, "same", REFERRER, referencing_schema("note"), Some(1))
+        .await
+        .expect("acceptance");
+    let before = current(&db, REFERRER).await;
+    let mutating = Arc::clone(&db);
+    let outcome = admit_with_a_mutation_in_the_gap(
+        &db,
+        worker_settings(),
+        operation_id,
+        move || async move {
+            admit(&mutating, "changed", BASE, base_schema("label"), Some(1)).await;
+        },
+    )
+    .await;
+    let item = &outcome.items[0];
+    assert_eq!(item.status, OperationItemStatus::Unchanged);
+    assert_eq!(item.resource_version, Some(1));
+    assert_eq!(item.revision_no, None);
+    let after = current(&db, REFERRER).await;
+    assert_eq!(after.revision_no, before.revision_no);
+    assert_ne!(after.resolution_fingerprint, before.resolution_fingerprint);
+    assert!(after.resolved_schema.contains("label"));
+}
+
+#[tokio::test]
+async fn unchanged_probe_cannot_hide_a_concurrent_deletion() {
+    let dir = TestDir::new("types-registry-unchanged-deleted");
+    let db = test_db_file(&dir.path().join("registry.db")).await;
+    admit(&db, "base", BASE, base_schema("name"), None).await;
+    let operation_id = submit(&db, "same", BASE, base_schema("name"), Some(1))
+        .await
+        .expect("acceptance");
+    let mutating = Arc::clone(&db);
+    let outcome = admit_with_a_mutation_in_the_gap(
+        &db,
+        worker_settings(),
+        operation_id,
+        move || async move {
+            let id = entity(&mutating, BASE).await.id;
+            let ports = stores();
+            worker(&mutating)
+                .transaction(move |tx| {
+                    Box::pin(async move {
+                        ports
+                            .claim_entity_write_order(tx, &allow_all(), LATER)
+                            .await?;
+                        assert_eq!(
+                            EntityRepo::mark_deleted(tx, &allow_all(), id, 1, LATER).await?,
+                            Some(2)
+                        );
+                        Ok(())
+                    })
+                })
+                .await
+                .expect("delete");
+        },
+    )
+    .await;
+    assert_eq!(outcome.items[0].status, OperationItemStatus::Failed);
+    assert_eq!(
+        outcome.items[0].failure.as_ref().expect("refusal").reason,
+        AdmissionFailureReason::EntityDeleted
+    );
+    assert_eq!(entity(&db, BASE).await.resource_version, 2);
+    assert_eq!(current(&db, BASE).await.revision_no, 1);
 }
 
 #[tokio::test]

--- a/gears/system/types-registry/types-registry/tests/revision_race_backends_test.rs
+++ b/gears/system/types-registry/types-registry/tests/revision_race_backends_test.rs
@@ -1,9 +1,9 @@
 //! Commit exclusion and rollback on `PostgreSQL` and `MySQL`.
 //!
 //! The first commit is paused after claiming `entity_write_order`; a second real
-//! connection must wait and then observe the first commit. SQLite cannot distinguish
-//! this lock from its own writer serialization, so only PostgreSQL and MySQL run it.
-//! A separate MySQL case exhausts the database recursion limit during the commit
+//! connection must wait and then observe the first commit. `SQLite` cannot distinguish
+//! this lock from its own writer serialization, so only `PostgreSQL` and `MySQL` run it.
+//! A separate `MySQL` case exhausts the database recursion limit during the commit
 //! guard and proves that the claim rolls back without becoming a candidate refusal.
 //!
 //! Gated behind `--features integration` because it needs a Docker daemon:
@@ -33,9 +33,8 @@ use common::{
     ClaimSignallingStores, PausePoint, PausingStores, allow_all, provider_for,
     seed_current_type_schema, seed_operation_item, seed_pending_revision_item,
 };
-use types_registry::domain::admission::unit::{
-    EvaluatedOutcome, EvaluatedUnit, RevisionCommit, commit_revision,
-};
+use types_registry::domain::admission::revision::RevisionCommit;
+use types_registry::domain::admission::unit::{EvaluatedOutcome, EvaluatedUnit, commit_revision};
 use types_registry::domain::admission::vector::RevisionVector;
 use types_registry::domain::admission::worker::{ItemFailure, WorkerError};
 use types_registry::domain::artifacts::{MaterializedArtifacts, content_hash};

--- a/gears/system/types-registry/types-registry/tests/revision_test.rs
+++ b/gears/system/types-registry/types-registry/tests/revision_test.rs
@@ -266,6 +266,9 @@ async fn an_instance_revises_and_re_records_its_schema_revision() {
     admit(&db, "type", CF_TYPE, schema(CF_TYPE, "t"), None).await;
     admit(&db, "i1", CF_INSTANCE, json!({ "name": "first" }), None).await;
 
+    let revised_type = admit(&db, "type-2", CF_TYPE, schema(CF_TYPE, "revised"), Some(1)).await;
+    assert_eq!(revised_type.items[0].revision_no, Some(2));
+
     let outcome = admit(&db, "i2", CF_INSTANCE, json!({ "name": "second" }), Some(1)).await;
 
     let item = &outcome.items[0];
@@ -287,8 +290,8 @@ async fn an_instance_revises_and_re_records_its_schema_revision() {
     assert_eq!(revisions.len(), 2);
     assert!(revisions[1].canonical_value.contains("second"));
     assert_eq!(
-        revisions[1].type_schema_revision_no, 1,
-        "the schema has not moved, so both values were validated against revision 1",
+        revisions[1].type_schema_revision_no, 2,
+        "the changed value records the revised conforming schema",
     );
 
     let current = instance::Entity::find()
@@ -460,6 +463,49 @@ async fn an_instance_value_equal_to_its_current_revision_is_unchanged() {
     assert_eq!(item.revision_no, None);
     assert_eq!(item.resource_version, Some(1));
     assert_eq!(resource_version_of(&db, CF_INSTANCE).await, 1);
+}
+
+/// Equality is about authored content, even when the conforming schema changed
+/// and would reject that old value if it were submitted as a new revision.
+#[tokio::test]
+async fn unchanged_instance_is_not_revalidated_against_a_new_conforming_schema() {
+    let db = test_db().await;
+    admit(&db, "type", CF_TYPE, schema(CF_TYPE, "t"), None).await;
+    admit(&db, "value", CF_INSTANCE, json!({ "name": "first" }), None).await;
+    let mut revised = schema(CF_TYPE, "numeric-name");
+    revised["properties"]["name"]["type"] = json!("integer");
+    let changed_type = admit(&db, "type-revised", CF_TYPE, revised, Some(1)).await;
+    assert_eq!(
+        changed_type.items[0].status,
+        domain_enums::OperationItemStatus::Succeeded
+    );
+
+    let outcome = admit(
+        &db,
+        "same",
+        CF_INSTANCE,
+        json!({ "name": "first" }),
+        Some(1),
+    )
+    .await;
+    let item = &outcome.items[0];
+    assert_eq!(
+        item.status,
+        domain_enums::OperationItemStatus::Unchanged,
+        "{item:?}"
+    );
+    assert_eq!(item.resource_version, Some(1));
+    assert_eq!(item.revision_no, None);
+    let id = entity_id_of(&db, CF_INSTANCE).await;
+    let revisions = instance_revision::Entity::find()
+        .filter(instance_revision::Column::EntityId.eq(id))
+        .secure()
+        .scope_with(&allow_all())
+        .all(&db.conn().expect("conn"))
+        .await
+        .expect("revisions");
+    assert_eq!(revisions.len(), 1);
+    assert_eq!(revisions[0].type_schema_revision_no, 1);
 }
 
 /// ADR-0005: content equal to an **older, non-current** revision is a new update.

--- a/gears/system/types-registry/types-registry/tests/schema_projection_test.rs
+++ b/gears/system/types-registry/types-registry/tests/schema_projection_test.rs
@@ -1,0 +1,158 @@
+//! Verify that admission reads exclude artifact payloads in the executed SQL.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod common;
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use time::macros::datetime;
+use toolkit_db::secure::AccessScope;
+use toolkit_gts::gts_id;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::{Context, SubscriberExt};
+
+use common::{
+    allow_all, seed_current_type_schema, seed_operation_item, seed_type_schema_revision, test_db,
+};
+use types_registry::domain::enums::{EntityKind, OwnershipScope};
+use types_registry::domain::ports::{NewEntity, snapshot_read};
+use types_registry::infra::storage::repo::{EntityRepo, TypeSchemaRepo, VersionFamilyRepo};
+
+#[derive(Clone, Default)]
+struct SqlStatements(Arc<Mutex<Vec<String>>>);
+
+#[derive(Default)]
+struct Statement(Option<String>);
+
+impl Visit for Statement {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "db.statement" {
+            self.0 = Some(value.to_owned());
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
+}
+
+impl<S: Subscriber> Layer<S> for SqlStatements {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        if event.metadata().target() == "sqlx::query" {
+            let mut statement = Statement::default();
+            event.record(&mut statement);
+            if let Some(sql) = statement.0 {
+                self.0.lock().push(sql);
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn admission_reads_select_revision_identity_and_authored_content_without_artifacts() {
+    // SQLite executes queries on its connection worker thread.
+    // This test binary installs one subscriber so those events are captured too.
+    let statements = SqlStatements::default();
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::registry().with(statements.clone()),
+    )
+    .unwrap();
+    let db = test_db().await;
+    let conn = db.conn().unwrap();
+    let scope = allow_all();
+    let now = datetime!(2026-09-08 12:00 UTC);
+    let id = gts_id!("cf.core.projection.subject.v1~");
+    let (family, _) = VersionFamilyRepo::create_or_get(
+        &conn,
+        &scope,
+        "gts.cf.core.projection.subject",
+        OwnershipScope::Global,
+        None,
+        now,
+    )
+    .await
+    .unwrap();
+    let entity = EntityRepo::insert(
+        &conn,
+        &scope,
+        NewEntity {
+            gts_uuid: gts::GtsId::try_new(id).unwrap().to_uuid(),
+            gts_id: id.to_owned(),
+            entity_kind: EntityKind::TypeSchema,
+            family_id: family.id,
+            ownership_scope: OwnershipScope::Global,
+            owner_tenant_id: None,
+            owning_gear: Some("types-registry".to_owned()),
+            now,
+        },
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    let old = r#"{"title":"old"}"#;
+    let latest = r#"{"title":"current"}"#;
+    for (revision, body) in [(1, old), (2, latest)] {
+        let item = seed_operation_item(&conn, id, revision, now).await;
+        seed_type_schema_revision(&conn, entity.id, revision, item, body, now).await;
+    }
+    seed_current_type_schema(&conn, entity.id, 2, latest, now).await;
+
+    statements.0.lock().clear();
+    let projections = TypeSchemaRepo::current_projections(&conn, &scope, &[entity.id])
+        .await
+        .unwrap();
+    assert_eq!(projections.len(), 1);
+    assert_eq!(projections[0].revision_no, 2);
+    assert_eq!(projections[0].resolution_fingerprint, vec![0x11]);
+
+    let documents = db
+        .transaction_with_config(snapshot_read(&db.db()), move |tx| {
+            Box::pin(async move {
+                Ok(TypeSchemaRepo::current_documents(tx, &allow_all(), &[entity.id]).await?)
+            })
+        })
+        .await
+        .unwrap();
+    assert_eq!(documents.len(), 1);
+    assert_eq!(documents[0].raw_schema, latest);
+    assert_eq!(documents[0].content_hash, vec![2]);
+    assert_eq!(documents[0].projection.revision_no, 2);
+    assert_eq!(documents[0].projection.resolution_fingerprint, vec![0x11]);
+
+    assert!(
+        TypeSchemaRepo::current_projections(&conn, &AccessScope::default(), &[entity.id])
+            .await
+            .unwrap()
+            .is_empty(),
+        "a custom SQL projection must preserve deny-all scoping"
+    );
+
+    let captured = statements.0.lock();
+    let selects: Vec<&str> = captured
+        .iter()
+        .map(|sql| sql.trim())
+        .filter(|sql| sql.starts_with("SELECT") && sql.contains("types_registry__type_schema"))
+        .collect();
+    assert_eq!(
+        selects.len(),
+        4,
+        "capture every repository read: {captured:?}"
+    );
+    for sql in selects {
+        let columns = sql.split(" FROM ").next().unwrap();
+        for unused in [
+            "resolved_schema",
+            "effective_traits",
+            "effective_traits_schema",
+            "gts_spec_version",
+            "gts_impl_version",
+            "operation_item_id",
+            "created_at",
+            "updated_at",
+        ] {
+            assert!(!columns.contains(unused), "unneeded {unused} in {sql}");
+        }
+    }
+}

--- a/gears/system/types-registry/types-registry/tests/schema_projection_test.rs
+++ b/gears/system/types-registry/types-registry/tests/schema_projection_test.rs
@@ -104,8 +104,8 @@ async fn admission_reads_select_revision_identity_and_authored_content_without_a
         .await
         .unwrap();
     assert_eq!(projections.len(), 1);
-    assert_eq!(projections[0].revision_no, 2);
-    assert_eq!(projections[0].resolution_fingerprint, vec![0x11]);
+    assert_eq!(projections[0].cas.revision_no, 2);
+    assert_eq!(projections[0].cas.resolution_fingerprint, vec![0x11]);
 
     let documents = db
         .transaction_with_config(snapshot_read(&db.db()), move |tx| {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added early detection for unchanged submissions.
  - Unchanged resubmissions now complete without creating a new revision or repeating dependency resolution and materialization.
  - Unchanged results avoid consuming activation and resolution limits.
  - Added safeguards to recheck concurrent changes before finalizing an unchanged result.

- **Observability**
  - Added metrics distinguishing unchanged-submission probe hits from misses.

- **Improvements**
  - Admission reads now use focused schema projections, improving efficiency while preserving current revision and fingerprint checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->