### PR TITLE
docs: move ADR frontmatter above the header comment

### DIFF
--- a/docs/adrs/tests/0001-tests-in-separate-files.md
+++ b/docs/adrs/tests/0001-tests-in-separate-files.md
@@ -1,9 +1,9 @@
-<!-- Created: 2026-04-15 by Constructor Tech -->
 ---
 status: accepted
 date: 2026-04-15
 decision-makers: Constructor Fabric Steering Committee
 ---
+<!-- Created: 2026-04-15 by Constructor Tech -->
 
 # Enforce test code in separate files vian architecture lint DE1101
 

--- a/gears/chat-engine/docs/ADR/0023-llm-gateway-plugin.md
+++ b/gears/chat-engine/docs/ADR/0023-llm-gateway-plugin.md
@@ -1,10 +1,9 @@
-<!-- Created: 2026-03-06 by Constructor Tech -->
-<!-- Updated: 2026-04-07 by Constructor Tech -->
-
 ---
 status: accepted
 date: 2026-03-06
 ---
+<!-- Created: 2026-03-06 by Constructor Tech -->
+<!-- Updated: 2026-04-07 by Constructor Tech -->
 
 # ADR-0023: LLM Gateway Plugin
 

--- a/gears/serverless-runtime/docs/ADR/0003-cpt-cf-serverless-runtime-adr-workflow-dsl.md
+++ b/gears/serverless-runtime/docs/ADR/0003-cpt-cf-serverless-runtime-adr-workflow-dsl.md
@@ -1,11 +1,12 @@
-<!--
-Created:  2026-03-30 by Constructor Tech
-Updated:  2026-04-22 by Constructor Tech
--->
 ---
 status: accepted
 date: 2026-03-30
 ---
+<!--
+Created:  2026-03-30 by Constructor Tech
+Updated:  2026-04-22 by Constructor Tech
+-->
+
 <!--
 =============================================================================
 ARCHITECTURE DECISION RECORD (ADR) — based on MADR format

--- a/gears/serverless-runtime/docs/ADR/0004-cpt-cf-serverless-runtime-adr-temporal-workflow-engine.md
+++ b/gears/serverless-runtime/docs/ADR/0004-cpt-cf-serverless-runtime-adr-temporal-workflow-engine.md
@@ -1,11 +1,12 @@
-<!--
-Created:  2026-03-30 by Constructor Tech
-Updated:  2026-04-22 by Constructor Tech
--->
 ---
 status: accepted
 date: 2026-03-30
 ---
+<!--
+Created:  2026-03-30 by Constructor Tech
+Updated:  2026-04-22 by Constructor Tech
+-->
+
 <!--
 =============================================================================
 ARCHITECTURE DECISION RECORD (ADR) — based on MADR format

--- a/gears/serverless-runtime/docs/ADR/0005-cpt-cf-serverless-runtime-adr-thin-host.md
+++ b/gears/serverless-runtime/docs/ADR/0005-cpt-cf-serverless-runtime-adr-thin-host.md
@@ -1,11 +1,12 @@
-<!--
-Created:  2026-04-20 by Constructor Tech
-Updated:  2026-04-20 by Constructor Tech
--->
 ---
 status: accepted
 date: 2026-04-20
 ---
+<!--
+Created:  2026-04-20 by Constructor Tech
+Updated:  2026-04-20 by Constructor Tech
+-->
+
 <!--
 =============================================================================
 ARCHITECTURE DECISION RECORD (ADR) — based on MADR format


### PR DESCRIPTION
## Description
Five ADR files had an HTML comment above the frontmatter. Frontmatter only works on the first line, so `md-fabric.py` did not read it and the node preview showed no `status` or `date`.

This swaps the two blocks so the frontmatter comes first, like `docs/spec-templates/gears-sdlc/ADR/template.md`. No text is changed.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] New tests added for new functionality

Ran `extract_frontmatter` and `build_node_preview` from `tools/scripts/md-fabric.py` on all five files. Each one now returns its `status` and `date`. A scan of the whole repo found no other file with this problem.

## Documentation
- [ ] Code is documented with rustdoc comments
- [ ] README updated (if applicable)
- [ ] API documentation updated (if applicable)

No code changed, so these do not apply.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] No linting errors (`cargo clippy`)
- [ ] Code is properly formatted (`cargo fmt`)
- [ ] Tests pass (`cargo test`)

Only Markdown changed, so the cargo checks do not apply.

## Related Issues
None.
