### PR TITLE
chore(OLTP) additional improvements of OLTP for external customers

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,12 +223,14 @@ gears:
 
 ### Environment Variable Overrides
 
-Configuration supports environment variable overrides with `CF_` prefix:
+Configuration supports environment variable overrides with the `APP__` prefix,
+using `__` to separate nesting levels:
 
 ```bash
-export CF_GEARS_DATABASE_URL="postgres://user:pass@localhost/db"
-export CF_GEARS_API_GATEWAY_BIND_ADDR="0.0.0.0:8080"
-export CF_GEARS_LOGGING_DEFAULT_CONSOLE_LEVEL="debug"
+export APP__SERVER__PORT=8087
+export APP__MODULES__api_gateway__CONFIG__BIND_ADDR="0.0.0.0:8080"
+export APP__LOGGING__DEFAULT__CONSOLE_LEVEL="debug"
+export APP__OPENTELEMETRY__TRACING__ENABLED=true
 ```
 
 ## Testing

--- a/config/e2e-local.yaml
+++ b/config/e2e-local.yaml
@@ -571,8 +571,9 @@ opentelemetry:
     # HTTP-specific options
     http:
       inject_request_id_header: "x-request-id"
-      # WARNING: "authorization" sends bearer tokens to the trace collector — dev/test only
-      record_headers: [ "user-agent", "x-forwarded-for", "authorization" ]
+      # Credential-bearing headers ("authorization", "cookie", …) must never
+      # be listed here: whatever is recorded reaches the trace collector.
+      record_headers: [ "user-agent", "x-forwarded-for" ]
 
     # Log correlation (future feature)
     logs_correlation:

--- a/config/e2e-local.yaml
+++ b/config/e2e-local.yaml
@@ -575,7 +575,9 @@ opentelemetry:
       # be listed here: whatever is recorded reaches the trace collector.
       record_headers: [ "user-agent", "x-forwarded-for" ]
 
-    # Log correlation (future feature)
+    # Add top-level trace_id / span_id to JSON log records so a backend can
+    # link a log line to its span. Off by default: it costs a context lookup
+    # per event.
     logs_correlation:
       inject_trace_ids_into_logs: true
 

--- a/config/github-mirror-dev.yaml
+++ b/config/github-mirror-dev.yaml
@@ -280,7 +280,9 @@ opentelemetry:
       # be listed here: whatever is recorded reaches the trace collector.
       record_headers: [ "user-agent", "x-forwarded-for" ]
 
-    # Log correlation (future feature)
+    # Add top-level trace_id / span_id to JSON log records so a backend can
+    # link a log line to its span. Off by default: it costs a context lookup
+    # per event.
     logs_correlation:
       inject_trace_ids_into_logs: true
 

--- a/config/quickstart-windows.yaml
+++ b/config/quickstart-windows.yaml
@@ -279,7 +279,9 @@ opentelemetry:
       # be listed here: whatever is recorded reaches the trace collector.
       record_headers: [ "user-agent", "x-forwarded-for" ]
 
-    # Log correlation (future feature)
+    # Add top-level trace_id / span_id to JSON log records so a backend can
+    # link a log line to its span. Off by default: it costs a context lookup
+    # per event.
     logs_correlation:
       inject_trace_ids_into_logs: true
 

--- a/config/quickstart-windows.yaml
+++ b/config/quickstart-windows.yaml
@@ -275,8 +275,9 @@ opentelemetry:
     # HTTP-specific options
     http:
       inject_request_id_header: "x-request-id"
-      # WARNING: "authorization" sends bearer tokens to the trace collector — dev/test only
-      record_headers: [ "user-agent", "x-forwarded-for", "authorization" ]
+      # Credential-bearing headers ("authorization", "cookie", …) must never
+      # be listed here: whatever is recorded reaches the trace collector.
+      record_headers: [ "user-agent", "x-forwarded-for" ]
 
     # Log correlation (future feature)
     logs_correlation:

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -453,8 +453,9 @@ opentelemetry:
     # HTTP-specific options
     http:
       inject_request_id_header: "x-request-id"
-      # WARNING: "authorization" sends bearer tokens to the trace collector — dev/test only
-      record_headers: [ "user-agent", "x-forwarded-for", "authorization" ]
+      # Credential-bearing headers ("authorization", "cookie", …) must never
+      # be listed here: whatever is recorded reaches the trace collector.
+      record_headers: [ "user-agent", "x-forwarded-for" ]
 
     # Log correlation (future feature)
     logs_correlation:

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -457,7 +457,9 @@ opentelemetry:
       # be listed here: whatever is recorded reaches the trace collector.
       record_headers: [ "user-agent", "x-forwarded-for" ]
 
-    # Log correlation (future feature)
+    # Add top-level trace_id / span_id to JSON log records so a backend can
+    # link a log line to its span. Off by default: it costs a context lookup
+    # per event.
     logs_correlation:
       inject_trace_ids_into_logs: true
 

--- a/docs/TRACING_SETUP.md
+++ b/docs/TRACING_SETUP.md
@@ -8,7 +8,7 @@ collector — there is no `/metrics` scrape endpoint and no vendor-specific
 exporter. Any OTLP-compatible backend works: the OpenTelemetry Collector,
 Jaeger, Uptrace, or the Datadog Agent.
 
-**Logs are not exported over OTLP.** They are written to stdout as JSON and
+**Logs are not exported over OTLP.** They are written to stderr as JSON and
 collected from there — see [Logs](#logs) below.
 
 ## Overview
@@ -144,9 +144,11 @@ opentelemetry:
   # A per-signal `exporter` block fully replaces this one.
   exporter:
     kind: "otlp_grpc"                 # otlp_grpc (4317) | otlp_http (4318)
-    endpoint: "http://127.0.0.1:4317"
+    endpoint: "http://127.0.0.1:4317" # plaintext only for a loopback collector
     timeout_ms: 5000
-    headers:                          # e.g. backend auth
+    # Backend auth. Credential-bearing headers require an https:// endpoint —
+    # over plaintext OTLP they travel in the clear to anything on the path.
+    headers:
       authorization: "Bearer token"
 
   tracing:
@@ -176,11 +178,27 @@ Each of `tracing` and `metrics` has its own `enabled` flag, defaulting to
 even install the W3C propagator. Every config shipped in `config/` has them off
 — enable them deliberately.
 
+### Migrating from the old `tracing:` block
+
+Before 2026-03 the settings lived in a top-level `tracing:` section. That form
+is no longer accepted: loading a config that still uses it fails with an error
+naming each key's new home. The same applies to `APP__TRACING__*` environment
+overrides, which are now `APP__OPENTELEMETRY__*`.
+
+| Old | New |
+|---|---|
+| `tracing.enabled` | `opentelemetry.tracing.enabled` |
+| `tracing.service_name` | `opentelemetry.resource.service_name` |
+| `tracing.resource` | `opentelemetry.resource.attributes` |
+| `tracing.metrics` | `opentelemetry.metrics` |
+| `tracing.exporter` | `opentelemetry.exporter`, or `opentelemetry.tracing.exporter` to override it for traces only |
+| `tracing.sampler`, `.propagation`, `.http`, `.logs_correlation` | `opentelemetry.tracing.*` |
+
 ### Not yet implemented
 
-`tracing.propagation`, `tracing.http`, and `tracing.logs_correlation` are
-accepted by the config parser but **read by no code**. W3C propagation is always
-on when tracing is enabled, regardless of `propagation.w3c_trace_context`.
+`tracing.propagation` and `tracing.http` are accepted by the config parser but
+**read by no code**. W3C propagation is always on when tracing is enabled,
+regardless of `propagation.w3c_trace_context`.
 
 ---
 
@@ -200,8 +218,9 @@ logging:
 ```
 
 The Datadog Agent's container log collection, or an OpenTelemetry Collector
-`filelog` receiver, then reads the container's stdout. Nothing needs to be
-enabled inside the process.
+`filelog` receiver, then reads the container's log stream — the runtime captures
+stderr and stdout together, so the console sink is picked up as it is. Nothing
+needs to be enabled inside the process.
 
 ### Correlating logs with traces
 

--- a/docs/TRACING_SETUP.md
+++ b/docs/TRACING_SETUP.md
@@ -1,36 +1,41 @@
-````markdown
-# Distributed Tracing Setup
+# Telemetry Setup
 
-This guide walks you through setting up **OpenTelemetry distributed tracing** with **Jaeger** or **Uptrace** for the
-Gears middleware for testing purposes.
+This guide covers the **OpenTelemetry** setup shared by every gear: distributed
+tracing and metrics.
+
+Both signals speak **OTLP only** (gRPC or HTTP/protobuf) and are **pushed** to a
+collector — there is no `/metrics` scrape endpoint and no vendor-specific
+exporter. Any OTLP-compatible backend works: the OpenTelemetry Collector,
+Jaeger, Uptrace, or the Datadog Agent.
+
+**Logs are not exported over OTLP.** They are written to stdout as JSON and
+collected from there — see [Logs](#logs) below.
 
 ## Overview
 
-The Gears middleware includes first-class support for distributed tracing with:
+- **Automatic trace-context extraction** from incoming HTTP requests (W3C Trace Context)
+- **Automatic trace-context injection** into outgoing HTTP requests
+- **OTel metrics** through a global `SdkMeterProvider`; gears only declare instruments
+- **Centralized configuration** in one `opentelemetry:` YAML block
+- **Graceful flush** of both signals on shutdown
+- **Log correlation** — `trace_id`/`span_id` in the JSON log records
 
-- **Automatic trace context extraction** from incoming HTTP requests (W3C Trace Context)
-- **Automatic trace context injection** for outgoing HTTP requests
-- **Centralized configuration** via YAML
-- **HttpClient with OTEL layer** for instrumented HTTP calls
-- **Integration with existing logging**
+> **Config key.** Everything lives under the top-level `opentelemetry:` key.
+> Config structs use `#[serde(deny_unknown_fields)]`, so a misspelled or
+> misplaced key is a hard load error, not a silently ignored setting.
 
-## Quick Start with Jaeger
+---
 
-### 1. Start Jaeger (Local Development)
+## Quick start with Jaeger (traces only)
 
 ```bash
-# Start Jaeger All-in-One with OTLP support
 docker run -d --name jaeger \
-  -p 16686:16686 \    # UI: http://localhost:16686
-  -p 4317:4317 \      # OTLP gRPC
-  -p 4318:4318 \      # OTLP HTTP
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
   -e COLLECTOR_OTLP_ENABLED=true \
   jaegertracing/all-in-one:latest
-````
-
-### 2. Configure Tracing
-
-Create a configuration file (e.g., `config/with-tracing.yaml`):
+```
 
 ```yaml
 server:
@@ -38,388 +43,330 @@ server:
   host: "127.0.0.1"
   port: 8087
 
-# Enable OpenTelemetry tracing
-tracing:
-  enabled: true
-  service_name: "cf-gears-api"
+opentelemetry:
+  resource:
+    service_name: "cf-gears-api"
+    attributes:
+      service.version: "1.0.0"
+      deployment.environment: "dev"
 
   exporter:
     kind: "otlp_grpc"
     endpoint: "http://127.0.0.1:4317"
     timeout_ms: 5000
 
-  sampler:
-    parent_based_ratio:
-      ratio: 0.1  # Sample 10% of traces
-
-  propagation:
-    w3c_trace_context: true
-
-  resource:
-    service.version: "1.0.0"
-    deployment.environment: "dev"
+  tracing:
+    enabled: true
+    sampler:
+      parent_based_ratio:
+        ratio: 1.0
 
 logging:
   default:
     console_level: "info"
-    file: "logs/cf-gears.log"
 ```
-
-### 3. Run the Server
 
 ```bash
 cargo run --bin cf-gears-server -- --config config/with-tracing.yaml
 ```
 
-### 4. View Traces
-
-Open [http://localhost:16686](http://localhost:16686) and search for service `cf-gears-api`.
+Traces appear at <http://localhost:16686> under service `cf-gears-api`.
 
 ---
 
-## Quick Start with Uptrace
+## Quick start with Datadog
 
-[Uptrace](https://uptrace.dev) is a modern tracing UI that works with OpenTelemetry and ClickHouse/Postgres.
+Datadog ingests OTLP through the **Datadog Agent**, so no gear-side change is
+needed beyond configuration.
 
-### 1. Start Uptrace (Docker Compose)
+### Locally
 
-```yaml
-services:
-  uptrace:
-    image: uptrace/uptrace:2.0.1
-    ports:
-      - "14318:80"     # Web UI: http://localhost:14318
-      - "14317:4317"   # OTLP gRPC
-      - "14319:4318"   # OTLP HTTP
-    volumes:
-      - ./uptrace.yml:/etc/uptrace/config.yml
-    depends_on:
-      - clickhouse
-      - postgres
-      - redis
-
-  clickhouse:
-    image: clickhouse/clickhouse-server:25.8
-    ports: [ "9000:9000" ]
-
-  postgres:
-    image: postgres:16
-    environment:
-      POSTGRES_DB: uptrace
-      POSTGRES_USER: uptrace
-      POSTGRES_PASSWORD: uptrace
-
-  redis:
-    image: redis:8.2
+```bash
+export DD_API_KEY=...
+export DD_SITE=datadoghq.com          # or datadoghq.eu
+docker compose -f testing/docker/docker-compose.observability.yml up -d
 ```
 
-### 2. Configure Tracing with Uptrace DSN
+That starts an OpenTelemetry Collector on `:4317`/`:4318` which forwards traces
+and metrics to Datadog (see `testing/docker/otel-collector-datadog.yaml`).
+
+### In Kubernetes
+
+Enable the OTLP receiver on the Datadog Agent DaemonSet:
+
+```
+DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT=0.0.0.0:4317
+```
+
+and point each pod at its own node:
 
 ```yaml
-tracing:
-  enabled: true
-  service_name: "cf-gears-api"
+env:
+  - name: HOST_IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+  - name: APP__OPENTELEMETRY__EXPORTER__ENDPOINT
+    value: "http://$(HOST_IP):4317"
+```
 
-  exporter:
-    kind: "otlp_grpc"
-    endpoint: "http://127.0.0.1:14317"
-    timeout_ms: 5000
-    headers:
-      uptrace-dsn: "http://project1_secret@localhost:14318?grpc=14317"
+### Unified service tagging
 
-  sampler:
-    always_on: { }
+Datadog derives `service`, `env`, and `version` from OTel resource attributes:
 
+| Resource attribute                     | Datadog tag |
+|----------------------------------------|-------------|
+| `resource.service_name`                | `service`   |
+| `attributes.deployment.environment`    | `env`       |
+| `attributes.service.version`           | `version`   |
+
+Set all three — without `env` and `version`, APM, metrics, and logs will not
+correlate into one service view.
+
+---
+
+## Configuration reference
+
+The full surface, with every key shown:
+
+```yaml
+opentelemetry:
+  # Resource identity — attached to all traces and metrics.
   resource:
-    service.version: "1.3.7"
-    deployment.environment: "dev"
-    service.namespace: "cf-gears"
-```
+    service_name: "my-service"
+    attributes:
+      service.version: "1.2.3"
+      deployment.environment: "production"
+      service.namespace: "cf-gears"
+      k8s.cluster.name: "prod-cluster"
 
-### 3. Run the Server
-
-```bash
-cargo run --bin cf-gears-server -- --config config/with-tracing.yaml
-```
-
-### 4. View Traces
-
-Open [http://localhost:14318](http://localhost:14318) and search for service `cf-gears-api`.
-
----
-
-## Configuration Reference
-
-### Basic Configuration
-
-```yaml
-tracing:
-  enabled: true                    # Enable/disable tracing
-  service_name: "my-service"       # Service name in traces
-```
-
-### Exporter Configuration
-
-#### OTLP gRPC (Default)
-
-```yaml
-tracing:
+  # Default exporter, shared by both signals.
+  # A per-signal `exporter` block fully replaces this one.
   exporter:
-    kind: "otlp_grpc"
+    kind: "otlp_grpc"                 # otlp_grpc (4317) | otlp_http (4318)
     endpoint: "http://127.0.0.1:4317"
     timeout_ms: 5000
-    headers: # Optional auth headers
+    headers:                          # e.g. backend auth
       authorization: "Bearer token"
+
+  tracing:
+    enabled: true
+    sampler:
+      parent_based_ratio:             # parent_based_always_on | parent_based_ratio
+        ratio: 0.1                    # always_on | always_off
+    exporter:                         # optional per-signal override
+      kind: "otlp_grpc"
+      endpoint: "http://127.0.0.1:14317"
+
+  metrics:
+    enabled: true
+    cardinality_limit: 2000           # optional; SDK default when omitted
 ```
 
-#### OTLP HTTP
+### Samplers
 
-```yaml
-tracing:
-  exporter:
-    kind: "otlp_http"
-    endpoint: "http://127.0.0.1:4318/v1/traces"
-    timeout_ms: 5000
-```
+`always_on: {}`, `always_off: {}`, `parent_based_always_on: {}`, or
+`parent_based_ratio: { ratio: 0.1 }`. The default when `sampler` is omitted is
+`parent_based_always_on`; `parent_based_ratio` with no `ratio` defaults to `0.1`.
+
+### Signals are independent
+
+Each of `tracing` and `metrics` has its own `enabled` flag, defaulting to
+**`false`**. A gear with neither enabled emits no telemetry at all and does not
+even install the W3C propagator. Every config shipped in `config/` has them off
+— enable them deliberately.
+
+### Not yet implemented
+
+`tracing.propagation`, `tracing.http`, and `tracing.logs_correlation` are
+accepted by the config parser but **read by no code**. W3C propagation is always
+on when tracing is enabled, regardless of `propagation.w3c_trace_context`.
 
 ---
 
-(rest of your original doc unchanged below)
+## Logs
 
-### Sampling Strategies
+Logs do **not** travel over OTLP. Each gear writes to stderr and, when a `file:`
+sink is configured, to rotating files — both governed by the `logging:` block,
+which is independent of `opentelemetry:`.
 
-#### Always Sample
-
-```yaml
-tracing:
-  sampler:
-    always_on: { }
-```
-
-#### Never Sample
+For a collector or agent to pick them up, emit JSON:
 
 ```yaml
-tracing:
-  sampler:
-    always_off: { }
+logging:
+  default:
+    console_format: "json"     # text (default) | json
+    console_level: info
 ```
 
-#### Ratio-Based Sampling
+The Datadog Agent's container log collection, or an OpenTelemetry Collector
+`filelog` receiver, then reads the container's stdout. Nothing needs to be
+enabled inside the process.
+
+### Correlating logs with traces
+
+For a backend to link a log line to the span that produced it, the record has
+to carry the ids. Enable:
 
 ```yaml
-tracing:
-  sampler:
-    parent_based_ratio:
-      ratio: 0.1  # Sample 10% of traces
+opentelemetry:
+  tracing:
+    logs_correlation:
+      inject_trace_ids_into_logs: true
 ```
 
-### Resource Attributes
+With this on, every JSON record emitted inside a sampled span gains top-level
+`trace_id` and `span_id` fields, in the same lowercase-hex form as the
+`traceparent` header. Records emitted outside a span are unchanged.
 
-Add metadata to all spans:
+The flag costs a context lookup per event, so it is off by default and the
+stock formatter is used unless it is enabled.
 
-```yaml
-tracing:
-  resource:
-    service.version: "1.2.3"
-    deployment.environment: "production"
-    service.namespace: "cf-gears"
-    k8s.cluster.name: "prod-cluster"
-    k8s.namespace.name: "cf-gears-ns"
-```
+## Environment variable overrides
 
-### HTTP Options
-
-```yaml
-tracing:
-  http:
-    inject_request_id_header: "x-request-id"
-    record_headers:
-      - "user-agent"
-      - "x-forwarded-for"
-      - "authorization"  # Be careful with sensitive headers
-```
-
-## Using HttpClient with OpenTelemetry
-
-> **Important: Feature Gate Required**
->
-> The `.with_otel()` method on `HttpClientBuilder` requires the `otel` feature to be enabled.
-> Add this to your `Cargo.toml`:
->
-> ```toml
-> [dependencies]
-> toolkit-http = { workspace = true, features = ["otel"] }
-> ```
->
-> Without this feature, the `with_otel()` method will not be available, and you'll get
-> a compile error.
-
-### In Your Gear
-
-```rust,ignore
-use toolkit_http::{HttpClient, HttpClientBuilder};
-
-#[async_trait]
-impl MyGear {
-    async fn call_external_api(&self) -> Result<String> {
-        // Build client with OTEL tracing enabled
-        let client = HttpClientBuilder::new()
-            .with_otel()  // Enable OpenTelemetry tracing
-            .build()?;
-
-        // Trace context is automatically injected via W3C traceparent header
-        // RequestBuilder API: chain methods then send
-        let data = client
-            .get("https://api.example.com/data")
-            .send()
-            .await?
-            .checked_bytes()
-            .await?;
-
-        Ok(String::from_utf8_lossy(&data).into_owned())
-    }
-}
-```
-
-### Configuring the toolkit_http::HttpClient
-
-```rust,ignore
-use toolkit_http::{HttpClient, HttpClientBuilder};
-use std::time::Duration;
-
-// Full configuration example
-let client = HttpClientBuilder::new()
-    .with_otel()                          // Enable OpenTelemetry tracing
-    .timeout(Duration::from_secs(30))     // Request timeout
-    .user_agent("my-service/1.0")         // Custom User-Agent
-    .max_body_size(10 * 1024 * 1024)      // 10MB body limit
-    .build()?;
-```
-
-## Manual Span Creation
-
-Create custom spans for business logic:
-
-```rust,ignore
-use toolkit_http::HttpClientBuilder;
-use tracing::{info_span, Instrument, info};
-
-async fn process_user_data(user_id: u64) -> Result<()> {
-    // Create a span for this operation
-    let span = info_span!("process_user", user.id = user_id);
-
-    async {
-        // Your business logic here
-        info!("Processing user {}", user_id);
-
-        // Child operations will be traced automatically with OTEL-enabled client
-        let client = HttpClientBuilder::new()
-            .with_otel()
-            .build()?;
-
-        let url = format!("https://api.example.com/users/{}", user_id);
-        let user_data = client.get(&url).send().await?.checked_bytes().await?;
-
-        Ok(())
-    }.instrument(span).await
-}
-```
-
-## Production Deployment
-
-### Docker Compose with Jaeger
-
-```yaml
-  services:
-    jaeger:
-      image: ${REGISTRY:-}jaegertracing/jaeger:${JAEGER_VERSION:-latest}
-      ports:
-        - "16686:16686"
-        - "4317:4317"
-        - "4318:4318"
-      environment:
-        - LOG_LEVEL=debug
-        - COLLECTOR_OTLP_ENABLED=true
-      networks:
-        - jaeger-example
-
-  networks:
-    jaeger-example:
-```
-
-### Environment Variable Overrides
-
-You can override any config via environment variables:
+Any key can be overridden through the generic `APP__` figment layer, with `__`
+as the nesting separator:
 
 ```bash
-# Enable tracing
-export APP__TRACING__ENABLED=true
-export APP__TRACING__SERVICE_NAME=cf-gears-prod
-
-# Configure exporter
-export APP__TRACING__EXPORTER__KIND=otlp_grpc
-export APP__TRACING__EXPORTER__ENDPOINT=http://jaeger:4317
-
-# Configure sampling
-export APP__TRACING__SAMPLER__STRATEGY=parentbased_ratio
-export APP__TRACING__SAMPLER__RATIO=0.01  # 1% sampling in prod
+export APP__OPENTELEMETRY__TRACING__ENABLED=true
+export APP__OPENTELEMETRY__METRICS__ENABLED=true
+export APP__OPENTELEMETRY__RESOURCE__SERVICE_NAME=cf-gears-prod
+export APP__OPENTELEMETRY__EXPORTER__KIND=otlp_grpc
+export APP__OPENTELEMETRY__EXPORTER__ENDPOINT=http://collector:4317
 ```
+
+The only standard OpenTelemetry variable honoured is
+**`OTEL_EXPORTER_OTLP_HEADERS`** (`k=v,k2=v2`), merged over any headers from the
+config file. `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, and
+`OTEL_RESOURCE_ATTRIBUTES` are **not** read.
+
+---
+
+## Cargo features
+
+The toolkit enables `otel` by default, so telemetry bootstrap is always present.
+Two features are **not** default and silently remove outbound instrumentation
+when missing:
+
+```toml
+[dependencies]
+toolkit-http = { workspace = true, features = ["otel"] }      # .with_otel()
+toolkit-contract = { workspace = true, features = ["otel"] }  # generated clients
+```
+
+Without `toolkit-http/otel` the `with_otel()` method does not exist and the
+build fails; without `toolkit-contract/otel` generated clients compile fine but
+drop out of the trace.
+
+---
+
+## Instrumented HTTP clients
+
+```rust,ignore
+use toolkit_http::HttpClient;
+use std::time::Duration;
+
+let client = HttpClient::builder()
+    .with_otel()                       // span + W3C traceparent injection
+    .with_metrics("payments")          // http.client.request.duration
+    .timeout(Duration::from_secs(30))
+    .build()?;
+
+let data = client
+    .get("https://api.example.com/data")
+    .send()
+    .await?
+    .checked_bytes()
+    .await?;
+```
+
+## Metrics in a gear
+
+Instruments come from the global provider installed by the bootstrap. A gear
+must **not** build its own exporter or provider, and must not expose a
+`/metrics` endpoint:
+
+```rust,ignore
+let meter = opentelemetry::global::meter_with_scope(scope);
+let counter = meter.u64_counter("my_gear_operation_total").build();
+```
+
+The established pattern is a metrics port in `domain/ports/` with an OTel
+adapter in `infra/metrics.rs`.
+
+## Manual spans
+
+```rust,ignore
+use tracing::{info_span, Instrument, info};
+
+async fn process_user_data(user_id: u64) -> anyhow::Result<()> {
+    async {
+        info!("Processing user");
+        // …
+        Ok(())
+    }
+    .instrument(info_span!("process_user", user.id = user_id))
+    .await
+}
+```
+
+Or declaratively:
+
+```rust,ignore
+#[tracing::instrument(skip(self, ctx), fields(user_id = %id))]
+pub async fn get_user(&self, ctx: &SecurityContext, id: Uuid) -> Result<User, DomainError> {
+    tracing::debug!("Getting user by id");
+    // …
+}
+```
+
+---
 
 ## Troubleshooting
 
-### No Traces Appearing
+**No data at all.** Check that the relevant `enabled` flag is `true` — both
+default to `false`. On startup the bootstrap emits a `startup_check` span and
+runs a connectivity probe; look for `OpenTelemetry tracing initialized`,
+and `OpenTelemetry metrics initialized successfully`.
 
-1. **Check Jaeger is running**: Visit http://localhost:16686
-2. **Verify endpoint**: Ensure `exporter.endpoint` matches Jaeger's OTLP port
-3. **Check sampling**: Set `sampler.strategy: {always_on: {}}` for testing
-4. **View logs**: Look for "OpenTelemetry tracing initialized" message
+**Traces stop at a service boundary.** Outbound HTTP needs `.with_otel()` and
+the `toolkit-http/otel` feature. Note that **gRPC hops do not propagate trace
+context yet**, so an internal gRPC call currently starts a new, unlinked trace.
 
-### Performance Impact
+**Config file fails to load.** `deny_unknown_fields` rejects any key it does not
+recognise. The block is `opentelemetry:`, not `tracing:`.
 
-1. **Use sampling in production**: Set appropriate `ratio` (0.01 = 1%)
-2. **Monitor resource usage**: Tracing adds some CPU/memory overhead
-3. **Batch export**: The framework uses batched export by default
+**Data missing right after a restart.** Telemetry is flushed by
+`bootstrap::run::tracing_shutdown()` during graceful shutdown. A process killed
+with `SIGKILL` loses whatever is still batched.
 
-### Trace Context Not Propagating
+**Performance.** Use `parent_based_ratio` in production (`0.01` = 1%). Export is
+batched on a background task. Consider `metrics.cardinality_limit` for
+instruments with unbounded attribute values.
 
-1. **Check headers**: Ensure upstream sends `traceparent` header
-2. **Verify propagation**: Set `propagation.w3c_trace_context: true`
-3. **Use HttpClient with OTEL**: Ensure outgoing calls use `HttpClientBuilder::new().with_otel()`
+---
 
-## Observability Best Practices
+## Best practices
 
-### Structured Attributes
-
-Use consistent attribute names:
+Use consistent, low-cardinality attribute names, and keep high-cardinality
+values (ids, keys, names) on spans rather than on metric attributes:
 
 ```rust,ignore
 tracing::info_span!(
     "user_operation",
     user.id = user_id,
-    user.email = %user_email,
     operation.type = "create",
-    operation.result = "success"
-)
+);
 ```
 
-### Error Handling
-
-Mark spans with errors:
+Record failures on the span so the backend can flag it:
 
 ```rust,ignore
-let span = tracing::info_span!("risky_operation");
-let _guard = span.enter();
-
 match risky_operation().await {
-Ok(result) => {
-span.record("operation.result", "success");
-Ok(result)
-}
-Err(e) => {
-span.record("error", true);
-span.record("error.message", % e);
-span.record("operation.result", "error");
-Err(e)
-}
+    Ok(result) => Ok(result),
+    Err(e) => {
+        tracing::error!(error = %e, "risky_operation failed");
+        Err(e)
+    }
 }
 ```

--- a/docs/slides/1_OVERVIEW.md
+++ b/docs/slides/1_OVERVIEW.md
@@ -687,7 +687,7 @@ gears:
 
 Build selects compiled-in gears by Cargo feature flags. YAML config supplies each compiled-in gear's `config` and optional gear-owned `database` settings.
 
-Env overrides with `CF_` prefix, e.g. `CF_GEARS_DATABASE_URL=postgres://...`
+Env overrides with `APP__` prefix and `__` between levels, e.g. `APP__SERVER__PORT=8087`
 
 ---
 

--- a/docs/web-docs/build-with-gears/add-observability.md
+++ b/docs/web-docs/build-with-gears/add-observability.md
@@ -1,42 +1,55 @@
 ---
 title: Add observability
-description: OpenTelemetry tracing, request IDs, health endpoints, and instrumented HTTP clients.
+description: OpenTelemetry traces and metrics, JSON logs, request IDs, health endpoints, and instrumented HTTP clients.
 sidebar:
   label: Add observability
   order: 9
 ---
 
-Gears ship a common operational surface: distributed tracing, request-id propagation, health
-endpoints, and instrumented outbound HTTP — configured centrally, so every gear behaves the
-same. This guide covers the knobs (see `docs/TRACING_SETUP.md` in the framework repo for the
-full reference).
+Gears ship a common operational surface: distributed tracing, metrics, structured
+logs, request-id propagation, health endpoints, and instrumented outbound HTTP —
+configured centrally, so every gear behaves the same. This guide covers the knobs (see
+`docs/TRACING_SETUP.md` in the framework repo for the full reference).
 
-## Configure tracing
+## Configure telemetry
 
-Tracing is configured in a `tracing:` block. Point it at any OTLP-compatible backend
-(Jaeger, Uptrace, Datadog, …):
+Traces and metrics are configured in one `opentelemetry:` block and pushed over
+OTLP. Point it at any OTLP-compatible backend (the OpenTelemetry Collector,
+Jaeger, Uptrace, the Datadog Agent, …). Logs are not sent over OTLP — see
+[Logs](#logs) below:
 
 ```yaml
-tracing:
-  enabled: true
-  service_name: "cf-gears-api"
+opentelemetry:
+  resource:
+    service_name: "cf-gears-api"
+    attributes:
+      service.version: "1.0.0"
+      deployment.environment: "dev"
   exporter:
     kind: "otlp_grpc"            # or "otlp_http"
     endpoint: "http://127.0.0.1:4317"
     timeout_ms: 5000
-  sampler:
-    parent_based_ratio:
-      ratio: 0.1                 # 10% — use always_on in dev, a ratio in prod
-  resource:
-    service.version: "1.0.0"
-    deployment.environment: "dev"
-  propagation:
-    w3c_trace_context: true
+  tracing:
+    enabled: true
+    sampler:
+      parent_based_ratio:
+        ratio: 0.1               # 10% — use always_on in dev, a ratio in prod
+  metrics:
+    enabled: true
 ```
 
-Samplers: `always_on`, `always_off`, or `parent_based_ratio`. Exporters: `otlp_grpc`
-(port 4317) or `otlp_http` (port 4318). Settings can be overridden by environment variables
-for production (e.g. `APP__TRACING__EXPORTER__ENDPOINT=...`).
+Samplers: `always_on`, `always_off`, `parent_based_always_on`, or
+`parent_based_ratio`. Exporters: `otlp_grpc` (port 4317) or `otlp_http`
+(port 4318).
+
+:::caution
+Each signal defaults to **disabled**, and every config shipped in `config/` has
+both off — enable them deliberately. The config structs also use
+`deny_unknown_fields`, so an unrecognised key is a hard load error.
+:::
+
+Settings can be overridden by environment variables using the `APP__` prefix
+with `__` between levels, e.g. `APP__OPENTELEMETRY__EXPORTER__ENDPOINT=...`.
 
 Spin up a local collector to view traces:
 
@@ -45,6 +58,35 @@ docker run -d --name jaeger -p 16686:16686 -p 4317:4317 -p 4318:4318 \
   -e COLLECTOR_OTLP_ENABLED=true jaegertracing/all-in-one:latest
 # UI at http://localhost:16686
 ```
+
+For a Datadog-backed local setup, see
+`testing/docker/docker-compose.observability.yml` in the framework repository.
+
+## Logs
+
+Logs go to stderr, and to rotating files when a `file:` sink is configured —
+both governed by the `logging:` block, which is separate from `opentelemetry:`.
+Emit JSON so a collector or agent can read them off the container's stdout:
+
+```yaml
+logging:
+  default:
+    console_format: "json"     # text (default) | json
+    console_level: info
+```
+
+To let a backend link a log line to the span that produced it, add the trace ids
+to the records:
+
+```yaml
+opentelemetry:
+  tracing:
+    logs_correlation:
+      inject_trace_ids_into_logs: true
+```
+
+Every JSON record emitted inside a sampled span then carries top-level
+`trace_id` and `span_id`.
 
 ## Spans, request IDs, and health — for free
 
@@ -87,7 +129,9 @@ pub async fn get_user(&self, ctx: &SecurityContext, id: Uuid) -> Result<User, Do
 ## Trace outbound HTTP
 
 Build outbound clients through `toolkit-http` with `.with_otel()` (enable the `otel` feature)
-so external calls join the trace and carry the `traceparent` header:
+so external calls join the trace and carry the `traceparent` header. Note that `otel` is
+**not** a default feature of `toolkit-http` or `toolkit-contract` — without it outbound calls
+silently drop out of the trace:
 
 ```rust
 let client = HttpClient::builder()
@@ -99,13 +143,15 @@ let bytes = client.get("https://api.example.com/data").send().await?.checked_byt
 ```
 
 :::note[Initialization]
-Telemetry is initialized by the server bootstrap from the `tracing:` config — a standalone
-server does this in `run_server(config)`. The framework docs describe the config surface in
-full; the exact init entry point is part of the bootstrap, not something gears call directly.
+Telemetry is initialized by the server bootstrap from the `opentelemetry:` config — a
+standalone server does this in `run_server(config)`. The bootstrap also flushes both
+signals on graceful shutdown. The exact init entry point is part of the bootstrap, not
+something gears call directly.
 :::
 
 ## See also
 
 - [Runtime & lifecycle](../../concepts/runtime-and-lifecycle/) — where background work and
   cancellation fit.
-- Full reference: `docs/TRACING_SETUP.md` in the framework repository.
+- Full reference: `docs/TRACING_SETUP.md` in the framework repository — covers both
+  signals, logs, the Datadog setup, and unified service tagging.

--- a/docs/web-docs/build-with-gears/add-observability.md
+++ b/docs/web-docs/build-with-gears/add-observability.md
@@ -66,7 +66,7 @@ For a Datadog-backed local setup, see
 
 Logs go to stderr, and to rotating files when a `file:` sink is configured —
 both governed by the `logging:` block, which is separate from `opentelemetry:`.
-Emit JSON so a collector or agent can read them off the container's stdout:
+Emit JSON so a collector or agent can read them off the container's log stream:
 
 ```yaml
 logging:

--- a/docs/web-docs/build-with-gears/configure.md
+++ b/docs/web-docs/build-with-gears/configure.md
@@ -52,13 +52,13 @@ gears:
 - **API gateway** — `bind_addr`, `enable_docs`, `prefix_path`, CORS, rate limits, timeouts.
 - **Deployment shape** — `gears.<name>.runtime.type: local | oop` selects in-process vs
   out-of-process. See [Run a gear out-of-process](../out-of-process/).
-- **Tracing** — a `tracing:` block points at an OTLP backend. See
-  [Add observability](../add-observability/).
+- **Telemetry** — an `opentelemetry:` block points traces and metrics at an OTLP
+  backend. See [Add observability](../add-observability/).
 - **Database** — `database.servers.<name>` connection templates (`engine`, `params`, `pool`) that gears inherit; SQLite, PostgreSQL, and MariaDB engines are supported.
 
 ## Environment overrides
 
-Settings can be overridden by environment variables for production, e.g. `APP__TRACING__EXPORTER__ENDPOINT=...`. Select which config to run with `--app` / `--env` or `GEARS_CONFIG`.
+Settings can be overridden by environment variables for production, e.g. `APP__OPENTELEMETRY__EXPORTER__ENDPOINT=...` (the `APP__` prefix, with `__` between nesting levels). Select which config to run with `--app` / `--env` or `GEARS_CONFIG`.
 
 ## Config and the CLI manifest
 

--- a/gears/mini-chat/deploy/helm/mini-chat/templates/configmap.yaml
+++ b/gears/mini-chat/deploy/helm/mini-chat/templates/configmap.yaml
@@ -420,6 +420,21 @@ data:
           allow_http_upstream: true
 
     opentelemetry:
+      {{- with .Values.observability }}
+      resource:
+        service_name: {{ .resource.serviceName | quote }}
+        {{- if or .resource.environment .resource.version }}
+        attributes:
+          {{- with .resource.environment }}
+          deployment.environment: {{ . | quote }}
+          {{- end }}
+          {{- with .resource.version }}
+          service.version: {{ . | quote }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      # The two `enabled` flags and the exporter endpoint are injected as
+      # APP__OPENTELEMETRY__* env vars by the Deployment.
       tracing:
         enabled: false
       metrics:

--- a/gears/mini-chat/deploy/helm/mini-chat/templates/deployment.yaml
+++ b/gears/mini-chat/deploy/helm/mini-chat/templates/deployment.yaml
@@ -58,6 +58,34 @@ spec:
                 secretKeyRef:
                   name: {{ include "mini-chat.fullname" . }}
                   key: pg-password
+            {{- with .Values.observability }}
+            - name: APP__OPENTELEMETRY__EXPORTER__KIND
+              value: {{ .exporter.kind | quote }}
+            {{- if eq .exporter.endpoint "node" }}
+            # Node IP, so OTLP reaches the agent running on this node.
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: APP__OPENTELEMETRY__EXPORTER__ENDPOINT
+              value: "http://$(HOST_IP):{{ .exporter.port }}"
+            {{- else }}
+            - name: APP__OPENTELEMETRY__EXPORTER__ENDPOINT
+              value: "{{ .exporter.endpoint }}"
+            {{- end }}
+            - name: APP__OPENTELEMETRY__TRACING__ENABLED
+              value: {{ .traces.enabled | quote }}
+            - name: APP__OPENTELEMETRY__METRICS__ENABLED
+              value: {{ .metrics.enabled | quote }}
+            - name: APP__OPENTELEMETRY__RESOURCE__SERVICE_NAME
+              value: {{ .resource.serviceName | quote }}
+            {{- end }}
+            {{- /*
+              resource.attributes are set in the ConfigMap, not here: their keys
+              contain dots ("deployment.environment"), and the APP__ env layer
+              splits on "." as well as "__", so a dotted key would be parsed as
+              a nested map and fail config loading.
+            */}}
           volumeMounts:
             - name: config
               mountPath: /app/config/mini-chat.yaml

--- a/gears/mini-chat/deploy/helm/mini-chat/values.yaml
+++ b/gears/mini-chat/deploy/helm/mini-chat/values.yaml
@@ -26,6 +26,31 @@ postgres:
   user: "mini_chat"
   password: "REPLACE_ME"
 
+# OpenTelemetry export. Disabled by default, matching the framework defaults.
+#
+# With `endpoint: node`, telemetry is sent to the OTLP receiver of whatever agent
+# runs on the same node (e.g. the Datadog Agent DaemonSet started with
+# DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT=0.0.0.0:4317). Set an explicit
+# URL instead to target a standalone collector Service.
+#
+# Logs are not exported over OTLP: they go to the pod's stdout as JSON and are
+# collected from there by the node agent.
+observability:
+  traces:
+    enabled: false
+  metrics:
+    enabled: false
+  exporter:
+    kind: otlp_grpc               # otlp_grpc (4317) | otlp_http (4318)
+    # "node" resolves to http://$(HOST_IP):<port>; anything else is used verbatim.
+    endpoint: node
+    port: 4317
+  # Datadog derives service/env/version from these resource attributes.
+  resource:
+    serviceName: mini-chat
+    environment: ""
+    version: ""
+
 resources:
   requests:
     cpu: 100m

--- a/gears/mini-chat/deploy/helm/mini-chat/values.yaml
+++ b/gears/mini-chat/deploy/helm/mini-chat/values.yaml
@@ -33,8 +33,8 @@ postgres:
 # DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT=0.0.0.0:4317). Set an explicit
 # URL instead to target a standalone collector Service.
 #
-# Logs are not exported over OTLP: they go to the pod's stdout as JSON and are
-# collected from there by the node agent.
+# Logs are not exported over OTLP: they go to the pod's stderr as JSON and are
+# collected from the container log stream by the node agent.
 observability:
   traces:
     enabled: false

--- a/libs/toolkit/src/bootstrap/config/mod.rs
+++ b/libs/toolkit/src/bootstrap/config/mod.rs
@@ -439,6 +439,45 @@ pub(crate) fn remap_gear_env_key(key: &str) -> String {
     }
 }
 
+/// Reject the pre-2026-03 top-level `tracing:` section with a migration hint.
+///
+/// The section moved under `opentelemetry:` in `8c2187bc4`, which also put
+/// `deny_unknown_fields` on [`AppConfig`] — so an unmigrated config already
+/// fails, but with a bare "unknown field" that says nothing about where the
+/// settings went. This turns that into an actionable error.
+///
+/// One check covers both shapes the old documentation taught: `Env::prefixed`
+/// splits on `__`, so `APP__TRACING__EXPORTER__ENDPOINT` lands on the same
+/// `tracing.*` path as the YAML block.
+///
+/// The nested `opentelemetry.tracing` is untouched — `find_value` resolves from
+/// the root — and `AppConfig::default()` contributes no `tracing` key.
+///
+/// # Errors
+/// Returns an error when a root-level `tracing` key is present.
+fn reject_legacy_tracing_key(figment: &figment::Figment) -> Result<()> {
+    if figment.find_value("tracing").is_err() {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "the top-level `tracing:` section was replaced by `opentelemetry:`; \
+         move the settings across:\n\
+         \n\
+         \x20 tracing.enabled       -> opentelemetry.tracing.enabled\n\
+         \x20 tracing.service_name  -> opentelemetry.resource.service_name\n\
+         \x20 tracing.resource      -> opentelemetry.resource.attributes\n\
+         \x20 tracing.metrics       -> opentelemetry.metrics\n\
+         \x20 tracing.exporter      -> opentelemetry.exporter (shared) or \
+         opentelemetry.tracing.exporter\n\
+         \x20 tracing.sampler, .propagation, .http, .logs_correlation \
+         -> opentelemetry.tracing.*\n\
+         \n\
+         Environment overrides use the same path, so APP__TRACING__* becomes \
+         APP__OPENTELEMETRY__*. See docs/TRACING_SETUP.md."
+    );
+}
+
 impl AppConfig {
     /// Load configuration with layered loading: defaults → YAML file → environment variables.
     /// Also normalizes `server.home_dir` into an absolute path and creates the directory.
@@ -453,7 +492,7 @@ impl AppConfig {
 
         // For layered loading, start from AppConfig::default() which provides logging
         // defaults (via default_logging_config()); other optional sections (database,
-        // tracing, gears_dir) remain None unless overridden by YAML/ENV.
+        // opentelemetry, gears_dir) remain None unless overridden by YAML/ENV.
         let figment = Figment::new()
             .merge(Serialized::defaults(AppConfig::default()))
             .merge(StrictYaml::file(config_path))
@@ -463,6 +502,8 @@ impl AppConfig {
                     .split("__")
                     .map(|key| remap_gear_env_key(key.as_str()).into()),
             );
+
+        reject_legacy_tracing_key(&figment)?;
 
         let mut config: AppConfig = figment
             .extract()
@@ -3410,9 +3451,108 @@ vendor: {}
         assert!(config.vendor.is_empty());
     }
 
+    // ========== Legacy `tracing:` section ==========
+
+    /// The pre-2026-03 shape must fail with a migration hint, not a bare
+    /// `unknown field` from `deny_unknown_fields`.
+    // `#[serial]`: sets `APP__TRACING__*` below (via the sibling env-override
+    // test), which lands on the same root-level `tracing` path this test
+    // asserts is absent; serialize against it and the other APP__-mutating tests.
+    #[test]
+    #[serial]
+    fn test_legacy_tracing_section_reports_migration() {
+        let tmp = tempdir().unwrap();
+        let cfg_path = tmp.path().join("cfg.yaml");
+        let yaml = r#"
+server:
+  home_dir: "~/.test_legacy_tracing"
+tracing:
+  enabled: true
+  service_name: "cf-gears-api"
+  exporter:
+    kind: "otlp_grpc"
+    endpoint: "http://127.0.0.1:4317"
+"#;
+        fs::write(&cfg_path, yaml).unwrap();
+
+        let result = AppConfig::load_layered(&cfg_path);
+        assert!(result.is_err(), "legacy `tracing:` should be rejected");
+        let msg = format!("{:?}", result.unwrap_err());
+
+        for expected in [
+            "opentelemetry",
+            "opentelemetry.resource.service_name",
+            "docs/TRACING_SETUP.md",
+        ] {
+            assert!(msg.contains(expected), "missing {expected:?} in: {msg}");
+        }
+    }
+
+    /// The nested `opentelemetry.tracing` must not trip the root-level guard.
+    // `#[serial]`: see rationale on `test_legacy_tracing_section_reports_migration`.
+    #[test]
+    #[serial]
+    fn test_nested_opentelemetry_tracing_is_accepted() {
+        let tmp = tempdir().unwrap();
+        let cfg_path = tmp.path().join("cfg.yaml");
+        let yaml = r#"
+server:
+  home_dir: "~/.test_nested_tracing"
+opentelemetry:
+  resource:
+    service_name: "cf-gears-api"
+  tracing:
+    enabled: true
+  metrics:
+    enabled: false
+"#;
+        fs::write(&cfg_path, yaml).unwrap();
+
+        let config = AppConfig::load_layered(&cfg_path).expect("nested form should load");
+        assert!(config.opentelemetry.tracing.enabled);
+        assert_eq!(config.opentelemetry.resource.service_name, "cf-gears-api");
+    }
+
+    /// `reject_legacy_tracing_key` must also catch the legacy shape when it
+    /// arrives through the `APP__` env layer rather than the YAML file —
+    /// `Env::prefixed` splits `APP__TRACING__ENABLED` onto the same
+    /// `tracing.enabled` path as the old YAML block.
+    // `#[serial]`: mutates the process-global `APP__TRACING__*` var.
+    #[test]
+    #[serial]
+    fn test_legacy_tracing_env_override_reports_migration() {
+        let tmp = tempdir().unwrap();
+        let cfg_path = tmp.path().join("cfg.yaml");
+        let yaml = r#"
+server:
+  home_dir: "~/.test_legacy_tracing_env"
+opentelemetry:
+  resource:
+    service_name: "cf-gears-api"
+"#;
+        fs::write(&cfg_path, yaml).unwrap();
+
+        with_var("APP__TRACING__ENABLED", Some("true"), || {
+            let result = AppConfig::load_layered(&cfg_path);
+            assert!(
+                result.is_err(),
+                "legacy `APP__TRACING__*` override should be rejected"
+            );
+            let msg = format!("{:?}", result.unwrap_err());
+            assert!(
+                msg.contains("opentelemetry"),
+                "missing migration hint in: {msg}"
+            );
+        });
+    }
+
     // ========== Duplicate YAML key rejection tests ==========
 
+    // `#[serial]`: these call `load_layered`, which reads the process-global
+    // `APP__` env layer; serialize against the env-override tests that mutate
+    // `APP__*` vars via `with_var`.
     #[test]
+    #[serial]
     fn test_reject_duplicate_gear_names() {
         let tmp = tempdir().unwrap();
         let cfg_path = tmp.path().join("cfg.yaml");
@@ -3439,6 +3579,7 @@ gears:
     }
 
     #[test]
+    #[serial]
     fn test_reject_duplicate_keys_in_gear_file() {
         let tmp = tempdir().unwrap();
         let gears_dir = tmp.path().join("gears.d");
@@ -3477,6 +3618,7 @@ gears_dir: "{}"
     }
 
     #[test]
+    #[serial]
     fn test_no_false_positive_on_unique_gears() {
         let tmp = tempdir().unwrap();
         let cfg_path = tmp.path().join("cfg.yaml");

--- a/libs/toolkit/src/bootstrap/host/log_correlation.rs
+++ b/libs/toolkit/src/bootstrap/host/log_correlation.rs
@@ -1,0 +1,330 @@
+//! Trace-id injection for JSON log records.
+//!
+//! Logs are not exported over OTLP — they go to stderr and to the rotating
+//! files, and a collector picks them up from there. For a backend to link a log
+//! line to the span that produced it, the ids have to be *in the record*, at the
+//! top level: nested under `"span"` they are invisible to Datadog and most other
+//! backends without a bespoke remapper.
+//!
+//! The stock `fmt::layer().json()` formatter cannot add computed fields, so
+//! [`TraceIdJson`] wraps it: the inner formatter produces the record exactly as
+//! it does today, and the two ids are spliced in before the closing brace. That
+//! keeps the output byte-identical to the current shape apart from the two added
+//! keys — which is why this composes with the stock formatter instead of
+//! reimplementing it, where it would silently drift from upstream.
+//!
+//! Enabled by `opentelemetry.tracing.logs_correlation.inject_trace_ids_into_logs`.
+//! It is off by default because resolving the context costs a lookup on every
+//! event.
+
+use std::fmt;
+
+use tracing::{Event, Subscriber};
+use tracing_subscriber::fmt::format::{Format, Json, Writer};
+use tracing_subscriber::fmt::time::FormatTime;
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
+use tracing_subscriber::registry::LookupSpan;
+
+/// A JSON event formatter that adds top-level `trace_id` and `span_id`.
+///
+/// Delegates to the stock JSON formatter and splices the ids into the result.
+/// Records emitted outside a valid span pass through untouched.
+pub struct TraceIdJson<T> {
+    inner: Format<Json, T>,
+    /// When false this is a transparent wrapper — no context lookup, no
+    /// splice. Keeping the type the same either way lets the caller build one
+    /// layer type instead of branching at the type level.
+    enabled: bool,
+}
+
+impl<T> TraceIdJson<T> {
+    pub const fn new(inner: Format<Json, T>, enabled: bool) -> Self {
+        Self { inner, enabled }
+    }
+}
+
+impl<S, N, T> FormatEvent<S, N> for TraceIdJson<T>
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+    T: FormatTime,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        if !self.enabled {
+            return self.inner.format_event(ctx, writer, event);
+        }
+
+        let Some(ids) = current_trace_ids() else {
+            // No active OTel span (or no tracer installed): nothing to add.
+            return self.inner.format_event(ctx, writer, event);
+        };
+
+        let mut buf = String::new();
+        self.inner.format_event(ctx, Writer::new(&mut buf), event)?;
+
+        match splice_ids(&buf, &ids) {
+            Some(line) => writer.write_str(&line),
+            // The inner formatter produced something that is not the expected
+            // `{...}` object. Emitting it unchanged is strictly better than
+            // corrupting it.
+            None => writer.write_str(&buf),
+        }
+    }
+}
+
+/// The ids of the currently active span, if there is a valid one.
+///
+/// Reads OpenTelemetry's own thread-local context. `OpenTelemetrySpanExt::context()`
+/// would be the obvious route but it re-enters the subscriber to build the span,
+/// which is not possible from inside `on_event` — it silently yields an empty
+/// context there. `OpenTelemetryLayer` attaches the context on span entry
+/// (`context_activation`, on by default), so by the time an event is formatted
+/// the current context already carries the span.
+fn current_trace_ids() -> Option<(String, String)> {
+    use opentelemetry::trace::TraceContextExt as _;
+
+    let context = opentelemetry::Context::current();
+    let span = context.span();
+    let span_context = span.span_context();
+    if !span_context.is_valid() {
+        return None;
+    }
+    // `Display` for both is lowercase hex (32 and 16 chars), matching the
+    // `traceparent` wire form and `toolkit_http::otel::parse_trace_id`.
+    Some((
+        span_context.trace_id().to_string(),
+        span_context.span_id().to_string(),
+    ))
+}
+
+/// Insert the ids into a rendered JSON object, before its closing brace.
+///
+/// Returns `None` when `line` is not a `{...}` object, leaving the caller to
+/// pass the original through.
+fn splice_ids(line: &str, (trace_id, span_id): &(String, String)) -> Option<String> {
+    let trailing_newlines = line.len() - line.trim_end_matches('\n').len();
+    let body = line.trim_end_matches('\n');
+
+    let head = body.strip_suffix('}')?;
+    if !head.starts_with('{') {
+        return None;
+    }
+
+    // An empty object (`{}`) takes no separating comma.
+    let separator = if head.trim_end() == "{" { "" } else { "," };
+
+    let mut out = String::with_capacity(line.len() + 80);
+    out.push_str(head);
+    out.push_str(separator);
+    // Both ids are hex, so they need no JSON escaping.
+    out.push_str(r#""trace_id":""#);
+    out.push_str(trace_id);
+    out.push_str(r#"","span_id":""#);
+    out.push_str(span_id);
+    out.push_str("\"}");
+    for _ in 0..trailing_newlines {
+        out.push('\n');
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::splice_ids;
+
+    fn ids() -> (String, String) {
+        (
+            "4bf92f3577b34da6a3ce929d0e0e4736".to_owned(),
+            "00f067aa0ba902b7".to_owned(),
+        )
+    }
+
+    #[test]
+    fn adds_ids_before_the_closing_brace() {
+        let out = splice_ids(r#"{"level":"INFO","message":"hi"}"#, &ids()).expect("object");
+        assert_eq!(
+            out,
+            r#"{"level":"INFO","message":"hi","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7"}"#
+        );
+    }
+
+    /// The fmt layer terminates records with a newline; it must stay last so the
+    /// line-delimited JSON stream is not broken.
+    #[test]
+    fn preserves_the_trailing_newline() {
+        let out = splice_ids("{\"a\":1}\n", &ids()).expect("object");
+        assert!(out.ends_with("}\n"), "got {out:?}");
+        assert_eq!(out.matches('\n').count(), 1);
+    }
+
+    /// An empty object must not gain a leading comma.
+    #[test]
+    fn empty_object_gets_no_separator() {
+        let out = splice_ids("{}", &ids()).expect("object");
+        assert!(out.starts_with(r#"{"trace_id":"#), "got {out:?}");
+    }
+
+    /// Anything that is not a JSON object is passed back as unsplicable rather
+    /// than corrupted.
+    #[test]
+    fn non_object_input_is_rejected() {
+        assert!(splice_ids("not json", &ids()).is_none());
+        assert!(splice_ids("[1,2,3]", &ids()).is_none());
+        assert!(splice_ids("", &ids()).is_none());
+    }
+
+    // ===== end-to-end through a real subscriber =============================
+
+    use std::sync::{Arc, Mutex};
+
+    use opentelemetry::trace::TracerProvider as _;
+    use tracing_subscriber::fmt::MakeWriter;
+    use tracing_subscriber::layer::SubscriberExt as _;
+
+    /// Collects formatted records so a test can read them back.
+    #[derive(Clone, Default)]
+    struct Buffer(Arc<Mutex<Vec<u8>>>);
+
+    impl Buffer {
+        fn contents(&self) -> String {
+            String::from_utf8(
+                self.0
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .clone(),
+            )
+            .unwrap_or_default()
+        }
+    }
+
+    impl std::io::Write for Buffer {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for Buffer {
+        type Writer = Self;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Run `emit` under a subscriber wired like the production JSON sink, and
+    /// return what that sink wrote.
+    fn capture_with(enabled: bool, emit: impl FnOnce()) -> String {
+        let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder().build();
+        let tracer = provider.tracer("log-correlation-test");
+
+        let buffer = Buffer::default();
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .json()
+            .event_format(super::TraceIdJson::new(
+                tracing_subscriber::fmt::format()
+                    .json()
+                    .with_ansi(false)
+                    .with_timer(tracing_subscriber::fmt::time::UtcTime::rfc_3339()),
+                enabled,
+            ))
+            .with_writer(buffer.clone());
+
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer))
+            .with(fmt_layer);
+
+        tracing::subscriber::with_default(subscriber, emit);
+
+        buffer.contents()
+    }
+
+    /// Emit one event inside a span and return what the JSON sink wrote.
+    fn capture(enabled: bool, inside_span: bool) -> String {
+        capture_with(enabled, || {
+            if inside_span {
+                tracing::info_span!("unit").in_scope(|| tracing::info!("hello"));
+            } else {
+                tracing::info!("hello");
+            }
+        })
+    }
+
+    /// An event carrying its own `trace_id`/`span_id` fields must not shadow
+    /// the spliced ids. The stock formatter nests event fields under `fields`
+    /// (`flatten_event` is off), so the splice owns the top level outright.
+    /// This pins that: enabling `flatten_event` would move the event's copies
+    /// up and produce duplicate keys, and this test fails if that ever happens.
+    #[test]
+    fn event_fields_do_not_shadow_the_spliced_ids() {
+        let out = capture_with(true, || {
+            tracing::info_span!("unit").in_scope(|| {
+                tracing::info!(trace_id = "from_event", span_id = "from_event", "hello");
+            });
+        });
+        let value: serde_json::Value =
+            serde_json::from_str(out.trim()).unwrap_or_else(|e| panic!("not JSON: {e}: {out}"));
+
+        assert_eq!(
+            value["trace_id"].as_str().unwrap_or_default().len(),
+            32,
+            "top-level trace_id must be the live span's, not the event's: {out}"
+        );
+        assert_eq!(
+            value["span_id"].as_str().unwrap_or_default().len(),
+            16,
+            "top-level span_id must be the live span's, not the event's: {out}"
+        );
+        assert_eq!(
+            value["fields"]["trace_id"], "from_event",
+            "the event's own field must stay nested under `fields`: {out}"
+        );
+        assert_eq!(
+            value["fields"]["span_id"], "from_event",
+            "the event's own field must stay nested under `fields`: {out}"
+        );
+    }
+
+    /// The real payoff: ids resolved from the live span context, not a fixture.
+    #[test]
+    fn injects_ids_for_an_event_inside_a_span() {
+        let out = capture(true, true);
+        let value: serde_json::Value =
+            serde_json::from_str(out.trim()).unwrap_or_else(|e| panic!("not JSON: {e}: {out}"));
+
+        let trace_id = value["trace_id"].as_str().unwrap_or_default();
+        let span_id = value["span_id"].as_str().unwrap_or_default();
+
+        assert_eq!(trace_id.len(), 32, "trace_id should be 32 hex chars: {out}");
+        assert_eq!(span_id.len(), 16, "span_id should be 16 hex chars: {out}");
+        assert!(trace_id.chars().all(|c| c.is_ascii_hexdigit()), "{out}");
+        assert_ne!(trace_id, "0".repeat(32), "trace_id must not be the nil id");
+    }
+
+    /// Disabled is a transparent passthrough — the stock record, unmodified.
+    #[test]
+    fn adds_nothing_when_disabled() {
+        let out = capture(false, true);
+        assert!(!out.contains("trace_id"), "{out}");
+        assert!(out.contains("hello"), "record still emitted: {out}");
+    }
+
+    /// No active span means no ids, and no panic.
+    #[test]
+    fn adds_nothing_outside_a_span() {
+        let out = capture(true, false);
+        assert!(!out.contains("trace_id"), "{out}");
+        assert!(out.contains("hello"), "record still emitted: {out}");
+    }
+}

--- a/libs/toolkit/src/bootstrap/host/logging.rs
+++ b/libs/toolkit/src/bootstrap/host/logging.rs
@@ -7,6 +7,9 @@ use std::sync::{Arc, OnceLock};
 use parking_lot::Mutex;
 use tracing_subscriber::{Layer, fmt};
 
+#[cfg(feature = "otel")]
+use super::log_correlation;
+
 // ========== OTEL-agnostic layer type (compiles with/without the feature) ==========
 #[cfg(feature = "otel")]
 pub type OtelLayer = tracing_opentelemetry::OpenTelemetryLayer<
@@ -15,6 +18,35 @@ pub type OtelLayer = tracing_opentelemetry::OpenTelemetryLayer<
 >;
 #[cfg(not(feature = "otel"))]
 pub type OtelLayer = ();
+
+// The JSON event formatter used by the console and file sinks.
+//
+// `fmt::layer().json()` configures the event format through the layer builder,
+// but replacing that format (to add trace ids) discards those settings — so the
+// `Format` is built by `base_json_format()` and installed via `.event_format()`.
+//
+// Generic over the timer so the caller never has to name the (private-ish)
+// `Rfc3339` type behind `UtcTime::rfc_3339()`.
+#[cfg(feature = "otel")]
+type JsonEventFormat<T> = log_correlation::TraceIdJson<T>;
+#[cfg(not(feature = "otel"))]
+type JsonEventFormat<T> = fmt::format::Format<fmt::format::Json, T>;
+
+/// Wrap the JSON format so records carry `trace_id` / `span_id` when enabled.
+#[cfg_attr(not(feature = "otel"), allow(unused_variables))]
+fn json_event_format<T>(
+    base: fmt::format::Format<fmt::format::Json, T>,
+    inject_trace_ids: bool,
+) -> JsonEventFormat<T> {
+    #[cfg(feature = "otel")]
+    {
+        log_correlation::TraceIdJson::new(base, inject_trace_ids)
+    }
+    #[cfg(not(feature = "otel"))]
+    {
+        base
+    }
+}
 
 // ================= level helpers =================
 
@@ -195,7 +227,12 @@ static CONSOLE_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 
 /// Unified initializer used by both functions above.
 #[allow(unknown_lints, de1301_no_print_macros)] // runs before tracing subscriber is installed
-pub fn init_logging_unified(cfg: &LoggingConfig, base_dir: &Path, otel_layer: Option<OtelLayer>) {
+pub fn init_logging_unified(
+    cfg: &LoggingConfig,
+    base_dir: &Path,
+    otel_layer: Option<OtelLayer>,
+    inject_trace_ids: bool,
+) {
     CONSOLE_GUARD.get_or_init(|| {
         // Bridge `log` → `tracing` *before* installing the subscriber
         if let Err(e) = tracing_log::LogTracer::init() {
@@ -226,6 +263,7 @@ pub fn init_logging_unified(cfg: &LoggingConfig, base_dir: &Path, otel_layer: Op
             file_router,
             console_format,
             otel_layer,
+            inject_trace_ids,
         )
     });
 }
@@ -393,6 +431,7 @@ fn install_subscriber(
     file_router: MultiFileRouter,
     console_format: ConsoleFormat,
     #[cfg_attr(not(feature = "otel"), allow(unused_variables))] otel_layer: Option<OtelLayer>,
+    #[cfg_attr(not(feature = "otel"), allow(unused_variables))] inject_trace_ids: bool,
 ) -> WorkerGuard {
     use tracing_subscriber::{EnvFilter, Registry, fmt, layer::SubscriberExt};
 
@@ -402,6 +441,18 @@ fn install_subscriber(
 
     // Console writer (non-blocking stderr)
     let (nb_stderr, guard) = tracing_appender::non_blocking(std::io::stderr());
+
+    // Shared base JSON `Format`, referenced by the doc comment on
+    // `JsonEventFormat` above. Built once here so the console and file JSON
+    // sinks cannot drift from each other.
+    let base_json_format = || {
+        fmt::format()
+            .json()
+            .with_ansi(false)
+            .with_target(true)
+            .with_level(true)
+            .with_timer(fmt::time::UtcTime::rfc_3339())
+    };
 
     // Console fmt layers: text (human-friendly) or JSON (structured).
     // Only one is active at a time; the other is None.
@@ -423,11 +474,8 @@ fn install_subscriber(
             Some(
                 fmt::layer()
                     .json()
+                    .event_format(json_event_format(base_json_format(), inject_trace_ids))
                     .with_writer(nb_stderr)
-                    .with_ansi(false)
-                    .with_target(true)
-                    .with_level(true)
-                    .with_timer(fmt::time::UtcTime::rfc_3339())
                     .with_filter(console_targets.clone()),
             ),
         ),
@@ -440,10 +488,7 @@ fn install_subscriber(
         Some(
             fmt::layer()
                 .json()
-                .with_ansi(false)
-                .with_target(true)
-                .with_level(true)
-                .with_timer(fmt::time::UtcTime::rfc_3339())
+                .event_format(json_event_format(base_json_format(), inject_trace_ids))
                 .with_writer(file_router)
                 .with_filter(file_targets.clone()),
         )
@@ -479,6 +524,10 @@ fn install_subscriber(
 }
 // de1301_no_print_macros: same rationale as install_subscriber above.
 #[allow(unknown_lints, de1301_no_print_macros)]
+/// Minimal fallback subscriber: INFO to the console, honouring `RUST_LOG`.
+///
+/// Text output only, so trace-id injection does not apply here — it adds fields
+/// to JSON records.
 fn init_minimal(
     #[cfg_attr(not(feature = "otel"), allow(unused_variables))] otel: Option<OtelLayer>,
 ) -> WorkerGuard {

--- a/libs/toolkit/src/bootstrap/host/mod.rs
+++ b/libs/toolkit/src/bootstrap/host/mod.rs
@@ -5,6 +5,8 @@
 //!
 //! Configuration types are now in the top-level `config` gear.
 
+#[cfg(feature = "otel")]
+pub(crate) mod log_correlation;
 pub mod logging;
 pub mod panic;
 pub mod paths;

--- a/libs/toolkit/src/bootstrap/oop.rs
+++ b/libs/toolkit/src/bootstrap/oop.rs
@@ -640,6 +640,12 @@ pub async fn run_oop_with_options(opts: OopRunOptions) -> Result<()> {
         info!("Gear runtime completed successfully");
     }
 
+    // Graceful shutdown - flush remaining telemetry. An OoP gear is a separate
+    // OS process owning its own global providers, so the in-process host's
+    // flush in `bootstrap::run` does not cover it.
+    #[cfg(feature = "otel")]
+    crate::bootstrap::run::tracing_shutdown();
+
     result
 }
 

--- a/libs/toolkit/src/bootstrap/oop.rs
+++ b/libs/toolkit/src/bootstrap/oop.rs
@@ -491,7 +491,20 @@ pub async fn run_oop_with_options(opts: OopRunOptions) -> Result<()> {
         .and_then(|cfg| crate::telemetry::init::init_metrics_provider(cfg).err());
 
     // Initialize logging with MERGED config (master base + local override)
-    init_logging_unified(&merged_logging, &config.server.home_dir, otel_layer);
+    // Trace-id injection follows the same rule as the other telemetry
+    // settings: it comes from the master's rendered config, never the local one.
+    #[cfg(feature = "otel")]
+    let inject_trace_ids =
+        otel_cfg.is_some_and(crate::telemetry::OpenTelemetryConfig::inject_trace_ids_into_logs);
+    #[cfg(not(feature = "otel"))]
+    let inject_trace_ids = false;
+
+    init_logging_unified(
+        &merged_logging,
+        &config.server.home_dir,
+        otel_layer,
+        inject_trace_ids,
+    );
 
     // Now that logging is available, report deferred metrics init error
     #[cfg(feature = "otel")]
@@ -644,7 +657,7 @@ pub async fn run_oop_with_options(opts: OopRunOptions) -> Result<()> {
     // OS process owning its own global providers, so the in-process host's
     // flush in `bootstrap::run` does not cover it.
     #[cfg(feature = "otel")]
-    crate::bootstrap::run::tracing_shutdown();
+    crate::bootstrap::run::tracing_shutdown().await;
 
     result
 }

--- a/libs/toolkit/src/bootstrap/run.rs
+++ b/libs/toolkit/src/bootstrap/run.rs
@@ -101,7 +101,7 @@ pub async fn run_server(config: AppConfig) -> Result<()> {
 
     // Graceful shutdown - flush remaining telemetry
     #[cfg(feature = "otel")]
-    tracing_shutdown();
+    tracing_shutdown().await;
 
     result
 }
@@ -177,7 +177,7 @@ pub async fn run_migrate(config: AppConfig) -> Result<()> {
 
     // Graceful shutdown - flush remaining telemetry
     #[cfg(feature = "otel")]
-    tracing_shutdown();
+    tracing_shutdown().await;
 
     result?;
 
@@ -312,7 +312,12 @@ pub fn init_procedure(config: &AppConfig) -> Result<()> {
     let otel_layer = None;
 
     // Initialize logging + otel in one Registry
-    init_logging_unified(&config.logging, &config.server.home_dir, otel_layer);
+    init_logging_unified(
+        &config.logging,
+        &config.server.home_dir,
+        otel_layer,
+        config.opentelemetry.inject_trace_ids_into_logs(),
+    );
 
     // Register custom panic hook to reroute panic backtrace into tracing.
     init_panic_tracing();
@@ -351,7 +356,17 @@ pub fn init_procedure(config: &AppConfig) -> Result<()> {
 ///
 /// This delegates to the current telemetry shutdown helpers so callers can use a
 /// single bootstrap-level function during graceful shutdown.
-pub fn tracing_shutdown() {
-    crate::telemetry::init::shutdown_metrics();
-    crate::telemetry::init::shutdown_tracing();
+///
+/// `shutdown_metrics`/`shutdown_tracing` drain the SDK's batch processor, which
+/// blocks on exporting the final batch (real network I/O to the OTLP endpoint).
+/// Run that on a blocking-pool thread so it never stalls a Tokio worker thread.
+pub async fn tracing_shutdown() {
+    if let Err(e) = tokio::task::spawn_blocking(|| {
+        crate::telemetry::init::shutdown_metrics();
+        crate::telemetry::init::shutdown_tracing();
+    })
+    .await
+    {
+        tracing::warn!(error = %e, "Telemetry shutdown task panicked");
+    }
 }

--- a/libs/toolkit/src/telemetry/config.rs
+++ b/libs/toolkit/src/telemetry/config.rs
@@ -33,6 +33,18 @@ impl OpenTelemetryConfig {
     pub fn metrics_exporter(&self) -> Option<&Exporter> {
         self.metrics.exporter.as_ref().or(self.exporter.as_ref())
     }
+    /// Whether JSON log records should carry top-level `trace_id` / `span_id`.
+    ///
+    /// Off unless explicitly enabled: resolving the span context costs a lookup
+    /// on every event.
+    #[must_use]
+    pub fn inject_trace_ids_into_logs(&self) -> bool {
+        self.tracing
+            .logs_correlation
+            .as_ref()
+            .and_then(|c| c.inject_trace_ids_into_logs)
+            .unwrap_or(false)
+    }
 }
 
 /// OpenTelemetry resource identity — attached to all traces and metrics.

--- a/libs/toolkit/src/telemetry/config.rs
+++ b/libs/toolkit/src/telemetry/config.rs
@@ -100,6 +100,11 @@ pub enum ExporterKind {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Exporter {
+    /// Defaults to `otlp_grpc`, matching `extract_exporter_config`. Without a
+    /// default, overriding only the endpoint (e.g. via
+    /// `APP__OPENTELEMETRY__EXPORTER__ENDPOINT`) would fail to load because
+    /// `kind` would be missing from the partially-built map.
+    #[serde(default)]
     pub kind: ExporterKind,
     pub endpoint: Option<String>,
     pub headers: Option<HashMap<String, String>>,

--- a/libs/toolkit/src/telemetry/init.rs
+++ b/libs/toolkit/src/telemetry/init.rs
@@ -439,11 +439,15 @@ fn do_init_metrics_provider(otel_cfg: &OpenTelemetryConfig) -> anyhow::Result<()
 
     let provider = builder.build();
 
-    // Retain a handle for the shutdown flush before the global registry takes it.
-    if METER_PROVIDER.set(provider.clone()).is_err() {
-        tracing::debug!("meter provider handle already stored");
-    }
-    global::set_meter_provider(provider);
+    // Retain a handle for the shutdown flush, and register *that* handle
+    // globally. `METRICS_INIT` is checked before this function and set after
+    // it, so two concurrent first-callers both reach this point; storing one
+    // provider while registering the other would leave `shutdown_metrics`
+    // flushing an instrument-less provider and losing the live one's final
+    // interval. `get_or_init` makes the winner's provider the only one that is
+    // ever retained or registered; the loser's is dropped unused.
+    let installed = METER_PROVIDER.get_or_init(|| provider);
+    global::set_meter_provider(installed.clone());
     tracing::info!("OpenTelemetry metrics initialized successfully");
 
     Ok(())

--- a/libs/toolkit/src/telemetry/init.rs
+++ b/libs/toolkit/src/telemetry/init.rs
@@ -8,7 +8,7 @@ use anyhow::Context;
 #[cfg(feature = "otel")]
 use opentelemetry::{KeyValue, global, trace::TracerProvider as _};
 #[cfg(feature = "otel")]
-use std::sync::Once;
+use std::sync::{Once, OnceLock};
 
 #[cfg(feature = "otel")]
 use opentelemetry_otlp::{Protocol, WithExportConfig};
@@ -134,6 +134,18 @@ fn build_grpc_exporter(
 #[cfg(feature = "otel")]
 static INIT_TRACING: Once = Once::new();
 
+/// Handle to the installed tracer provider, kept so `shutdown_tracing()` can
+/// flush the batch processor on graceful shutdown. `global::set_tracer_provider`
+/// consumes the provider and exposes no way to get it back, so without this
+/// handle the last batch of spans is lost on every restart.
+#[cfg(feature = "otel")]
+static TRACER_PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
+
+/// Handle to the installed meter provider — same rationale as
+/// [`TRACER_PROVIDER`], for the final metrics collection interval.
+#[cfg(feature = "otel")]
+static METER_PROVIDER: OnceLock<opentelemetry_sdk::metrics::SdkMeterProvider> = OnceLock::new();
+
 /// Initialize OpenTelemetry tracing from configuration and return a layer
 /// to be attached to `tracing_subscriber`.
 ///
@@ -183,8 +195,13 @@ pub fn init_tracing(
     let tracer = provider.tracer(service_name);
     let otel_layer = tracing_opentelemetry::OpenTelemetryLayer::new(tracer);
 
-    // Make it global
+    // Make it global. Keep a clone first: `set_tracer_provider` takes ownership
+    // and the global registry offers no accessor, so this is the only chance to
+    // retain a handle for the shutdown flush.
     INIT_TRACING.call_once(|| {
+        if TRACER_PROVIDER.set(provider.clone()).is_err() {
+            tracing::debug!("tracer provider handle already stored");
+        }
         global::set_tracer_provider(provider);
     });
 
@@ -277,13 +294,25 @@ pub(crate) fn build_metadata_from_cfg_and_env(
 
 // ===== shutdown_tracing =======================================================
 
-/// Gracefully shut down OpenTelemetry tracing.
-/// In opentelemetry 0.31 there is no global `shutdown_tracer_provider()`.
-/// Keep a handle to `SdkTracerProvider` in your app state and call `shutdown()`
-/// during graceful shutdown. This function remains a no-op for compatibility.
+/// Gracefully shut down OpenTelemetry tracing, flushing the batch processor.
+///
+/// There is no global `shutdown_tracer_provider()` in opentelemetry 0.32, so
+/// this drains the handle retained by [`init_tracing`]. Without it the spans
+/// still sitting in the batch processor are dropped when the process exits.
+///
+/// Safe to call when tracing was never initialised (no handle — no-op) and
+/// idempotent: a second call hits the SDK's already-shut-down state and is
+/// logged at debug level rather than treated as a failure.
 #[cfg(feature = "otel")]
 pub fn shutdown_tracing() {
-    tracing::info!("Tracing shutdown: no-op (keep a provider handle to call `shutdown()`).");
+    let Some(provider) = TRACER_PROVIDER.get() else {
+        tracing::debug!("Tracing shutdown: no provider installed, nothing to flush");
+        return;
+    };
+    match provider.shutdown() {
+        Ok(()) => tracing::info!("OpenTelemetry tracing flushed and shut down"),
+        Err(e) => tracing::warn!(error = %e, "OpenTelemetry tracing shutdown failed"),
+    }
 }
 
 #[cfg(not(feature = "otel"))]
@@ -291,13 +320,20 @@ pub fn shutdown_tracing() {
     tracing::info!("Tracing shutdown (no-op)");
 }
 
-/// Gracefully shut down OpenTelemetry metrics.
-/// In opentelemetry 0.31 there is no global `shutdown_meter_provider()`.
-/// Keep a handle to `SdkMeterProvider` in your app state and call `shutdown()`
-/// during graceful shutdown. This function remains a no-op for compatibility.
+/// Gracefully shut down OpenTelemetry metrics, exporting the final interval.
+///
+/// Drains the handle retained by [`init_metrics_provider`]; see
+/// [`shutdown_tracing`] for the rationale and the idempotency contract.
 #[cfg(feature = "otel")]
 pub fn shutdown_metrics() {
-    tracing::info!("Metrics shutdown: no-op (keep a provider handle to call `shutdown()`).");
+    let Some(provider) = METER_PROVIDER.get() else {
+        tracing::debug!("Metrics shutdown: no provider installed, nothing to flush");
+        return;
+    };
+    match provider.shutdown() {
+        Ok(()) => tracing::info!("OpenTelemetry metrics flushed and shut down"),
+        Err(e) => tracing::warn!(error = %e, "OpenTelemetry metrics shutdown failed"),
+    }
 }
 
 #[cfg(not(feature = "otel"))]
@@ -403,6 +439,10 @@ fn do_init_metrics_provider(otel_cfg: &OpenTelemetryConfig) -> anyhow::Result<()
 
     let provider = builder.build();
 
+    // Retain a handle for the shutdown flush before the global registry takes it.
+    if METER_PROVIDER.set(provider.clone()).is_err() {
+        tracing::debug!("meter provider handle already stored");
+    }
     global::set_meter_provider(provider);
     tracing::info!("OpenTelemetry metrics initialized successfully");
 

--- a/testing/docker/docker-compose.observability.yml
+++ b/testing/docker/docker-compose.observability.yml
@@ -1,0 +1,31 @@
+# Local observability backend for gears-rust.
+#
+# Kept separate from `docker-compose.yml` on purpose: that file is what the CI
+# e2e job brings up, and a collector that cannot start without DD_API_KEY would
+# break it.
+#
+# Usage:
+#   export DD_API_KEY=...          # required
+#   export DD_SITE=datadoghq.eu    # or datadoghq.com
+#   docker compose -f testing/docker/docker-compose.observability.yml up -d
+#
+# Then point a gear at it by enabling both signals in its config:
+#
+#   opentelemetry:
+#     exporter: { kind: "otlp_grpc", endpoint: "http://127.0.0.1:4317" }
+#     tracing: { enabled: true }
+#     metrics: { enabled: true }
+
+services:
+  otel-collector:
+    # The Datadog exporter ships in the -contrib distribution only.
+    image: otel/opentelemetry-collector-contrib:0.115.1
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./otel-collector-datadog.yaml:/etc/otelcol/config.yaml:ro
+    environment:
+      - DD_API_KEY=${DD_API_KEY:?DD_API_KEY must be set}
+      - DD_SITE=${DD_SITE:-datadoghq.com}
+    ports:
+      - "4317:4317"   # OTLP gRPC
+      - "4318:4318"   # OTLP HTTP

--- a/testing/docker/docker-compose.observability.yml
+++ b/testing/docker/docker-compose.observability.yml
@@ -26,6 +26,8 @@ services:
     environment:
       - DD_API_KEY=${DD_API_KEY:?DD_API_KEY must be set}
       - DD_SITE=${DD_SITE:-datadoghq.com}
+    # Loopback-only: the collector holds a Datadog API key and needs no
+    # reachability beyond the gears running on this host.
     ports:
-      - "4317:4317"   # OTLP gRPC
-      - "4318:4318"   # OTLP HTTP
+      - "127.0.0.1:4317:4317"   # OTLP gRPC
+      - "127.0.0.1:4318:4318"   # OTLP HTTP

--- a/testing/docker/otel-collector-datadog.yaml
+++ b/testing/docker/otel-collector-datadog.yaml
@@ -1,0 +1,45 @@
+# OpenTelemetry Collector config for local Datadog-backed development.
+#
+# Gears push traces and metrics here over OTLP; the collector forwards them to
+# Datadog and, for local debugging, also prints them to its own stdout.
+#
+# In a cluster this role is played by the Datadog Agent's own OTLP receiver
+# (DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT=0.0.0.0:4317) and no separate
+# collector is needed.
+#
+# Logs are not sent over OTLP. Gears write JSON to stdout; collect them from
+# there (the Agent's container log collection, or a filelog receiver).
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  # Datadog's exporter requires batching; it rejects an unbatched pipeline.
+  batch:
+    timeout: 10s
+
+exporters:
+  datadog:
+    api:
+      key: ${env:DD_API_KEY}
+      site: ${env:DD_SITE}
+  # Prints every received span and metric locally. Drop this from the pipelines
+  # once you have confirmed data is flowing — it is noisy.
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog, debug]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog, debug]

--- a/testing/docker/otel-collector-datadog.yaml
+++ b/testing/docker/otel-collector-datadog.yaml
@@ -7,8 +7,9 @@
 # (DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT=0.0.0.0:4317) and no separate
 # collector is needed.
 #
-# Logs are not sent over OTLP. Gears write JSON to stdout; collect them from
-# there (the Agent's container log collection, or a filelog receiver).
+# Logs are not sent over OTLP. Gears write JSON to stderr; collect them from the
+# container log stream (the Agent's container log collection, or a filelog
+# receiver).
 
 receivers:
   otlp:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified OpenTelemetry configuration for traces and metrics.
  * Added optional `trace_id` and `span_id` fields to JSON logs.
  * Added Helm observability settings for mini-chat, including exporter, service metadata, and enablement controls.
  * Added local Datadog-backed telemetry collector setup.

* **Bug Fixes**
  * Credential-bearing authorization headers are no longer included in HTTP trace records.
  * Telemetry now flushes during graceful shutdown.

* **Documentation**
  * Updated configuration examples to use `APP__` environment-variable overrides.
  * Added migration guidance from the legacy `tracing:` configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->