### PR TITLE
docs(pr-review): rewrite comment voice and fill the Rust rule gaps

### DIFF
--- a/.claude/agents/toolkit-pr-review-v2-design.md
+++ b/.claude/agents/toolkit-pr-review-v2-design.md
@@ -1,6 +1,6 @@
 ---
 name: toolkit-pr-review-v2-design
-description: "API design, types & architecture review sub-agent for toolkit-pr-review-v2. Covers RUST-API-001, RUST-TYPE-001, RUST-OWN-001, RUST-DATA-001, RUST-OBS-001, RUST-MOD-001, RUST-NO-007. Returns JSON array only."
+description: "API design, types & architecture review sub-agent for toolkit-pr-review-v2. Covers RUST-API-001, RUST-TYPE-001, RUST-OWN-001, RUST-DATA-001, RUST-OBS-001..002, RUST-MOD-001, RUST-LINT-001, RUST-NO-007. Returns JSON array only."
 tools: Read, Bash
 model: inherit
 ---

--- a/.claude/agents/toolkit-pr-review-v2-security.md
+++ b/.claude/agents/toolkit-pr-review-v2-security.md
@@ -1,6 +1,6 @@
 ---
 name: toolkit-pr-review-v2-security
-description: "Security review sub-agent for toolkit-pr-review-v2. Covers RUST-SEC-001, RUST-NO-006, TOOLKIT-SEC-001..002. Returns JSON array only."
+description: "Security review sub-agent for toolkit-pr-review-v2. Covers RUST-SEC-001..002, RUST-NO-006, RUST-DEP-001, TOOLKIT-SEC-001..002. Returns JSON array only."
 tools: Read, Bash
 model: inherit
 ---

--- a/.claude/agents/toolkit-pr-review-v2-tests.md
+++ b/.claude/agents/toolkit-pr-review-v2-tests.md
@@ -1,6 +1,6 @@
 ---
 name: toolkit-pr-review-v2-tests
-description: "Test quality review sub-agent for toolkit-pr-review-v2. Covers RUST-TEST-001 and 9 test anti-patterns. Returns JSON array only."
+description: "Test quality review sub-agent for toolkit-pr-review-v2. Covers RUST-TEST-001 and 10 test anti-patterns. Returns JSON array only."
 tools: Read, Bash
 model: inherit
 ---

--- a/.claude/skills/toolkit-pr-review-v2/SKILL.md
+++ b/.claude/skills/toolkit-pr-review-v2/SKILL.md
@@ -101,10 +101,15 @@ Apply **Rust unit test quality review** (`docs/pr-review/toolkit-tests-quality-r
 
 For non-Rust files in the diff (TOML, YAML, migrations, etc.) — apply only general correctness checks, do not force Rust-specific rules.
 
+Apply **RUST-DEP-001** (dependency and advisory manifest hygiene) only to the manifest and config
+files collected in Step 2: `Cargo.toml`, `Cargo.lock`, `deny.toml`, `.cargo/audit.toml`,
+`.cargo/config.toml`, `clippy.toml`, `rust-toolchain.toml`. When the diff touches none of them,
+the check is skipped.
+
 ## Coding guidelines reference
 
 When reviewing, also consult:
-- `guidelines/DNA/languages/RUST.md` — project Rust conventions
+- `docs/pr-review/comment-style.md` — comment voice. The only authority on how findings are worded
 - `guidelines/SECURITY.md` — security requirements
 
 ---
@@ -142,7 +147,20 @@ For added/modified files, note the changed line ranges (added lines only — you
 
 Also record, per file, a **deletion anchor** for every hunk that removes lines with no added replacement in that hunk (a "pure deletion" hunk in a file that still exists at the review head) — needed so a finding about a partially deleted test (e.g. `TEST-QUALITY-9`) still has a valid line to anchor on. The anchor is the hunk's `newStart` value from its `@@ -oldStart,oldCount +newStart,newCount @@` header — the nearest surviving line in the new file at the deletion point. If `newStart` is `0`, use line `1`; if it falls past the end of the file, use the file's last line.
 
-For a `.rs` file **deleted entirely** (present in the base, absent at the review head — its diff hunk targets `/dev/null`), include its path in `rust_files` too, but track it separately in a `deleted_files` list. A deleted file has **no** RIGHT-side line at all, so do not compute `changed_ranges` or a `deletion_anchors` entry for it — see Step 4a for how its content is snapshotted and Step 5 for how findings on it are posted.
+For a reviewed file **deleted entirely** (present in the base, absent at the review head — its diff hunk targets `/dev/null`), include its path in its own list (`rust_files` or `manifest_files`) **and** track it in `deleted_files`. A deleted file has **no** RIGHT-side line at all, so do not compute `changed_ranges` or a `deletion_anchors` entry for it — see Step 4a for how its content is snapshotted and Step 5 for how findings on it are posted.
+
+This covers manifest and advisory config as well as `.rs`. Deleting `deny.toml` or
+`.cargo/audit.toml` outright removes a supply-chain control, which is exactly what
+`RUST-DEP-001` exists to catch; if such a file were snapshotted at the head (where it no longer
+exists) and filtered against its empty `changed_ranges`, every finding on it would be silently
+dropped.
+
+Also collect changed **manifest and lint/advisory config** files into a separate `manifest_files`
+list: `Cargo.toml`, `Cargo.lock`, `deny.toml`, `.cargo/audit.toml`, `.cargo/config.toml`,
+`clippy.toml`, `rust-toolchain.toml` (at any depth in the repo). Compute `changed_ranges` for them
+exactly as for `.rs` files, so findings anchor on real diff lines. These files are **not** added to
+`rust_files`; they exist only to feed `RUST-DEP-001`. If the diff touches none of them, leave the
+list empty.
 
 ### Step 3: Read review guidelines and classify files
 
@@ -174,7 +192,8 @@ Write `/tmp/toolkit-pr-review-v2-$REVIEW_ID/context.json` with the metadata, fil
   "base_branch": "<BASE_BRANCH, or null in PR mode>",
   "head_sha": "<HEAD_SHA>",
   "rust_files": [<list of .rs files from Step 2, including deleted files>],
-  "deleted_files": [<subset of rust_files deleted entirely — no RIGHT-side content>],
+  "deleted_files": [<any reviewed file deleted entirely, from rust_files or manifest_files — no RIGHT-side content>],
+  "manifest_files": [<changed manifest/lint/advisory config files from Step 2; [] if none>],
   "toolkit_owned_files": [<files classified as ToolKit-owned in Step 3>],
   "has_test_code": <boolean: true if any rust_files contains #[test], #[tokio::test], #[cfg(test)], or lives under tests/ — for deleted_files, check their base-side content instead of the (nonexistent) head content>,
   "changed_ranges": {
@@ -190,11 +209,24 @@ The `changed_ranges` dict maps each file to its list of changed line ranges (der
 
 The `deletion_anchors` dict maps each file to the pure-deletion-hunk anchor lines from Step 2. It is a secondary, narrower set of valid line targets — used only for findings about content partially removed from a file that still exists (no added line exists to anchor on), such as `TEST-QUALITY-9`. Omit a file's entry (or use `[]`) when it has no pure-deletion hunks. **Files listed in `deleted_files` never get an entry here** — they have no RIGHT-side line to anchor on at all; see Step 5 for how findings on them are posted instead.
 
-For each file in `rust_files` that is **not** in `deleted_files`, read the file at the review head (the PR head commit in PR mode, `$BRANCH_NAME` in local mode) and write its full content to:
+The `manifest_files` list gates `RUST-DEP-001`. Agent B skips that check when the list is empty.
+
+For each file in `rust_files` or `manifest_files` that is **not** in `deleted_files`, read the file
+at the review head (the PR head commit in PR mode, `$BRANCH_NAME` in local mode) and write its full
+content to:
 ```text
 /tmp/toolkit-pr-review-v2-$REVIEW_ID/files/<escaped-path>
 ```
-For each file **in** `deleted_files`, read it instead at the base commit (the PR's base SHA in PR mode, the merge-base with `$BASE_BRANCH` in local mode) and write that pre-deletion content to the same path — this lets Agent F see what was removed.
+For each file **in** `deleted_files`, read it instead at the base commit (the PR's base SHA in PR mode, the merge-base with `$BASE_BRANCH` in local mode) and write that pre-deletion content to the same path — this lets Agent F see which test was removed, and Agent B see which policy a deleted `deny.toml` or `.cargo/audit.toml` used to enforce.
+
+**Advisory counterpart.** `RUST-DEP-001` checks that `.cargo/audit.toml` and `deny.toml` do not
+drift apart, which needs both files even when the diff touches only one. So when either is in
+`manifest_files`, also snapshot the other into `files/` at the review head (or at the base commit
+if it is in `deleted_files`), even though it is unchanged. Do **not** add that counterpart to
+`manifest_files` and do **not** give it a `changed_ranges` entry: it is read-only context, and a
+finding must still anchor on the file the PR actually changed, or Step 4c drops it. If the
+counterpart does not exist in the repo at all, skip it — its absence means there is nothing to
+drift from, not that the check failed.
 
 `<escaped-path>` replaces `/` with `__` (e.g., `gears/foo/src/service.rs` → `gears__foo__src__service.rs`).
 
@@ -210,20 +242,22 @@ Spawn these agents (skip Agent E if toolkit_owned_files is empty; skip Agent F i
 Check IDs: RUST-ERR-001, RUST-PANIC-001, RUST-NO-001, RUST-NO-002, RUST-NO-003, TOOLKIT-ERR-001, TOOLKIT-ERR-002
 
 **Agent B — Security** (`toolkit-pr-review-v2-security`):
-Check IDs: RUST-SEC-001, RUST-NO-006, TOOLKIT-SEC-001, TOOLKIT-SEC-002
+Check IDs: RUST-SEC-001, RUST-SEC-002, RUST-NO-006, RUST-DEP-001, TOOLKIT-SEC-001, TOOLKIT-SEC-002
+(RUST-DEP-001 is skipped when `manifest_files` is empty; RUST-NO-006 applies only to a crate that
+opts out of the workspace `unsafe_code = "forbid"`)
 
 **Agent C — Async, Concurrency, Performance** (`toolkit-pr-review-v2-async`):
 Check IDs: RUST-ASYNC-001, RUST-CONC-001, RUST-PERF-001, RUST-NO-004, RUST-NO-005, TOOLKIT-LIFE-001
 
 **Agent D — Design, Types, Architecture** (`toolkit-pr-review-v2-design`):
-Check IDs: RUST-API-001, RUST-TYPE-001, RUST-OWN-001, RUST-DATA-001, RUST-OBS-001, RUST-MOD-001, RUST-NO-007
+Check IDs: RUST-API-001, RUST-TYPE-001, RUST-OWN-001, RUST-DATA-001, RUST-OBS-001, RUST-OBS-002, RUST-MOD-001, RUST-LINT-001, RUST-NO-007
 
 **Agent E — ToolKit Framework Compliance** (`toolkit-pr-review-v2-toolkit`):
 Check IDs: TOOLKIT-CORE-001, TOOLKIT-CORE-002, TOOLKIT-CORE-003, TOOLKIT-REST-001, TOOLKIT-REST-002, TOOLKIT-REST-003, TOOLKIT-DB-001, TOOLKIT-DB-002, TOOLKIT-CLIENT-001, TOOLKIT-CLIENT-002, TOOLKIT-ODATA-001, TOOLKIT-OOP-001
 (Gated: skip if toolkit_owned_files is empty)
 
 **Agent F — Test Quality** (`toolkit-pr-review-v2-tests`):
-Check IDs: RUST-TEST-001, TEST-QUALITY-1 through TEST-QUALITY-9
+Check IDs: RUST-TEST-001, TEST-QUALITY-1 through TEST-QUALITY-10
 (Gated: skip if has_test_code is false)
 
 Each agent returns a JSON array of findings. See `docs/pr-review/agents/toolkit-pr-review-v2-<name>.md` for detailed prompt structure.
@@ -241,8 +275,14 @@ Deduplicate: drop any finding where `(file, line, id)` duplicates an earlier fin
 Apply filter rules:
 - For a finding whose `file` is in `deleted_files`: keep it regardless of `line` (it has none — it posts as a file-level comment in Step 5).
 - For every other finding: drop it if `line` is not in `changed_ranges[file]` and not in `deletion_anchors[file]` for that file.
-- Drop style-only issues that rustfmt or clippy should catch.
-- Drop speculative or hypothetical findings (containing phrases like "might", "could consider", "may want to").
+- Drop style-only issues that rustfmt or clippy should catch. This includes anything the checklist
+  marks `Enforcement: clippy ... (deny)` — `Cargo.toml` `[workspace.lints]` already fails the build
+  on it, so posting it costs a slot a real finding needs.
+- Drop findings whose `issue` is speculative rather than evidenced: a hypothetical problem, not an
+  observed one. Judge this on the `issue` field only. Do **not** filter on `comment` wording —
+  hedged phrasing there ("this should probably be X", "looks like this can panic if...") is
+  intentional when the finding itself is uncertain, and is required by
+  `docs/pr-review/comment-style.md`.
 
 Sort by severity: CRITICAL → HIGH → MEDIUM → LOW.
 
@@ -264,8 +304,13 @@ gh api repos/$REPO/pulls/<PR_NUMBER>/comments \
   -f commit_id="<HEAD_SHA>" \
   -f path="gears/foo/src/tests.rs" \
   -f subject_type="file" \
-  -f body="**HIGH**\n\nTest `send_dead_letter_on_timeout` was deleted with no follow-up.\n\nRestore the test or open a tracked issue and link it here."
+  -f body=$'**HIGH**\n\n`send_dead_letter_on_timeout` is gone and nothing links a follow-up. If it was failing, we lose both the coverage and the signal.'
 ```
+
+Note the `$'...'` quoting: inside plain double quotes bash keeps `\n` as two literal characters and
+`gh` posts them verbatim, so the comment renders with visible `\n`. ANSI-C quoting turns them into
+real newlines, and backticks stay literal inside it. The JSON-payload path below does not need this
+(there `\n` is a JSON escape that the parser turns into a newline).
 
 Post these after the batch review below. If there are zero findings in both groups, skip straight to the "zero findings" review call.
 
@@ -276,6 +321,17 @@ Build the review payload:
 IMPORTANT: The `gh api` `-f` array syntax is limited. For multiple comments, build a JSON file and POST it.
 
 The review `body` MUST be empty string — no summary in the review itself. The summary goes to the terminal only (Step 6).
+
+Each comment `body` is built from the finding's `comment` field, with the severity header added
+only for the two top severities:
+
+```text
+CRITICAL or HIGH  ->  "**<SEVERITY>**\n\n<comment>"
+MEDIUM or LOW     ->  "<comment>"
+```
+
+Never post `issue` or `fix` as comment text — those two fields exist for the summary table and the
+local-mode report. The second example below shows a MEDIUM comment, with no header.
 
 ```bash
 cat > /tmp/review-payload.json << 'REVIEW_EOF'
@@ -288,7 +344,13 @@ cat > /tmp/review-payload.json << 'REVIEW_EOF'
       "path": "gears/foo/src/domain/service.rs",
       "line": 42,
       "side": "RIGHT",
-      "body": "**HIGH**\n\nError context discarded by `map_err(|_| ...)`.\n\nPreserve the source error — wrap with `.context()` or map to a domain error that keeps the cause."
+      "body": "**HIGH**\n\nThe original error gets dropped by `map_err(|_| ...)` here. When this fails in production we only see the generic variant, not what actually went wrong."
+    },
+    {
+      "path": "gears/foo/src/domain/service.rs",
+      "line": 77,
+      "side": "RIGHT",
+      "body": "Why do we need the intermediate `Vec` here? The iterator is consumed once right below."
     }
   ]
 }
@@ -331,9 +393,9 @@ Structure:
 
 ### Critical
 
-- **<One-sentence issue description>** — `<file>:<line>` (`<ID>`)
-  - **Why:** <one sentence on why it matters>
-  - **Fix:** <concrete change to make>
+- **<the finding's `issue`>** — `<file>:<line>` (`<ID>`)
+  - **Why:** <the finding's `comment`>
+  - **Fix:** <the finding's `fix`>
 
 ### High
 
@@ -356,7 +418,11 @@ Structure:
 
 Rules for the report:
 - One severity section per severity present. Omit empty sections.
-- Findings keep the same wording discipline as inline comments (see [Comment formatting rules](#comment-formatting-rules)) — but the checklist ID **is** included here, since there is no separate terminal-only table.
+- The report uses all three text fields, one per line: `issue` is the bolded headline, `comment`
+  fills `**Why:**` (it is the field that carries the reasoning), and `fix` fills `**Fix:**`. This is
+  a report rather than a conversation, so the labelled fixed shape is correct here even though
+  inline comments drop it. The checklist ID **is** included, since there is no separate
+  terminal-only table.
 - File paths are repo-relative and include the line number, so they are clickable. Exception: a finding whose `file` is in `deleted_files` has no line — render just the file path (e.g. `` `gears/foo/src/tests.rs` ``).
 - If there are zero findings, write the header plus a single line: `No issues found.`
 
@@ -390,25 +456,29 @@ Wrote <N> findings to <REPO_ROOT>/REVIEW_<BRANCH_SLUG>.md
 
 ## Comment formatting rules
 
-Each inline comment MUST follow this format:
+**Wording is defined in `docs/pr-review/comment-style.md`, and nowhere else.** That file is the
+contract: read it rather than relying on a summary here, because a summary is what drifts. The
+sub-agents produce the text in the finding's `comment` field. Do not rewrite it here beyond fixing
+an outright style violation, and never substitute `issue` + `fix` for it.
+
+The body has exactly two shapes, chosen by severity:
 
 ```text
-**<SEVERITY>**
+CRITICAL or HIGH   **<SEVERITY>**
+                   <blank line>
+                   <comment>
 
-<One-sentence issue description.>
-
-<One-sentence why it matters.>
-
-<Concrete fix — what to change, not a vague suggestion.>
+MEDIUM or LOW      <comment>
 ```
 
-Where `<SEVERITY>` is one of: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`.
+The header is dropped for MEDIUM and LOW on purpose: a bold severity tag on every comment is the
+clearest signal that a machine wrote it, and severity is still carried by the terminal summary
+table (Step 6) and the local-mode report (Step 5L), so nothing is lost for triage.
 
-Do NOT include checklist IDs (e.g. RUST-ERR-001, TOOLKIT-SEC-001) in inline comments. IDs appear only in the terminal summary table (Step 6) and — in local mode — in the markdown report.
+Do NOT include checklist IDs (e.g. RUST-ERR-001, TOOLKIT-SEC-001) in inline comments. IDs appear
+only in the terminal summary table (Step 6) and — in local mode — in the markdown report.
 
-Rules:
-- Engineering English. No filler, no praise, no hedging.
-- No "consider", "you might want to", "it would be nice if". State what is wrong and what to do.
+Mechanical rules, which the style file does not cover:
 - One issue per comment. If a line has two problems, post two comments.
 - Line number must point to an added/modified line that exists in the diff. Do not comment on unchanged lines.
 - If you cannot determine the exact line, do not guess — skip that finding. Exception: a finding on a file in `deleted_files` has no line by design — post it as a file-level comment (see Step 5), don't skip it and don't force a line onto it.
@@ -424,6 +494,8 @@ Rules:
 - Do not post generic praise or "LGTM" if there are no issues
 - Do not invent issues without evidence in the code
 - Do not complain about formatting that rustfmt handles
+- Do not post a finding the checklist marks `Enforcement: clippy ... (deny)` — the build already rejects it
+- Do not flag code for failing to use an API newer than the pinned toolchain (`rust-toolchain.toml`), which is what the `Requires Rust >= X.Y` markers in the checklist are for
 - Do not suggest speculative abstractions or premature generalization
 - Do not report more than 30 findings per review (prioritize by severity)
 - If there are zero findings, post a single review comment: "No issues found." (PR mode) / write `No issues found.` into the report (local mode)

--- a/.devin/workflows/toolkit-pr-review-v2.md
+++ b/.devin/workflows/toolkit-pr-review-v2.md
@@ -56,14 +56,16 @@ echo "HEAD SHA: $(jq -r .headRefOid /tmp/toolkit-pr-review-v2-${PR_NUMBER}/meta.
 Parse `/tmp/toolkit-pr-review-v2-${PR_NUMBER}/diff.patch` to extract:
 
 - **`rust_files`** — all added, modified, or deleted `.rs` files (strip `a/`/`b/` prefix)
-- **`deleted_files`** — subset of `rust_files` whose diff hunk targets `/dev/null` on the new side (deleted entirely). These have no RIGHT-side line at all — no `changed_ranges` or `deletion_anchors` entry is computed for them; see Step 4 (base-side snapshot) and Step 7 (file-level comment).
+- **`deleted_files`** — any reviewed file, from `rust_files` **or** `manifest_files`, whose diff hunk targets `/dev/null` on the new side (deleted entirely). These have no RIGHT-side line at all — no `changed_ranges` or `deletion_anchors` entry is computed for them; see Step 4 (base-side snapshot) and Step 7 (file-level comment). Manifests matter here: deleting `deny.toml` or `.cargo/audit.toml` outright removes a supply-chain control, and a head-only snapshot plus empty `changed_ranges` would silently drop every finding on it.
 - **`changed_ranges`** — per-file list of `[start, end]` line ranges from diff hunks (added lines only; empty for files in `deleted_files`)
 - **`deletion_anchors`** — per-file list of anchor lines for pure-deletion hunks in a file that still exists (hunks that remove lines with no added replacement). The anchor is the hunk's `newStart` from its `@@ -oldStart,oldCount +newStart,newCount @@` header (clamp to line `1` if `0`, or the file's last line if past EOF). Needed so a finding about a partially deleted test (e.g. `TEST-QUALITY-9`) still has a valid line to anchor on.
 - **`toolkit_owned_files`** — subset of `rust_files` where **any** of these signals is present:
   - nearest `Cargo.toml` declares `toolkit` dependency/feature, or crate name starts with `toolkit`
-  - file path matches `libs/toolkit*/`, `gears/*/src/`
+  - file path matches `gears/*/src/`, `crates/toolkit-*/`, `libs/toolkit*/`
   - source imports `use toolkit_*` or references `OperationBuilder`, `SecureConn`, `SecureORM`, `ClientHub`, `GearLifecycle`
 - **`has_test_code`** — `true` if `diff.patch` contains `#[test]`, `#[tokio::test]`, or `#[cfg(test)]` on **any** line (added or removed) — scanning the raw diff, not just head-side file content, so a wholesale-deleted test file still sets this `true`
+- **`manifest_files`** — changed manifest and lint/advisory config files at any depth: `Cargo.toml`, `Cargo.lock`, `deny.toml`, `.cargo/audit.toml`, `.cargo/config.toml`, `clippy.toml`, `rust-toolchain.toml`. Compute `changed_ranges` for them exactly as for `.rs` files. They are **not** added to `rust_files`; they exist only to gate `RUST-DEP-001` in Agent B. Empty list if the diff touches none of them
+  - **Advisory counterpart**: `RUST-DEP-001` checks that `.cargo/audit.toml` and `deny.toml` do not drift apart, which needs both files even when only one changed. When either appears here, Step 4 also snapshots the other as read-only context. It is **not** added to `manifest_files` and gets **no** `changed_ranges` entry, so a drift finding still anchors on the file the PR actually changed. Skip it if the counterpart does not exist in the repo
 
 ## Step 4: Write context and file snapshots
 
@@ -77,6 +79,7 @@ cat > /tmp/toolkit-pr-review-v2-${PR_NUMBER}/context.json << 'EOF'
   "head_sha": "<HEAD_SHA>",
   "rust_files": [],
   "deleted_files": [],
+  "manifest_files": [],
   "toolkit_owned_files": [],
   "has_test_code": false,
   "changed_ranges": {},
@@ -89,8 +92,17 @@ EOF
 # gh api repos/${REPO}/contents/path/to/file.rs?ref=<HEAD_SHA> -q .content \
 #   | base64 -d > /tmp/toolkit-pr-review-v2-${PR_NUMBER}/files/path__to__file.rs
 
-# For each file IN deleted_files, fetch its pre-deletion content at the base commit instead
-# (BASE_SHA = baseRefOid from meta.json) — the file no longer exists at HEAD_SHA:
+# Do the same for each file in manifest_files that is NOT in deleted_files, so Agent B can judge
+# RUST-DEP-001 against the whole manifest rather than only the hunk.
+
+# Advisory counterpart: if either deny.toml or .cargo/audit.toml is in manifest_files, snapshot
+# the OTHER one too (read-only context for the drift check), even though it is unchanged. Use
+# BASE_SHA instead of HEAD_SHA if that counterpart is in deleted_files. Skip if it does not exist:
+#   gh api repos/${REPO}/contents/deny.toml?ref=<HEAD_SHA> -q .content \
+#     | base64 -d > /tmp/toolkit-pr-review-v2-${PR_NUMBER}/files/deny.toml 2>/dev/null || true
+
+# For each file IN deleted_files (.rs or manifest), fetch its pre-deletion content at the base
+# commit instead (BASE_SHA = baseRefOid from meta.json) — it no longer exists at HEAD_SHA:
 # BASE_SHA=$(jq -r .baseRefOid /tmp/toolkit-pr-review-v2-${PR_NUMBER}/meta.json)
 # gh api repos/${REPO}/contents/path/to/file.rs?ref=${BASE_SHA} -q .content \
 #   | base64 -d > /tmp/toolkit-pr-review-v2-${PR_NUMBER}/files/path__to__file.rs
@@ -101,6 +113,8 @@ EOF
 Spawn all applicable agents as parallel background processes. Each reads its inputs from `/tmp/toolkit-pr-review-v2-${PR_NUMBER}/` and writes a JSON array to its output file.
 
 Skip Agent E if `toolkit_owned_files` is empty. Skip Agent F if `has_test_code` is false.
+Agent B always runs, but its `RUST-DEP-001` check is self-gated on `manifest_files` being
+non-empty; the agent file handles that, so no orchestration change is needed for it.
 
 // turbo
 ```bash
@@ -184,6 +198,16 @@ def in_range(file, line):
     # TEST-QUALITY-9 findings on partially deleted content may anchor here instead
     return line in deletion_anchors.get(file, [])
 
+# Drop findings whose `issue` is speculative rather than evidenced: a hypothetical
+# problem, not an observed one. Judged on `issue` only -- NOT on `comment`, where
+# hedged phrasing is intentional when the finding itself is uncertain (see
+# docs/pr-review/comment-style.md).
+SPECULATIVE = ("might", "could consider", "may want to", "it would be nice")
+
+def speculative(f):
+    issue = (f.get("issue") or "").lower()
+    return any(t in issue for t in SPECULATIVE)
+
 # Deduplicate by (file, line, id), validate line in diff.
 # A finding on a fully deleted file has no line at all (it posts as a
 # file-level comment in Step 7) and skips the line check entirely.
@@ -193,6 +217,8 @@ for f in combined:
     if key in seen:
         continue
     if f["file"] not in deleted_files and not in_range(f["file"], f.get("line")):
+        continue
+    if speculative(f):
         continue
     seen.add(key)
     filtered.append(f)
@@ -232,12 +258,23 @@ deleted_files = set(ctx.get("deleted_files", []))
 line_findings = [f for f in findings if f["file"] not in deleted_files]
 file_findings = [f for f in findings if f["file"] in deleted_files]
 
+# The comment body comes from the `comment` field, which the sub-agents write in the
+# voice defined by docs/pr-review/comment-style.md. `issue` and `fix` are for the
+# Step 8 summary table only and are never posted. The severity header is added for
+# CRITICAL and HIGH only: a bold tag on every comment is the clearest sign a machine
+# wrote it, and severity still shows in the summary table.
+def body_of(f):
+    text = f.get("comment") or f["issue"]
+    if f["severity"] in ("CRITICAL", "HIGH"):
+        return f"**{f['severity']}**\n\n{text}"
+    return text
+
 comments = [
     {
         "path": f["file"],
         "line": f["line"],
         "side": "RIGHT",
-        "body": f"**{f['severity']}**\n\n{f['issue']}\n\n{f['fix']}"
+        "body": body_of(f)
     }
     for f in line_findings
 ]
@@ -270,7 +307,13 @@ else
   # File-level comments: a deleted file has no RIGHT-side line to anchor on.
   jq -c '.[]' /tmp/file-level-findings.json | while read -r finding; do
     path=$(echo "$finding" | jq -r '.file')
-    body=$(echo "$finding" | jq -r '"**" + .severity + "**\n\n" + .issue + "\n\n" + .fix')
+    # `//` alone would keep an empty-string comment (jq treats "" as truthy), which
+    # would post a blank comment. Fall back to .issue when it is empty or null, so this
+    # matches body_of() above, where Python's `or` already treats "" as absent.
+    body=$(echo "$finding" | jq -r '(if ((.comment // "") == "") then .issue else .comment end) as $t
+      | if (.severity == "CRITICAL" or .severity == "HIGH")
+        then "**" + .severity + "**\n\n" + $t
+        else $t end')
     gh api repos/${REPO}/pulls/${PR_NUMBER}/comments \
       --method POST \
       -f commit_id="${HEAD_SHA}" \

--- a/docs/pr-review/agents/toolkit-pr-review-v2-async.md
+++ b/docs/pr-review/agents/toolkit-pr-review-v2-async.md
@@ -36,6 +36,8 @@ Apply **only** these specific check IDs:
    - Functions holding partial/shared state across `.await` points with no consideration of what happens if the future is dropped mid-await (`select!`, timeout)
    - `Drop` impls on async-held resources (transactions, connections, guards) that assume cleanup runs, when the cleanup actually needs an async call (`Drop` cannot `.await`)
    - CPU-bound async loops with no periodic `tokio::task::yield_now()`, starving other tasks on the executor
+   - An async fn reachable from `select!`, `timeout`, or an abortable task with no `// cancel-safe:` or `// NOT cancel-safe:` annotation. "All awaits are idempotent" is not a valid reason; per-call semantics differ (`read` is cancel-safe, `read_exact` is not)
+   - A lock guard that escapes `await_holding_lock`: returned from a helper, stored in a struct field, or produced by `MutexGuard::map`. The lint only sees the direct shape, so hand-review every `Mutex` import in an async module
 
 2. **RUST-CONC-001** — Concurrent state access must be safe. Check for:
    - Unjustified `unsafe` blocks in concurrent code
@@ -43,6 +45,7 @@ Apply **only** these specific check IDs:
    - Deadlock patterns (lock ordering, nested locks)
    - Channel misuse (closed channels, receiver drops)
    - Arc/Mutex/RwLock used correctly (not bypassed)
+   - A hand-rolled `compare_exchange` retry loop where `Atomic*::update` / `try_update` would do (needs Rust >= 1.95)
 
 3. **RUST-PERF-001** — Code must not have obvious performance footguns. Check for:
    - Unnecessary allocations or clones (especially in hot loops)
@@ -52,6 +55,16 @@ Apply **only** these specific check IDs:
    - Excessive logging or tracing in performance-critical paths
    - `.collect::<Vec<_>>()` immediately consumed by another loop/iteration instead of chaining iterators
    - `Box::new([0; N])` for large buffers instead of `vec![0; n]`
+   - `map.get(&key.to_string())` or a `.clone()` at a lookup site, when a `HashMap<String, V>` can be queried with `&str`
+   - Oversized enum variants that should be boxed, and double indirection (`Box<Vec<T>>`, `Box<String>`, `Arc<String>` where `Arc<str>` is meant)
+   - Hand-rolled shift/mask bit arithmetic where a std method exists (`bit_width`, `isolate_highest_one`, `isolate_lowest_one`, `highest_one`, `lowest_one`; needs Rust >= 1.97)
+   - `to_string()`/`format!` per iteration in a hot integer-formatting loop, where `NumBuffer` + `format_into` reuses one buffer (needs Rust >= 1.98)
+
+   Skip the following in this repo: gratuitous clones, `&str.to_string()`, `with_capacity(0)`,
+   `String::from("lit")`, `push_str` chains, and large stack arrays are all denied in
+   `Cargo.toml` `[workspace.lints]` (`redundant_clone`, `str_to_string`, `manual_string_new`,
+   `format_push_string`, `large_stack_arrays`), so the build already rejects them. Do not spend a
+   finding slot on them.
 
 4. **RUST-NO-004** — No async blocking footguns. Do not block the async runtime — equivalent to RUST-ASYNC-001 but phrased as a "must not."
 
@@ -65,6 +78,7 @@ Apply **only** these specific check IDs:
 
 ## Checklist References
 
+- `docs/pr-review/comment-style.md` — comment voice. **Mandatory read before emitting findings.**
 - `docs/pr-review/toolkit-rust-review.md` — sections on RUST-ASYNC-001, RUST-CONC-001, RUST-PERF-001, RUST-NO-004, RUST-NO-005
 - `docs/pr-review/toolkit-framework-compliance-review.md` — section on TOOLKIT-LIFE-001 (ToolKit files only)
 
@@ -88,6 +102,7 @@ Schema (one object per finding):
   "line": 42,
   "severity": "HIGH",
   "id": "RUST-ASYNC-001",
+  "comment": "`std::thread::sleep` parks the whole executor thread, not just this task. Every other task scheduled on it stalls for the full duration.",
   "issue": "std::thread::sleep() blocks the async runtime.",
   "fix": "Use tokio::time::sleep().await instead."
 }
@@ -96,7 +111,19 @@ Schema (one object per finding):
 Field rules:
 - `"file"`: repo-root-relative path, exactly as it appears in the diff (strip `a/` or `b/` prefix).
 - `"line"`: integer, must be in `changed_ranges[file]` for that file. If unsure, omit the finding.
+  Exception: when `"file"` is in `deleted_files` it has no RIGHT-side line at all, so omit this
+  field entirely (do not guess a value) and the finding posts as a file-level comment. Use that
+  exception only when the deletion **itself** violates one of your check IDs, such as a removed
+  public item under RUST-NO-007. Do not use it to comment on the contents of removed code; most
+  file deletions are deliberate and are not findings.
 - `"severity"`: one of `"CRITICAL"`, `"HIGH"`, `"MEDIUM"`, `"LOW"` (verbatim strings, uppercase). RUST-ASYNC-001 and RUST-CONC-001 violations are typically CRITICAL or HIGH.
 - `"id"`: exact check ID from the list above.
-- `"issue"`: one sentence, engineering English, no praise or hedging.
-- `"fix"`: one sentence, concrete and actionable (what to change, not a suggestion).
+- `"comment"`: **the inline comment body a human will read on GitHub.** 1 to 3 sentences.
+  `docs/pr-review/comment-style.md` is the contract for how it is worded, including which
+  phrasings are banned and how to keep a finding's uncertainty intact. Read it before emitting any
+  finding; its rules are deliberately not restated here, so that this file cannot drift from it.
+- `"issue"`: terse analytic restatement for the summary table and the local-mode report. One
+  sentence, engineering English, no praise or hedging. This is never posted as a comment, so it
+  does not need to read naturally.
+- `"fix"`: one sentence, concrete and actionable (what to change, not a suggestion). Table and
+  report only, like `"issue"`.

--- a/docs/pr-review/agents/toolkit-pr-review-v2-design.md
+++ b/docs/pr-review/agents/toolkit-pr-review-v2-design.md
@@ -1,6 +1,6 @@
 ---
 name: toolkit-pr-review-v2-design
-description: "API design, types & architecture review sub-agent for toolkit-pr-review-v2. Covers RUST-API-001, RUST-TYPE-001, RUST-OWN-001, RUST-DATA-001, RUST-OBS-001, RUST-MOD-001, RUST-NO-007. Returns JSON array only."
+description: "API design, types & architecture review sub-agent for toolkit-pr-review-v2. Covers RUST-API-001, RUST-TYPE-001, RUST-OWN-001, RUST-DATA-001, RUST-OBS-001..002, RUST-MOD-001, RUST-LINT-001, RUST-NO-007. Returns JSON array only."
 tools: Read, Bash
 model: inherit
 ---
@@ -40,6 +40,12 @@ Apply **only** these specific check IDs:
    - More than 2-3 boolean parameters on one function (should be an options struct/enum/builder)
    - Validating constructors that panic or silently clamp instead of returning `Result`
    - `Deref`/`DerefMut` impls used to fake inheritance on a wrapper type (leaks the inner API, blurs ownership)
+   - Third-party types in public signatures (`reqwest::Error`, `sqlx::Row`, `hyper::Uri`) instead of a wrapper, which pins the dependency into the API contract
+   - Public config/value types missing either `Default` or an inherent `new()`
+   - `pub` fields on a library value type where a validated constructor is meant
+   - A hand-rolled `match` on a kind/tag field that dispatches behavior, where a trait object or `Fn` strategy parameter belongs
+   - A local extension trait or free helper used where the orphan rule calls for a newtype
+   - New public types with no `Debug` impl, and new `pub` items in a library crate with no `///` docs
 
 2. **RUST-TYPE-001** — Type system must preserve invariants. Check for:
    - Types that allow invalid states (should use enum or newtype)
@@ -49,6 +55,14 @@ Apply **only** these specific check IDs:
    - Wildcard `_ =>` catch-all on a crate-owned enum where an exhaustive match would force new variants to be handled
    - Public enums/structs expected to grow that are missing `#[non_exhaustive]`
    - Easily-dropped-by-accident results (builders, "must apply" configs) missing `#[must_use]`
+   - A bare `as` for a lossless widening (`u64::from(x)` is meant) or a pointer cast (`.cast::<T>()` preserves constness). The lossy cases are already denied by clippy, so only these two shapes are yours
+   - A hand-written `PartialEq` next to a derived `Ord`/`PartialOrd`, or the reverse. Comparison traits must be all-manual or all-derived over the same field set, so `a == b` holds exactly when `cmp` returns `Equal` (needs Rust >= 1.98 for the derive fast path that exposes it)
+   - A type with a manual `PartialEq` used in a constant pattern (rejected on Rust >= 1.98)
+   - `#[repr(transparent)]` over a `#[non_exhaustive]`, `repr(C)`, or private-field type (rejected on Rust >= 1.98); it belongs only on real ABI or `transmute` needs
+   - `parse()` followed by `NonZero::new(..).ok_or(..)` where `NonZero::<u32>::from_str_radix(s, 10)?` makes zero a parse error (needs Rust >= 1.98)
+   - Manual `PartialEq`/`Hash`/`Ord` impls that do not destructure `Self { .. }`, so a new field is silently ignored instead of breaking the build
+   - A bare `_` or `..` in a destructuring pattern where a named ignore (`has_fuel: _`) would show which field was deliberately skipped
+   - `..Default::default()` in a crate-owned struct literal: a field added later is silently defaulted at every construction site
 
 3. **RUST-OWN-001** — Ownership and borrowing patterns must be clear and efficient. Check for:
    - Unnecessary copies (passing owned values when references suffice)
@@ -60,35 +74,54 @@ Apply **only** these specific check IDs:
    - A single lifetime parameter bounding both an input argument and a stored/returned reference (over-constrains callers)
    - Manual acquire/release pairs where an RAII guard (`Drop`) would be safer
    - Fallible functions that take ownership of an argument but don't return that value inside the error variant, forcing the caller to re-clone before retrying
+   - A clone, `RefCell`, or `Arc` introduced only to borrow two fields of the same struct, where decomposing the struct into independently borrowable parts is the fix
+   - A `move` closure or spawned task capturing `self` or a whole context instead of rebinding the narrowest value in a scope block, and a refcount bump written `x.clone()` instead of `Arc::clone(&x)`
+   - A `let mut` binding that stays mutable long after setup, where `let x = { let mut x = ..; x.sort(); x };` confines the mutability
 
 4. **RUST-DATA-001** — Serialization contracts must be explicit and maintainable. Check for:
    - Serialization without explicit versioning or backwards-compatibility consideration
    - Derive-macro usage without understanding the semantics (e.g., Serialize on types that should be opaque)
    - Breaking serialization changes in published APIs
    - Missing documentation of serialization format
+   - `n != 0` when decoding a strictly-0/1 wire or storage flag, where `bool::try_from(n).map_err(...)` surfaces out-of-contract bytes as a parse error rather than reading them as `true` (needs Rust >= 1.95)
+   - `f32`/`f64` `algebraic_add`/`sub`/`mul`/`div`/`rem` on a value that is compared, sorted, hashed, serialized, persisted, asserted on, or used for billing, quota, or alert thresholds. They permit reassociation, so the result varies across call sites, optimization levels, and targets (needs Rust >= 1.98)
 
 5. **RUST-OBS-001** — Code must be observable: logging, tracing, and metrics at appropriate levels. Check for:
    - Missing instrumentation for error cases or unusual control flow
    - Logging that is too verbose or too sparse (no detail on what went wrong)
    - No structured logging (using unstructured log calls when structured tracing would help)
    - Missing metrics for performance-critical operations
+   - Authentication attempts not logged, both success and failure and with the source IP, or authorization denials not logged with identity, requested resource, and reason
+   - Request or response bodies logged where they may carry credentials or PII
 
-6. **RUST-MOD-001** — Module boundaries must be clear and enforced. Check for:
+6. **RUST-OBS-002** — No debug artifacts in production output. Check for `println!()`, `eprintln!()`, or direct stdout/stderr writes in library or service code; diagnostics belong in `tracing`. `dbg!` and `{:?}` output are already denied by clippy (`dbg_macro`, `use_debug`), so only the print macros are yours. A CLI binary writing its intended program output to stdout is not a finding.
+
+7. **RUST-LINT-001** — In-source lint suppression hygiene. Check for:
+   - `#[allow(...)]` or `#[expect(...)]` with no `reason = "..."`
+   - `#[allow]` where `#[expect]` would self-remove once the suppression stops being needed
+   - A crate-level group `allow` (`clippy::all`, `clippy::pedantic`, `clippy::nursery`) added in source
+   - `#![deny(warnings)]` or equivalent blanket escalation in source: it turns any future lint, including new compiler lints, into a hard build break. Deny specific lints by name, or gate it in the build via `build.warnings = "deny"` / `CARGO_BUILD_WARNINGS=deny` (needs Rust >= 1.97)
+   - `unused_async_trait_impl` silenced crate-wide instead of per impl where a foreign trait mandates `async fn`
+
+8. **RUST-MOD-001** — Module boundaries must be clear and enforced. Check for:
    - Circular module dependencies
    - Implementation details exposed as pub (should be pub(crate) or inside modules)
    - Deep nesting without clear separation of concerns
    - Modules mixing unrelated functionality
-   - `#![deny(warnings)]` (or equivalent) added directly in source instead of denying specific lints by name or gating via CI/`RUSTFLAGS`
+   - A function past the pinned thresholds given another branch instead of being decomposed (`cognitive_complexity` 20, `too_many_lines` 200 are clippy-denied, so only flag the structural case the lint misses)
+   - New platform-gated code using the `cfg-if` crate where std `cfg_select!` belongs (needs Rust >= 1.95). Do not ask for existing `cfg_if!` usages to be migrated
+   - Source-level blanket lint escalation belongs to RUST-LINT-001, not here
 
-7. **RUST-NO-007** — No accidental contract drift. Check for:
+9. **RUST-NO-007** — No accidental contract drift. Check for:
    - Public API changes without documentation (docs, changelog)
    - Removing or renaming public items without deprecation
    - Breaking changes to serialization formats of published types
    - Changes to error types that break caller code
-   - New blanket trait impls (`impl<T: Bound> Trait for T`) added to a public API without deliberate justification (semver/coherence hazard)
+   - New blanket trait impls (`impl<T: Bound> Trait for T`) added to a public API without deliberate justification (semver/coherence hazard). The fix is to seal the trait behind a private supertrait so only this crate can implement it, or to write per-type impls
 
 ## Checklist References
 
+- `docs/pr-review/comment-style.md` — comment voice. **Mandatory read before emitting findings.**
 - `docs/pr-review/toolkit-rust-review.md` — sections on RUST-API-001, RUST-TYPE-001, RUST-OWN-001, RUST-DATA-001, RUST-OBS-001, RUST-MOD-001, RUST-NO-007
 
 ## Scope Rules
@@ -110,6 +143,7 @@ Schema (one object per finding):
   "line": 42,
   "severity": "MEDIUM",
   "id": "RUST-API-001",
+  "comment": "Does this need to be `pub`? Nothing outside the module calls it, and making it public commits us to keeping the signature.",
   "issue": "Public function exposed that should be module-private.",
   "fix": "Change pub to pub(crate) unless this function is part of the public API contract."
 }
@@ -118,7 +152,19 @@ Schema (one object per finding):
 Field rules:
 - `"file"`: repo-root-relative path, exactly as it appears in the diff (strip `a/` or `b/` prefix).
 - `"line"`: integer, must be in `changed_ranges[file]` for that file. If unsure, omit the finding.
+  Exception: when `"file"` is in `deleted_files` it has no RIGHT-side line at all, so omit this
+  field entirely (do not guess a value) and the finding posts as a file-level comment. Use that
+  exception only when the deletion **itself** violates one of your check IDs, such as a removed
+  public item under RUST-NO-007. Do not use it to comment on the contents of removed code; most
+  file deletions are deliberate and are not findings.
 - `"severity"`: one of `"CRITICAL"`, `"HIGH"`, `"MEDIUM"`, `"LOW"` (verbatim strings, uppercase). Design issues are typically MEDIUM or LOW unless they break the API.
 - `"id"`: exact check ID from the list above.
-- `"issue"`: one sentence, engineering English, no praise or hedging.
-- `"fix"`: one sentence, concrete and actionable (what to change, not a suggestion).
+- `"comment"`: **the inline comment body a human will read on GitHub.** 1 to 3 sentences.
+  `docs/pr-review/comment-style.md` is the contract for how it is worded, including which
+  phrasings are banned and how to keep a finding's uncertainty intact. Read it before emitting any
+  finding; its rules are deliberately not restated here, so that this file cannot drift from it.
+- `"issue"`: terse analytic restatement for the summary table and the local-mode report. One
+  sentence, engineering English, no praise or hedging. This is never posted as a comment, so it
+  does not need to read naturally.
+- `"fix"`: one sentence, concrete and actionable (what to change, not a suggestion). Table and
+  report only, like `"issue"`.

--- a/docs/pr-review/agents/toolkit-pr-review-v2-errors.md
+++ b/docs/pr-review/agents/toolkit-pr-review-v2-errors.md
@@ -27,13 +27,25 @@ supplies the concrete directory path. In the filename escaping, `/` becomes `__`
 
 Apply **only** these specific check IDs:
 
-1. **RUST-ERR-001** — Errors must preserve context and original cause. Check for `map_err(|_| ...)` patterns that discard the source error. Errors should be useful to callers, not opaque. Also flag `From` impls used for conversions that can fail (panic or silently coerce on bad input) — use `TryFrom` instead.
+1. **RUST-ERR-001** — Errors must preserve context and original cause. Check for `map_err(|_| ...)` patterns that discard the source error. Errors should be useful to callers, not opaque. Also flag `From` impls used for conversions that can fail (panic or silently coerce on bad input) — use `TryFrom` instead. Also check for:
+   - A stack of `if cond { return Err(..) }` guards where `bool::ok_or` / `bool::ok_or_else` reads better, as in `user.is_active().ok_or(Error::Inactive)?`. The receiver is the **`bool`** condition that must hold. This is the method on `bool` (unstable feature `bool_to_result`, needs Rust >= 1.98), not `Option::ok_or`, which has existed since Rust 1.0 and is never version-gated — do not apply the gate to an `Option` receiver
+   - A large error payload returned unboxed, or `Result<_, ()>` returned from an async signature. The rule itself holds on any toolchain; what is new is that `clippy::result_large_err` and `clippy::result_unit_err` now fire on `async fn` as well (needs Clippy >= 1.98), so on an older toolchain this is yours to catch rather than the lint's
 
-2. **RUST-PANIC-001** — Code should not panic at runtime except in truly exceptional conditions (e.g., internal invariant violations). Check for panic-prone patterns: unwrap/expect on fallible operations, indexing without bounds checks, panic-driven control flow.
+2. **RUST-PANIC-001** — Code should not panic at runtime except in truly exceptional conditions (e.g., internal invariant violations). Check for panic-prone patterns: unwrap/expect on fallible operations, indexing without bounds checks, panic-driven control flow. Specifically:
+   - `v[i]` or `&s[a..b]` where the index derives from external input, instead of `.get()` or a pattern match
+   - Byte-range slicing a `str` (`&s[..8]`) with externally derived bounds, which panics inside a multi-byte UTF-8 sequence. Use `s.get(..8)` or `chars().take(n)`
+   - An `is_empty()`/`len()` check decoupled from a later `v[0]`/`v[i]` access, where matching on `v.as_slice()` (`[]`, `[one]`, `[first, rest @ ..]`) lets the compiler prove the access
+   - `push`/`insert` followed by `last_mut().unwrap()`/`.expect()`, where `Vec::push_mut`, `Vec::insert_mut`, or `VecDeque::push_{front,back}_mut` hand back `&mut T` with no unwrap (needs Rust >= 1.95)
+   - An unbounded integer or char range loop (`for i in 250u8..`) that wraps, panics, or never terminates. The bug is real on any toolchain; only `clippy::for_unbounded_range` is new (needs Clippy >= 1.98)
+   - An `unwrap`/`expect` exception that does not state why the value is guaranteed. `unwrap_used` and `expect_used` are denied workspace-wide, so a bare call does not build at all; what you are looking for is a call carrying `#[allow]`/`#[expect]` with no reason attached. In service code, a startup invariant is the one defensible carve-out, and only with `#[expect(clippy::expect_used, reason = "...")]` plus a clear message; a `const` initializer is the other
+
+   Do not post the bare `unwrap()`/`expect()` call itself, nor "use `unwrap_or`/`unwrap_or_default` instead" — `Cargo.toml` `[workspace.lints]` denies `unwrap_used` and `expect_used`, so the build already rejects those.
 
 3. **RUST-NO-001** — Production code must not contain placeholder logic (e.g., `todo!()`, `unimplemented!()`, bare `panic!(...)` with no message). If present in the diff, it's a finding.
 
-4. **RUST-NO-002** — Silent failures are violations. Every error condition must be explicitly handled or propagated — not swallowed with `_ => { }` or `.ok().is_ok()` patterns that discard the error.
+4. **RUST-NO-002** — Silent failures are violations. Every error condition must be explicitly handled or propagated — not swallowed with `_ => { }` or `.ok().is_ok()` patterns that discard the error. Also flag:
+   - `iter.by_ref().peekable().peek()`, which silently consumes and discards an item. Bind the `Peekable` or call `.next()`. The bug is real on any toolchain; only `clippy::by_ref_peekable_peek` is new (needs Clippy >= 1.98), so on an older toolchain this is yours to catch
+   - `mem::forget` on a type with a `Drop` impl, which is almost always a leak bug rather than an intentional leak
 
 5. **RUST-NO-003** — Panic-driven control flow is not acceptable. Code must not use panics as a way to control program flow or signal expected conditions to the caller.
 
@@ -43,6 +55,7 @@ Apply **only** these specific check IDs:
 
 ## Checklist References
 
+- `docs/pr-review/comment-style.md` — comment voice. **Mandatory read before emitting findings.**
 - `docs/pr-review/toolkit-rust-review.md` — sections on RUST-ERR-001, RUST-PANIC-001, RUST-NO-001, RUST-NO-002, RUST-NO-003
 - `docs/pr-review/toolkit-framework-compliance-review.md` — sections on TOOLKIT-ERR-001, TOOLKIT-ERR-002 (ToolKit files only)
 
@@ -66,6 +79,7 @@ Schema (one object per finding):
   "line": 42,
   "severity": "HIGH",
   "id": "RUST-ERR-001",
+  "comment": "The original error gets dropped by `map_err(|_| ...)` here. When this fails in production we only see the generic variant, not what actually went wrong.",
   "issue": "Error context discarded by map_err(|_| ...). Original cause is lost.",
   "fix": "Replace with .context(...) from anyhow, or map to a domain error that preserves the cause."
 }
@@ -74,7 +88,19 @@ Schema (one object per finding):
 Field rules:
 - `"file"`: repo-root-relative path, exactly as it appears in the diff (strip `a/` or `b/` prefix).
 - `"line"`: integer, must be in `changed_ranges[file]` for that file. If unsure, omit the finding.
+  Exception: when `"file"` is in `deleted_files` it has no RIGHT-side line at all, so omit this
+  field entirely (do not guess a value) and the finding posts as a file-level comment. Use that
+  exception only when the deletion **itself** violates one of your check IDs, such as a removed
+  public item under RUST-NO-007. Do not use it to comment on the contents of removed code; most
+  file deletions are deliberate and are not findings.
 - `"severity"`: one of `"CRITICAL"`, `"HIGH"`, `"MEDIUM"`, `"LOW"` (verbatim strings, uppercase).
 - `"id"`: exact check ID from the list above.
-- `"issue"`: one sentence, engineering English, no praise or hedging.
-- `"fix"`: one sentence, concrete and actionable (what to change, not a suggestion).
+- `"comment"`: **the inline comment body a human will read on GitHub.** 1 to 3 sentences.
+  `docs/pr-review/comment-style.md` is the contract for how it is worded, including which
+  phrasings are banned and how to keep a finding's uncertainty intact. Read it before emitting any
+  finding; its rules are deliberately not restated here, so that this file cannot drift from it.
+- `"issue"`: terse analytic restatement for the summary table and the local-mode report. One
+  sentence, engineering English, no praise or hedging. This is never posted as a comment, so it
+  does not need to read naturally.
+- `"fix"`: one sentence, concrete and actionable (what to change, not a suggestion). Table and
+  report only, like `"issue"`.

--- a/docs/pr-review/agents/toolkit-pr-review-v2-security.md
+++ b/docs/pr-review/agents/toolkit-pr-review-v2-security.md
@@ -1,6 +1,6 @@
 ---
 name: toolkit-pr-review-v2-security
-description: "Security review sub-agent for toolkit-pr-review-v2. Covers RUST-SEC-001, RUST-NO-006, TOOLKIT-SEC-001..002. Returns JSON array only."
+description: "Security review sub-agent for toolkit-pr-review-v2. Covers RUST-SEC-001..002, RUST-NO-006, RUST-DEP-001, TOOLKIT-SEC-001..002. Returns JSON array only."
 tools: Read, Bash
 model: inherit
 ---
@@ -18,7 +18,10 @@ You are a Rust code reviewer responsible exclusively for **security** checks. Yo
 Read these files from the provided paths:
 1. `/tmp/toolkit-pr-review-v2-$REVIEW_ID/context.json` — review metadata, file lists, changed line ranges
 2. `/tmp/toolkit-pr-review-v2-$REVIEW_ID/diff.patch` — the full diff under review
-3. `/tmp/toolkit-pr-review-v2-$REVIEW_ID/files/<escaped-path>` — full source file contents
+3. `/tmp/toolkit-pr-review-v2-$REVIEW_ID/files/<escaped-path>` — full source file contents.
+   Manifest and config files listed in `manifest_files` (`Cargo.toml`, `deny.toml`,
+   `.cargo/audit.toml`, `clippy.toml`, `rust-toolchain.toml`, ...) are snapshotted here too, so
+   RUST-DEP-001 can be judged against the whole file rather than only the hunk.
 
 `$REVIEW_ID` is the PR number in PR mode, or `local-<branch-slug>` in local mode — the orchestrator
 supplies the concrete directory path. In the filename escaping, `/` becomes `__`.
@@ -32,23 +35,57 @@ Apply **only** these specific check IDs:
    - Security-sensitive randomness (tokens, session IDs, nonces) generated with a general-purpose or seeded PRNG instead of a CSPRNG
    - Outbound requests built from user-supplied URLs/hosts with no SSRF guard (destination validation/allowlisting) before the request is issued
    - Hardcoded secrets, API keys, passwords, or tokens committed literally in the diff
-   - Disabled or weakened TLS certificate validation
+   - Disabled or weakened TLS certificate validation, a TLS floor below 1.2, or mTLS that validates the client chain without checking CN/SAN (an accepted chain with no name check is not authentication)
+   - A string input with no explicit maximum length enforced before it is processed
+   - A validation pattern written as a denylist where an allowlist is meant
+   - An unvalidated identifier `format!`-interpolated into an outbound API path or URL
+   - Chained `strip_prefix`/`strip_suffix` with `unwrap_or(raw)` where `str::strip_circumfix` strips matching delimiters atomically. The chained form silently accepts half-delimited input, which matters for quoted header values and bracketed IPv6 in `Forwarded`/RFC 7239 parsing that feeds rate limiting or allowlists (needs Rust >= 1.98)
+   - UTF-16 decoded without stated endianness, or decoded with a `_lossy` variant on security-relevant input: `String::from_utf16le`/`from_utf16be` name the endianness and skip the intermediate `Vec<u16>`, and the fallible form matters because U+FFFD substitution collapses distinct malformed inputs and defeats allowlist comparison (needs Rust >= 1.98)
+   - A secret held in a plain `String` field rather than wrapped (`secrecy::Secret<String>`), so it neither zeroizes on drop nor redacts in `Debug`/`Display`. A plain field leaks through any `{:?}` log line
 
-2. **RUST-NO-006** — Unsafe blocks are permitted only when necessary for FFI or performance-critical code with formal justification. Every `unsafe` block must have a comment explaining WHY it is safe (the invariant being relied on, not just what the code does). Unsafe code without justification is a finding.
+2. **RUST-SEC-002** — HTTP response security headers and fingerprint suppression. Applies when the diff adds or changes a router, server bootstrap, or response middleware. Check that the OWASP Secure Headers set is applied once from a single tower layer: HSTS `max-age=63072000; includeSubDomains`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: deny`, CSP `default-src 'self'; object-src 'none'; frame-ancestors 'none'`, `Referrer-Policy: no-referrer`, a restrictive `Permissions-Policy`, COOP/COEP/CORP for browser-facing responses, and `Cache-Control: no-store` on API responses carrying per-user data. Also flag any `Server` or `X-Powered-By` header, and any `X-*` header carrying a build hash, internal hostname, or tracing ID. Post the missing-header finding once at the router, not per route; a header set applied per handler instead of as a layer is its own finding, since the next route will forget it.
 
-3. **TOOLKIT-SEC-001** — All database access must use `SecureConn` (or `SecureORM` for ORM queries). Direct SQL execution or raw connections are violations. This applies only to files in `toolkit_owned_files`.
+3. **RUST-NO-006** — Unsafe blocks are permitted only when necessary for FFI or performance-critical code with formal justification. Every `unsafe` block must have a comment explaining WHY it is safe (the invariant being relied on, not just what the code does). Unsafe code without justification is a finding.
 
-4. **TOOLKIT-SEC-002** — Authorization checks must be enforced via `PolicyEnforcer` before granting access to protected resources. No bypass of authorization logic; no "trust the caller" patterns. This applies only to files in `toolkit_owned_files`.
+   **Before applying this check**, note that `Cargo.toml` `[workspace.lints.rust]` sets
+   `unsafe_code = "forbid"`, and `forbid` cannot be overridden locally. Apply the criteria below
+   **only** to a crate that deliberately opts out of the workspace lint block; do not post them
+   against a crate that inherits `forbid`. In an opted-out crate, check for:
+   - `sub.as_ptr().offset_from(parent.as_ptr())` to recover a sub-slice offset, where `str::substr_range` / `[T]::subslice_range` return `Option` and need no `unsafe` (needs Rust >= 1.98; `subslice_range` panics for zero-sized element types)
+   - A transmute or `slice::from_raw_parts_mut` cast of a plain buffer to `[AtomicU32]`, where `Atomic::from_mut` / `from_mut_slice` / `get_mut_slice` apply: `&mut` already proves exclusivity (needs Rust >= 1.98)
+   - `*(p as *const u16)` or `ptr::read::<u16>` on a pointer derived from a `&[u8]`. Both require T-alignment and are UB or a hardware trap on non-x86 targets. Use `u16::from_le_bytes(buf.get(a..b).ok_or(..)?.try_into().map_err(..)?)`, or `core::ptr::read_unaligned` with a `// SAFETY:` comment. Never `try_into().unwrap()`
+   - `#[unsafe(no_mangle)]`, `#[unsafe(link_section)]`, `#[unsafe(export_name)]`, `#[unsafe(naked)]` in a crate still on `forbid`: they now trip `unsafe_code`, so the crate must move to `deny` plus a justified per-item `#[allow(unsafe_code)]` (needs Rust >= 1.98)
+   - Definitions of runtime-reserved symbols (`memcmp`, `memset`, `strlen`), or a `core::ffi::c_void` return from an `extern "C"` shim (needs Rust >= 1.98)
+   - Pointer casts that change alignment requirements, and raw-pointer arguments dereferenced in a safe fn
+   Do not demand Miri coverage on a crate with `unsafe_code = "forbid"`, on an FFI-heavy crate, or on a bare-metal target.
+
+4. **RUST-DEP-001** — Dependency and advisory manifest hygiene. **Gated: skip this check entirely when `manifest_files` in `context.json` is empty or absent.** Apply it only to files listed there. Check for:
+   - A dependency added with a `git = ...` source or a non-crates.io `registry = ...` source: supply-chain surface with no advisory or vet coverage
+   - A RUSTSEC id added to `ignore = [...]` in `.cargo/audit.toml` or `deny.toml` with no comment saying why it does not apply to this code. This is the highest-signal finding in the rule: it converts a known vulnerability into a silent one
+   - `.cargo/audit.toml` and `deny.toml` drifting apart, with an advisory accepted in one but not the other. When the diff touches only one of the two, the other is snapshotted in `files/` as read-only context even though it is unchanged, so you can compare them. It is deliberately absent from `manifest_files` and has no `changed_ranges` entry: anchor the finding on the file the PR actually changed, or it will be dropped. If the counterpart is missing from `files/` it does not exist in the repo, so there is nothing to drift from and this is not a finding
+   - A `[lints.*]` group entry (`all`, `pedantic`, `nursery`) added without `priority = -1`; Cargo rejects the manifest as soon as any per-lint override exists
+   - A lint declared that no longer exists (`string_to_string`, `from_iter_instead_of_collect` now emit `unknown_lints`)
+   - `unsafe_code` downgraded from `forbid` to `deny` with no justified per-item `#[allow(unsafe_code)]` accompanying the change
+   - The `deny.toml` license allowlist widened, or `[sources]` loosened, with no stated reason
+   - A `rust-toolchain.toml` pin change: call it out, since it shifts which version-gated criteria are live across the whole catalog
+   Wildcard version specifications are already denied (`clippy wildcard_dependencies`), so do not post those.
+
+5. **TOOLKIT-SEC-001** — All database access must use `SecureConn` (or `SecureORM` for ORM queries). Direct SQL execution or raw connections are violations. This applies only to files in `toolkit_owned_files`.
+
+6. **TOOLKIT-SEC-002** — Authorization checks must be enforced via `PolicyEnforcer` before granting access to protected resources. No bypass of authorization logic; no "trust the caller" patterns. This applies only to files in `toolkit_owned_files`.
 
 ## Checklist References
 
-- `docs/pr-review/toolkit-rust-review.md` — sections on RUST-SEC-001, RUST-NO-006
+- `docs/pr-review/comment-style.md` — comment voice. **Mandatory read before emitting findings.**
+- `docs/pr-review/toolkit-rust-review.md` — sections on RUST-SEC-001, RUST-SEC-002, RUST-NO-006, RUST-DEP-001
 - `guidelines/SECURITY.md` — input validation patterns, secrets management, SecureORM usage
 - `docs/pr-review/toolkit-framework-compliance-review.md` — sections on TOOLKIT-SEC-001, TOOLKIT-SEC-002 (ToolKit files only)
 
 ## Scope Rules
 
-- Apply RUST-* checks to all files in `rust_files` from context.json.
+- Apply RUST-SEC-001, RUST-SEC-002 and RUST-NO-006 to all files in `rust_files` from context.json.
+- Apply RUST-DEP-001 **only** to files listed in `manifest_files`. When `manifest_files` is empty or absent, skip that check entirely and report nothing for it.
+- A manifest file that is also in `deleted_files` was removed outright. Its snapshot in `files/` is the **base** content, so read it there to see what the PR dropped. Deleting `deny.toml` or `.cargo/audit.toml` removes a supply-chain control and is a RUST-DEP-001 finding in its own right; emit it with **no** `line` field at all (the file has no RIGHT-side line), the same way Agent F reports a wholly deleted test file. Do not skip it for lack of a line.
 - Apply TOOLKIT-SEC-* checks only to files listed in `toolkit_owned_files`.
 - Focus on lines added or modified in the diff (use `changed_ranges` from context.json to verify line numbers).
 - If a line number is outside the changed ranges for its file, omit the finding — do not guess.
@@ -66,6 +103,7 @@ Schema (one object per finding):
   "line": 42,
   "severity": "CRITICAL",
   "id": "RUST-SEC-001",
+  "comment": "This interpolates the raw request value straight into the query. Anything the caller sends lands in the SQL text.",
   "issue": "User input passed directly to database query without validation or parameterization.",
   "fix": "Validate input against a whitelist or use parameterized queries; never concatenate user input into SQL."
 }
@@ -73,8 +111,15 @@ Schema (one object per finding):
 
 Field rules:
 - `"file"`: repo-root-relative path, exactly as it appears in the diff (strip `a/` or `b/` prefix).
-- `"line"`: integer, must be in `changed_ranges[file]` for that file. If unsure, omit the finding.
+- `"line"`: integer, must be in `changed_ranges[file]` for that file. If unsure, omit the finding. Omit this field entirely (do not guess a value) when `"file"` is in `deleted_files` — that finding posts as a file-level comment.
 - `"severity"`: one of `"CRITICAL"`, `"HIGH"`, `"MEDIUM"`, `"LOW"` (verbatim strings, uppercase). Security findings are typically CRITICAL or HIGH.
 - `"id"`: exact check ID from the list above.
-- `"issue"`: one sentence, engineering English, no praise or hedging.
-- `"fix"`: one sentence, concrete and actionable (what to change, not a suggestion).
+- `"comment"`: **the inline comment body a human will read on GitHub.** 1 to 3 sentences.
+  `docs/pr-review/comment-style.md` is the contract for how it is worded, including which
+  phrasings are banned and how to keep a finding's uncertainty intact. Read it before emitting any
+  finding; its rules are deliberately not restated here, so that this file cannot drift from it.
+- `"issue"`: terse analytic restatement for the summary table and the local-mode report. One
+  sentence, engineering English, no praise or hedging. This is never posted as a comment, so it
+  does not need to read naturally.
+- `"fix"`: one sentence, concrete and actionable (what to change, not a suggestion). Table and
+  report only, like `"issue"`.

--- a/docs/pr-review/agents/toolkit-pr-review-v2-tests.md
+++ b/docs/pr-review/agents/toolkit-pr-review-v2-tests.md
@@ -1,6 +1,6 @@
 ---
 name: toolkit-pr-review-v2-tests
-description: "Test quality review sub-agent for toolkit-pr-review-v2. Covers RUST-TEST-001 and 9 test anti-patterns. Returns JSON array only."
+description: "Test quality review sub-agent for toolkit-pr-review-v2. Covers RUST-TEST-001 and 10 test anti-patterns. Returns JSON array only."
 tools: Read, Bash
 model: inherit
 ---
@@ -42,6 +42,8 @@ Tests must exercise the actual behavior of the code, not just "it compiles" or "
 - Tests must include edge cases and error paths, not only happy paths.
 - Complex logic must have multiple tests covering different scenarios.
 - If a function is added or changed but has no tests, it's a finding.
+- New parser, validator, or serde-roundtrip code should carry at least one property-based test (`proptest`/`quickcheck`): no panic on arbitrary input, and roundtrip identity. Point examples alone are a finding for this class of code.
+- Check tier placement. A test that needs live services or network access must not land in the unit tier; it belongs under `tests/integration` or `tests/e2e`, with the tier stated, so the default suite stays runnable without external dependencies.
 
 ### TEST-QUALITY-1 — Constructor Echo
 
@@ -139,6 +141,18 @@ fn test_config() {
 
 **Finding**: If a test relies solely on snapshot assertions (insta, pretty_assertions snapshots, etc.) without also asserting on specific properties or behavior, flag it as TEST-QUALITY-8.
 
+The other shape to catch is an assertion on a `Debug` rendering:
+
+```rust
+assert_eq!(format!("{:?}", cfg), "Config { path: \"/tmp/x\" }");
+```
+
+`Debug` output is not a stable format, and Rust 1.98 escapes more characters than earlier
+versions, so this can start failing with no change to the code under test. Assert on the data, or
+on an owned `render_*()` method whose format the type actually promises. The risk is highest in
+audit-log and redaction tests, where the assertion is often the only thing checking that a secret
+stays masked.
+
 ### TEST-QUALITY-9 — Suppressed or Deleted Failing Test
 
 **Anti-pattern**: A previously-failing test is deleted, weakened (assertion loosened or removed), or marked `#[ignore]` in the diff, with no linked follow-up issue or clear justification.
@@ -151,10 +165,34 @@ fn test_config() {
 
 Do not omit either case for lack of a line — see Scope Rules and Output Contract.
 
+### TEST-QUALITY-10 — Assertion-Macro Temporaries
+
+**Anti-pattern**: A guard, lock, or `RefCell` borrow created inline inside `assert_eq!` / `assert_ne!` instead of being bound to a `let` first.
+
+```rust
+assert_eq!(shared.lock().unwrap().len(), 1);
+```
+
+**Problem**: Rust 1.98 added a temporary scope to these macros, so the temporary now drops at the end of the assertion rather than the end of the statement. That changes borrow-checker outcomes: a test that compiled before can stop compiling, and a lock-held-too-long bug the old code exposed can be masked.
+
+**Finding**: Flag as TEST-QUALITY-10 and ask for the value to be read inside a short block, with the assertion on the copy:
+
+```rust
+let len = { shared.lock().unwrap().len() };
+assert_eq!(len, 1);
+```
+
+Do not ask for a bare `let guard = shared.lock().unwrap();` at statement level: that holds the lock
+for the rest of the scope, and any later `shared.lock()` in the same test deadlocks on a
+non-reentrant `std::sync::Mutex`. A guard should outlive the block only when several reads must be
+atomic, and then it should be scoped explicitly. Applies only on Rust >= 1.98 — check the toolchain
+pin before flagging.
+
 ---
 
 ## Checklist References
 
+- `docs/pr-review/comment-style.md` — comment voice. **Mandatory read before emitting findings.**
 - `docs/pr-review/toolkit-tests-quality-review.md` — full anti-pattern definitions and examples
 - Code under review in the diff
 
@@ -184,6 +222,7 @@ Schema (one object per finding):
   "line": 42,
   "severity": "MEDIUM",
   "id": "TEST-QUALITY-1",
+  "comment": "This only checks that the constructor stored what we passed it. It will keep passing if the logic underneath breaks.",
   "issue": "Constructor echo: test only verifies the constructor stores its input.",
   "fix": "Test behavior that depends on the constructor, not just the constructor itself."
 }
@@ -195,6 +234,7 @@ For a `TEST-QUALITY-9` finding whose `"file"` is listed in `context.json`'s `del
   "file": "gears/foo/tests/dead_letter.rs",
   "severity": "HIGH",
   "id": "TEST-QUALITY-9",
+  "comment": "The whole test file is gone with nothing linked. Was it failing? If so we lose the coverage and the signal.",
   "issue": "Test file was deleted wholesale with no linked follow-up.",
   "fix": "Restore the test or open a tracked issue and reference it in the PR description."
 }
@@ -204,6 +244,13 @@ Field rules:
 - `"file"`: repo-root-relative path, exactly as it appears in the diff (strip `a/` or `b/` prefix).
 - `"line"`: integer, must be in `changed_ranges[file]` for that file. If unsure, omit the finding. Omit this field entirely (do not set it to a guessed value) when `"file"` is in `deleted_files`.
 - `"severity"`: one of `"CRITICAL"`, `"HIGH"`, `"MEDIUM"`, `"LOW"` (verbatim strings, uppercase). Test quality issues are typically MEDIUM or LOW.
-- `"id"`: exact check ID: `"RUST-TEST-001"` for coverage gaps, or `"TEST-QUALITY-1"` through `"TEST-QUALITY-9"` for anti-patterns.
-- `"issue"`: one sentence, engineering English, no praise or hedging.
-- `"fix"`: one sentence, concrete and actionable (what to change, not a suggestion).
+- `"id"`: exact check ID: `"RUST-TEST-001"` for coverage gaps, or `"TEST-QUALITY-1"` through `"TEST-QUALITY-10"` for anti-patterns.
+- `"comment"`: **the inline comment body a human will read on GitHub.** 1 to 3 sentences.
+  `docs/pr-review/comment-style.md` is the contract for how it is worded, including which
+  phrasings are banned and how to keep a finding's uncertainty intact. Read it before emitting any
+  finding; its rules are deliberately not restated here, so that this file cannot drift from it.
+- `"issue"`: terse analytic restatement for the summary table and the local-mode report. One
+  sentence, engineering English, no praise or hedging. This is never posted as a comment, so it
+  does not need to read naturally.
+- `"fix"`: one sentence, concrete and actionable (what to change, not a suggestion). Table and
+  report only, like `"issue"`.

--- a/docs/pr-review/agents/toolkit-pr-review-v2-toolkit.md
+++ b/docs/pr-review/agents/toolkit-pr-review-v2-toolkit.md
@@ -63,6 +63,7 @@ Apply **only** to files listed in `toolkit_owned_files`, and apply **only** thes
 
 ## Checklist References
 
+- `docs/pr-review/comment-style.md` — comment voice. **Mandatory read before emitting findings.**
 - `docs/pr-review/toolkit-framework-compliance-review.md` — full definitions and examples for all TOOLKIT-* checks
 - `docs/toolkit_unified_system/README.md` — authoritative reference for ToolKit architecture
 
@@ -85,6 +86,7 @@ Schema (one object per finding):
   "line": 42,
   "severity": "CRITICAL",
   "id": "TOOLKIT-DB-002",
+  "comment": "This runs raw SQL outside a migration, so it bypasses the ORM scoping the rest of the layer relies on.",
   "issue": "Raw SQL executed outside a migration file.",
   "fix": "Route the query through the ORM or a repository abstraction instead of inline SQL."
 }
@@ -93,7 +95,19 @@ Schema (one object per finding):
 Field rules:
 - `"file"`: repo-root-relative path, exactly as it appears in the diff (strip `a/` or `b/` prefix). Must be in `toolkit_owned_files`.
 - `"line"`: integer, must be in `changed_ranges[file]` for that file. If unsure, omit the finding.
+  Exception: when `"file"` is in `deleted_files` it has no RIGHT-side line at all, so omit this
+  field entirely (do not guess a value) and the finding posts as a file-level comment. Use that
+  exception only when the deletion **itself** violates one of your check IDs, such as a removed
+  public item under RUST-NO-007. Do not use it to comment on the contents of removed code; most
+  file deletions are deliberate and are not findings.
 - `"severity"`: one of `"CRITICAL"`, `"HIGH"`, `"MEDIUM"`, `"LOW"` (verbatim strings, uppercase). TOOLKIT-DB-* violations are typically CRITICAL or HIGH.
 - `"id"`: exact check ID from the list above (TOOLKIT-CORE-*, TOOLKIT-REST-*, TOOLKIT-DB-*, TOOLKIT-CLIENT-*, TOOLKIT-ODATA-*, TOOLKIT-OOP-*).
-- `"issue"`: one sentence, engineering English, no praise or hedging.
-- `"fix"`: one sentence, concrete and actionable (what to change, not a suggestion).
+- `"comment"`: **the inline comment body a human will read on GitHub.** 1 to 3 sentences.
+  `docs/pr-review/comment-style.md` is the contract for how it is worded, including which
+  phrasings are banned and how to keep a finding's uncertainty intact. Read it before emitting any
+  finding; its rules are deliberately not restated here, so that this file cannot drift from it.
+- `"issue"`: terse analytic restatement for the summary table and the local-mode report. One
+  sentence, engineering English, no praise or hedging. This is never posted as a comment, so it
+  does not need to read naturally.
+- `"fix"`: one sentence, concrete and actionable (what to change, not a suggestion). Table and
+  report only, like `"issue"`.

--- a/docs/pr-review/comment-style.md
+++ b/docs/pr-review/comment-style.md
@@ -1,0 +1,135 @@
+---
+cf: true
+type: requirement
+name: PR Review Comment Style
+version: 1.0
+purpose: Single source of truth for the voice of PR review comments
+---
+
+# PR Review Comment Style
+
+This file defines how review comments are worded. It is the only place comment voice is
+specified. Every review sub-agent reads it before emitting findings.
+
+**Scope**: this governs the `comment` field of a finding, which becomes the inline comment body
+posted on GitHub. The terminal summary table and the local-mode markdown report use the separate
+`issue` and `fix` fields and keep their terse, fixed-shape phrasing. A table is a report, not a
+conversation.
+
+The goal is a comment that reads as if an experienced engineer wrote it during a real code
+review. Never change the technical meaning of a finding to make it sound better.
+
+## Goals
+
+- Concise and direct.
+- Write like an engineer talking to another engineer, not like an assistant or a formal report.
+- Prefer 1 to 3 short sentences.
+- Focus only on the actual issue found in the code.
+- State the problem first, then briefly explain why it matters if it is not already obvious.
+- Suggest a concrete fix only when it is useful.
+
+## Preserve
+
+- Filenames, identifiers, code snippets, error cases, and technical details.
+- Uncertainty. If the finding is uncertain, the comment stays uncertain.
+- Do not turn a definite bug into a vague suggestion.
+- Do not turn an uncertain observation into a definite claim.
+- Do not invent additional issues or assumptions.
+
+## Do not write like this
+
+Avoid these openers and hedges:
+
+- "Consider..."
+- "It might be beneficial to..."
+- "You may want to..."
+- "It would be better to..."
+- "This could potentially..."
+- "This is a great implementation, but..."
+- "Overall..."
+- "To improve..."
+- "For better maintainability..."
+- "For robustness..."
+- "This approach introduces a potential issue where..."
+- "I would recommend..."
+- "It is worth noting that..."
+- "Ensure that..."
+- "Please note that..."
+
+## Write like this
+
+- "This breaks when..."
+- "This can return X when..."
+- "We lose X here."
+- "This needs to happen before X."
+- "Why do we need X here?"
+- "Can we reuse X instead?"
+- "This should probably be X because..."
+- "I think this is missing X."
+- "This looks racy."
+- "We shouldn't hold the lock while doing X."
+- "This error gets swallowed here."
+- "This changes the existing behavior for X."
+- "Looks like this can panic if X is empty."
+- "Can we add a test for X?"
+
+## Style rules
+
+1. No headings like "Issue", "Problem", "Recommendation", "Impact", or "Suggested fix".
+2. Do not repeat or summarize the code unless it is needed to explain the bug.
+3. Do not explain basic programming concepts to the author.
+4. Do not over-explain obvious consequences.
+5. No praise or filler before criticism.
+6. Do not make every comment polite in the same artificial way.
+7. Questions are fine when something genuinely needs clarification.
+8. Do not turn definite bugs into vague suggestions.
+9. Do not turn uncertain observations into definite claims.
+10. No emojis.
+11. No em dashes. Use a comma, a period, or a colon.
+12. Never mention how the comment was produced.
+13. Keep existing Markdown and code formatting where it helps.
+14. Each comment must be independently understandable in the context of its code line.
+15. Simple English, appropriate for an international engineering team.
+
+## Examples
+
+Avoid:
+> "Consider handling the error returned by `send()`. Ignoring this error could potentially lead
+> to silent failures and make debugging more difficult."
+
+Write:
+> "The error from `send()` is ignored here. If the receiver is closed, we'll silently lose the
+> message."
+
+Avoid:
+> "It might be beneficial to move this check before acquiring the lock to reduce unnecessary lock
+> contention."
+
+Write:
+> "Can we do this check before taking the lock? It doesn't depend on the protected state."
+
+Avoid:
+> "This implementation could potentially result in a race condition if multiple requests attempt
+> to update the same entry concurrently."
+
+Write:
+> "This looks racy. Two requests can read the same value and then overwrite each other's update."
+
+Avoid:
+> "Consider adding a test case to verify the behavior when the token is expired."
+
+Write:
+> "Can we add a test for an expired token?"
+
+Avoid:
+> "The current implementation loads the entire response into memory, which may have negative
+> implications for memory usage when processing large responses."
+
+Write:
+> "This buffers the whole response in memory. That's a problem for large/streaming responses."
+
+Avoid:
+> "Ensure that `tenant_id` is validated before performing the database query."
+
+Write:
+> "`tenant_id` needs to be validated before this query."

--- a/docs/pr-review/toolkit-rust-review.md
+++ b/docs/pr-review/toolkit-rust-review.md
@@ -20,6 +20,25 @@ The checklist has two tiers:
 1. **Architecture review** — run once at the PR level before reading any file. Catches structural and design-level problems that span multiple files or are invisible inside a single hunk.
 2. **Code review** — run per-file. Catches implementation-level problems in the diff.
 
+### Bullet markers
+
+Some criteria carry an inline marker. Both change whether you may post a finding.
+
+- `Requires Rust >= X.Y` — the rule depends on an API or compiler behavior newer than the
+  baseline. Check `rust-toolchain.toml` (currently `1.97.0`) and the workspace
+  `rust-version` (currently `1.95.0`) before flagging. Never flag code for failing to use an API
+  that is newer than the pinned toolchain, and never flag code for failing to use an API newer
+  than the declared MSRV in a crate that must honor it.
+- `Requires Clippy >= X.Y` — only the **lint coverage** is newer, not the rule. The underlying
+  problem is a finding on any toolchain; the marker just tells you whether CI catches it for you.
+  Never skip one of these because the toolchain is older, which is the opposite of how
+  `Requires Rust >= X.Y` works.
+- `Enforcement: clippy <lint> (deny)` — the rule is already denied in `Cargo.toml`
+  `[workspace.lints]`, so a violation fails the build on its own. Keep it in mind while reading
+  the code, but **do not post it as a finding**: it falls under the existing rule that
+  clippy-catchable issues are dropped. `Enforcement: review-only` means no lint covers it and it
+  is yours to catch.
+
 ## Review Goals
 
 Review the PR as a senior Rust engineer. Prioritize:
@@ -52,9 +71,13 @@ For each issue include:
 
 ### Rules for reporting
 
+Comment wording is defined in one place only: `docs/pr-review/comment-style.md`. Read it before
+writing findings. The rules below are about *what* to report, not how to word it.
+
 - Report only problems, not praise
 - Do not invent issues without evidence
 - Do not complain about style that `rustfmt` should handle
+- Do not report anything marked `Enforcement: clippy ... (deny)` — the build already rejects it
 - Do not demand speculative abstractions
 - Prefer concrete Rust-specific guidance over generic OO theory
 - If something cannot be verified from the diff or context, do not state it as fact
@@ -113,6 +136,12 @@ Check that public APIs follow idiomatic Rust conventions.
 - Flag more than 2-3 boolean parameters on one function — use an options struct, enum, or builder instead
 - Validating constructors should return `Result`, not panic or silently clamp invalid input
 - Flag `Deref`/`DerefMut` impls used to simulate inheritance on a wrapper type — this leaks the inner type's full API and blurs ownership; prefer explicit delegation methods or a trait
+- Flag third-party types in public signatures (`reqwest::Error`, `sqlx::Row`, `hyper::Uri`) — wrap them so the dependency can be swapped without a breaking change
+- Public config and value types should implement both `Default` (so `unwrap_or_default` and generic containers work) and an inherent `new()`
+- Library value types should keep fields private behind a validated constructor; `pub` fields make every invariant a caller responsibility and are a semver commitment
+- Flag a hand-rolled `match` on a kind/tag field that dispatches behavior — take a trait object or an `Fn` strategy parameter instead
+- When the orphan rule blocks `impl ForeignTrait for ForeignType`, use a newtype wrapper, not a local extension trait or a free helper
+- New public types should implement `Debug`, and new `pub` items in a library crate need `///` docs. `Enforcement: clippy missing_errors_doc, missing_panics_doc (deny)` for the error/panic sections; the type-level `Debug` impl and the item doc itself are review-only
 
 ---
 
@@ -132,6 +161,15 @@ Check that public APIs follow idiomatic Rust conventions.
 - Prefer exhaustive `match` over a wildcard `_ =>` catch-all on crate-owned enums, so a new variant forces a compile error at call sites instead of silently falling through
 - Use `#[non_exhaustive]` on public enums/structs expected to grow variants or fields later
 - Use `#[must_use]` on results that are easy to drop by accident (builders, "must be applied" configs, guards)
+- No bare `as` for numeric conversion: widening uses `u64::from(x)`, narrowing uses `TryFrom` with a real error path, and pointer casts use `.cast::<T>()` so constness is preserved. `Enforcement: clippy cast_possible_truncation, cast_possible_wrap, cast_precision_loss, cast_sign_loss (deny)` for the lossy cases; lossless widening (`cast_lossless`) and pointer casts (`ptr_as_ptr`) are review-only
+- Comparison traits are all-manual or all-derived over the same field set — `a == b` must hold exactly when `cmp` returns `Equal`. A hand-written `PartialEq` next to a derived `Ord` (or the reverse) is a latent inconsistency. `Requires Rust >= 1.98` for the derive fast path that exposes it
+- A type with a manual `PartialEq` cannot be used in a constant pattern. `Requires Rust >= 1.98`
+- Do not apply `#[repr(transparent)]` over a `#[non_exhaustive]`, `repr(C)`, or private-field type; keep it only for real ABI or `transmute` needs. `Requires Rust >= 1.98`
+- Parse non-zero domain values with `NonZero::<u32>::from_str_radix(s, 10)?` instead of `parse()` followed by `NonZero::new(..).ok_or(..)`, so zero is a parse error rather than a second failure mode. `Requires Rust >= 1.98`
+- Manual `PartialEq`/`Hash`/`Debug`/`Ord` impls should destructure `Self { .. }` and name every ignored field, so adding a field breaks the build instead of silently changing semantics. `Enforcement: clippy missing_fields_in_debug (deny)` for `Debug` only; the other impls are review-only
+- In destructuring patterns prefer a named ignore (`has_fuel: _`) over a bare `_` or `..`, so the reader sees which fields were deliberately unused
+- Flag `..Default::default()` in a struct literal for a crate-owned config or request type — a field added later is silently defaulted at every construction site instead of forcing a compile error. List the fields explicitly
+- Note when reviewing exhaustiveness: `if let` guards do not participate in exhaustiveness checking, so a `match` that looks total may not be. `Requires Rust >= 1.95`
 
 ---
 
@@ -150,6 +188,8 @@ Check that public APIs follow idiomatic Rust conventions.
 - Flag generic error wrapping that hides root cause without reason
 - Prefer propagation with context over ad hoc stringification
 - Use `TryFrom`, not `From`, for conversions that can fail — a `From` impl that panics or silently coerces on bad input is a correctness bug
+- Prefer `bool::ok_or` / `bool::ok_or_else` over a stack of `if cond { return Err(..) }` guards: the receiver is the **`bool`** condition that must hold, as in `user.is_active().ok_or(Error::Inactive)?`. This is the method on `bool` (unstable feature `bool_to_result`), not the long-standing `Option::ok_or`, which needs no version gate. `Requires Rust >= 1.98`
+- Box large error payloads, and never return `Result<_, ()>` from an async signature — the `clippy::result_large_err` and `clippy::result_unit_err` lints now fire on `async fn` too. The underlying rule holds on any toolchain; only the lint coverage on `async fn` is new. `Requires Clippy >= 1.98`
 
 ---
 
@@ -163,8 +203,15 @@ Check that public APIs follow idiomatic Rust conventions.
 
 **Review guidance**:
 - In library code, panic is usually a much stronger smell
-- In service code, `expect()` may be acceptable only for startup invariants with a very clear message
+- In service code, `expect()` may be acceptable only for startup invariants, and only when the call carries `#[expect(clippy::expect_used, reason = "...")]` plus a very clear message. `expect_used` is denied workspace-wide, so an unannotated `expect()` does not build; the annotation is what makes the carve-out real
+- Every `unwrap`/`expect` exception must state why the value is guaranteed `Some`/`Ok`. A `const` initializer is the only broadly defensible case. `Enforcement: clippy unwrap_used, expect_used (deny)` for the bare call; the missing justification is review-only
 - Flag panic-prone code in request paths, workers, retries, background tasks, and data pipelines
+- When a missing value has a sensible default, the fix for `unwrap()` is `unwrap_or`/`unwrap_or_else`/`unwrap_or_default`, not a justification comment. `Enforcement: clippy unwrap_used (deny)`
+- Flag `push`/`insert` followed by `last_mut().unwrap()` or `.expect()` — `Vec::push_mut`, `Vec::insert_mut`, and `VecDeque::push_{front,back}_mut` hand back `&mut T` with no unwrap at all. `Requires Rust >= 1.95`
+- Flag an `is_empty()`/`len()` check decoupled from a later `v[0]`/`v[i]` access — match on `v.as_slice()` (`[]`, `[one]`, `[first, rest @ ..]`) so the compiler proves the access instead of the reviewer
+- Flag `v[i]` or `&s[a..b]` where the index derives from external input — use `.get()` or a pattern match
+- Byte-range slicing a `str` (`&s[..8]`) with externally derived bounds panics inside a multi-byte UTF-8 sequence — use `s.get(..8)` or `chars().take(n)`
+- Flag an unbounded integer or char range loop (`for i in 250u8..`) — it wraps, panics, or never terminates. The bug is real on any toolchain; only the `clippy::for_unbounded_range` lint is new. `Requires Clippy >= 1.98`
 
 ---
 
@@ -186,6 +233,9 @@ Check that public APIs follow idiomatic Rust conventions.
 - Fallible functions that take ownership of an argument should return that value inside the error so the caller can retry without re-cloning
 - Flag a single lifetime parameter used to bound both an input argument and a stored/returned reference — it over-constrains callers; use separate lifetimes
 - Prefer RAII guard types (custom `Drop`) over manual acquire/release call pairs
+- Flag a clone, `RefCell`, or `Arc` introduced only to borrow two fields of the same struct — decompose the struct into independently borrowable parts instead
+- `move` closures and spawned tasks should capture the narrowest value: rebind in a scope block (`let db = Arc::clone(&db);`) rather than capturing `self` or a whole context. Spell a refcount bump `Arc::clone(&x)`, never `x.clone()`, so it is distinguishable from a deep clone
+- Prefer confining `mut` to an initialization block (`let x = { let mut x = ..; x.sort(); x };`) over a binding that stays mutable long after setup
 
 ---
 
@@ -207,6 +257,8 @@ Check that public APIs follow idiomatic Rust conventions.
 - Functions holding partial or shared state across `.await` points should be auditable for cancel-safety — consider what happens if the future is dropped mid-await via `select!` or a timeout
 - `Drop` cannot `.await` — audit `Drop` impls on async-held resources (transactions, connections, guards) for cleanup that actually needs an async call; it must be handled explicitly, not assumed to run via `Drop`
 - CPU-bound async loops should yield periodically (`tokio::task::yield_now()`) so they do not starve other tasks on the same executor thread
+- Every async fn reachable from `select!`, `timeout`, or an abortable task should carry a `// cancel-safe: <reason>` or `// NOT cancel-safe: <reason>` comment. "All awaits are idempotent" is not a valid reason, and per-call semantics differ: `read` is cancel-safe, `read_exact` is not
+- `await_holding_lock` and `await_holding_refcell_ref` are necessary but not sufficient — hand-review every `Mutex` import in an async module. A guard returned from a helper, stored in a struct field, or produced by `MutexGuard::map` escapes the lint entirely. `Enforcement: clippy await_holding_lock, await_holding_refcell_ref (deny)` for the direct shape only; the escaping shapes are review-only
 
 ---
 
@@ -224,6 +276,7 @@ Check that public APIs follow idiomatic Rust conventions.
 - Prefer ownership transfer and message passing over pervasive shared state
 - Flag `Arc<Mutex<_>>` used as a default design habit
 - Flag nested locking or lock ordering hazards
+- Prefer `Atomic*::update` / `try_update` over a hand-rolled `compare_exchange` retry loop. `Requires Rust >= 1.95`
 
 ---
 
@@ -241,10 +294,39 @@ Check that public APIs follow idiomatic Rust conventions.
 - Flag security checks implemented too deep or too late
 - Flag implicit trust in upstream data without validation
 - Never leak internal details (stack traces, file paths, SQL text, dependency versions) in error responses returned to external callers
-- Security-sensitive randomness (tokens, session IDs, nonces) must use a CSPRNG, never a general-purpose or seeded PRNG
+- Security-sensitive randomness (tokens, session IDs, nonces) must use a CSPRNG — `OsRng` or `getrandom`, never `rand::thread_rng()` or a seeded PRNG
 - Outbound requests built from user-supplied URLs or hosts must guard against SSRF (validate/allowlist the destination, block internal/link-local ranges) before the request is issued
 - Flag hardcoded secrets, API keys, passwords, or tokens committed literally in the diff
-- Flag disabled or weakened TLS certificate validation
+- Flag disabled or weakened TLS certificate validation, and require a TLS floor of 1.2 or higher. For mTLS, the client chain must be validated *and* the CN/SAN checked — an accepted chain with no name check is not authentication
+- Every string input needs an explicit maximum length enforced before it is processed
+- Validation patterns must be allowlists, not denylists
+- Never `format!`-interpolate an unvalidated identifier into an outbound API path or URL; validate the charset first
+- Strip matching delimiters atomically with `str::strip_circumfix`. Chained `strip_prefix`/`strip_suffix` with `unwrap_or(raw)` silently accepts half-delimited input, which matters for quoted header values and bracketed IPv6 in `Forwarded`/RFC 7239 parsing that feeds rate limiting or allowlists. `Requires Rust >= 1.98`
+- Decode UTF-16 with `String::from_utf16le`/`from_utf16be` (endianness stated in the name, no intermediate `Vec<u16>`), and use the fallible form rather than `_lossy` on security-relevant input — U+FFFD substitution collapses distinct malformed inputs and defeats allowlist comparison. `Requires Rust >= 1.98`
+- Secrets held in memory must be wrapped (`secrecy::Secret<String>`) so they zeroize on drop and redact in `Debug`/`Display`. A plain `String` field in a config struct leaks through any `{:?}` log line
+
+---
+
+## RUST-SEC-002: HTTP Response Security Headers and Fingerprint Suppression
+**Severity**: HIGH
+
+Applies to a PR that adds or changes a router, server bootstrap, or response middleware.
+
+- The OWASP Secure Headers set is applied once, from a single tower layer, not per handler
+- `Strict-Transport-Security: max-age=63072000; includeSubDomains`
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: deny`
+- `Content-Security-Policy: default-src 'self'; object-src 'none'; frame-ancestors 'none'`
+- `Referrer-Policy: no-referrer`
+- `Permissions-Policy` present and restrictive
+- COOP, COEP, and CORP present for browser-facing responses
+- `Cache-Control: no-store` on API responses that carry per-user data
+- No `Server` or `X-Powered-By` header, and no `X-*` header carrying a build hash, internal hostname, or tracing ID
+
+**Review guidance**:
+- Flag a new router that mounts no header layer at all, once, at the router; do not repeat the finding per route
+- Flag a header set applied per handler instead of as a layer, since it will be forgotten on the next route
+- Flag a permissive CSP (`unsafe-inline`, `unsafe-eval`, `*`) added without a stated reason
 
 ---
 
@@ -261,6 +343,8 @@ Check that public APIs follow idiomatic Rust conventions.
 - Flag accidental wire-format changes
 - Flag fragile enum/string handling
 - Flag implicit defaults that can hide contract bugs
+- Flag `n != 0` when decoding a strictly-0/1 wire or storage flag — `bool::try_from(n).map_err(...)` surfaces out-of-contract bytes as a parse error instead of silently reading them as `true`. `Requires Rust >= 1.95`
+- The `f32`/`f64` `algebraic_add`/`sub`/`mul`/`div`/`rem` methods permit reassociation, so results vary across call sites, optimization levels, and targets. Never use them on a value that is compared, sorted, hashed, serialized, persisted, asserted on, or used for billing, quota, or alert thresholds. `Requires Rust >= 1.98`
 
 ---
 
@@ -279,6 +363,15 @@ Check that public APIs follow idiomatic Rust conventions.
 - Prefer evidence-based performance comments
 - Flag `.collect::<Vec<_>>()` immediately consumed by another loop or iteration — chain iterators instead of materializing an intermediate collection
 - Flag `Box::new([0; N])` for large buffers — allocate via `vec![0; n]` to avoid building an oversized value on the stack before the move
+- Flag `map.get(&key.to_string())` or a `.clone()` at a lookup site — a `HashMap<String, V>` can be queried with `&str`
+- Box oversized enum variants; collapse double indirection (`Box<Vec<T>>` to `Vec<T>`, `Box<String>` to `String`, `Arc<String>`/`Rc<String>` to `Arc<str>`/`Rc<str>`). `Enforcement: clippy rc_buffer (deny)` for the `Rc`/`Arc` shapes; `large_enum_variant` and the `Box` shapes are review-only
+- Flag `String::from("lit")` or `format!("lit")` with no interpolation — use the `&'static str` literal where the receiver accepts it. `Enforcement: clippy manual_string_new (deny)`
+- Prefer one `format!` over a chain of `push_str` for mixed literal and dynamic text; in hot paths use `String::with_capacity(n)` plus `push_str` instead of repeated `+`/`format!` reallocation. `Enforcement: clippy format_push_string (deny)`
+- `&str.to_string()` should be `.to_owned()`; `Vec::with_capacity(0)`/`String::with_capacity(0)` should be `new()`. `Enforcement: clippy str_to_string (deny)`
+- Large stack frames and large stack arrays in tasks with small stacks. `Enforcement: clippy large_stack_arrays (deny)` plus the `stack-size-threshold` in `clippy.toml`
+- Prefer std bit-manipulation methods (`bit_width`, `isolate_highest_one`, `isolate_lowest_one`, `highest_one`, `lowest_one`) over hand-rolled shift and mask arithmetic, which usually mishandles the zero case. `Requires Rust >= 1.97`
+- In hot integer-formatting loops, `core::fmt::NumBuffer<T>` plus `n.format_into(&mut buf)` reuses one stack buffer instead of allocating per call, and removes the need for an `itoa`-style dependency. `Requires Rust >= 1.98`
+- `core::hint::cold_path()` may mark a genuinely unlikely branch, but it is a hint only and must never be load-bearing for correctness. `Requires Rust >= 1.95`
 
 ---
 
@@ -295,6 +388,20 @@ Check that public APIs follow idiomatic Rust conventions.
 - Flag duplicate logging of the same error at multiple layers unless intentional
 - Flag logs with no identifiers or context
 - Flag missing observability in background workers, retries, queue processing, and external calls
+- Authentication attempts, both success and failure and with the source IP, and authorization denials, with identity, requested resource, and reason, must be logged through structured `tracing`. Never log request or response bodies that may carry credentials or PII
+
+---
+
+## RUST-OBS-002: No Debug Artifacts in Production Output
+**Severity**: MEDIUM
+
+- No `dbg!()` in committed code
+- No `println!()`, `eprintln!()`, or direct writes to stdout/stderr in library or service code
+- Diagnostic output goes through `tracing::{trace,debug,info,warn,error}` so it is structured, level-gated, and correlated
+
+**Review guidance**:
+- `Enforcement: clippy dbg_macro, use_debug (deny)` covers `dbg!` and `{:?}` formatting in output. `println!`/`eprintln!` are **not** denied in this workspace, so those are review-only and postable
+- A CLI binary writing intended program output to stdout is not a finding; a service or library doing it is
 
 ---
 
@@ -311,6 +418,8 @@ Check that public APIs follow idiomatic Rust conventions.
 **Review guidance**:
 - Do not require exhaustive testing for trivial refactors
 - Do flag missing tests for bug fixes, parsing, state transitions, retries, concurrency-sensitive code, and boundary conditions
+- New parser, validator, or serde-roundtrip code should carry at least one property-based test (`proptest`/`quickcheck`): no panic on arbitrary input, and roundtrip identity
+- A test that needs live services or network access must not land in the unit tier — place it under `tests/integration` or `tests/e2e` and state the tier, so the default suite stays runnable without external dependencies
 
 ---
 
@@ -328,7 +437,48 @@ Check that public APIs follow idiomatic Rust conventions.
 - Flag "god gears"
 - Flag handlers/controllers doing domain work directly
 - Flag infrastructure details leaking into domain logic without need
-- Flag `#![deny(warnings)]` (or equivalent) added directly in source — it silently escalates any future lint, including new compiler lints, into a hard build break for downstream consumers; deny specific lints by name, or gate via CI/`RUSTFLAGS`, not a blanket source-level deny
+- New platform-gated code should use std `cfg_select!` rather than the `cfg-if` crate. Do not ask for existing `cfg_if!` usages to be migrated. `Requires Rust >= 1.95`
+- A function past the pinned complexity or length thresholds should be decomposed, not given another branch. `Enforcement: clippy cognitive_complexity, too_many_lines (deny)` at the thresholds in `clippy.toml` (cognitive complexity 20, 200 lines)
+- Source-level blanket lint escalation is covered by RUST-LINT-001
+
+---
+
+## RUST-LINT-001: In-Source Lint Suppression Hygiene
+**Severity**: MEDIUM
+
+- Every in-source `#[allow(...)]` and `#[expect(...)]` carries `reason = "..."`
+- `#[expect]` is preferred over `#[allow]` so the suppression fails once it becomes unnecessary
+- Suppressions are as narrow as possible: per item or per expression, never crate-level
+- No crate-level group `allow` (`clippy::all`, `clippy::pedantic`, `clippy::nursery`) added in source
+- No `#![deny(warnings)]` or equivalent blanket escalation in source
+
+**Review guidance**:
+- A blanket source-level `deny(warnings)` silently escalates any future lint, including new compiler lints, into a hard build break for downstream consumers. Deny specific lints by name, or gate it in the build: prefer `build.warnings = "deny"` in `.cargo/config.toml` or `CARGO_BUILD_WARNINGS=deny` over `RUSTFLAGS="-D warnings"`, since it applies to local packages only and does not bust the build cache. `Requires Rust >= 1.97` for the `build.warnings` form
+- Where a foreign trait mandates `async fn`, silence `unused_async_trait_impl` per impl with `#[expect(..., reason = "...")]`, never crate-wide
+- `Enforcement: clippy ignore_without_reason (deny)` covers `#[ignore]` on tests only. The general `reason` requirement on `#[allow]`/`#[expect]` is not linted in this workspace and is review-only
+
+---
+
+## RUST-DEP-001: Dependency and Advisory Manifest Hygiene
+**Severity**: HIGH
+
+Applies **only** when the diff touches a manifest or lint/advisory config: `Cargo.toml`,
+`Cargo.lock`, `deny.toml`, `.cargo/audit.toml`, `.cargo/config.toml`, `clippy.toml`, or
+`rust-toolchain.toml`. Skip this rule entirely when the diff contains none of them.
+
+- No dependency added with a `git = ...` source or a non-crates.io `registry = ...` source; both are supply-chain surface with no advisory or vet coverage
+- No `*` or open-ended version specification on a newly added dependency
+- A RUSTSEC advisory added to `ignore = [...]` in `.cargo/audit.toml` or `deny.toml` carries a comment stating why it does not apply to this code
+- `.cargo/audit.toml` and `deny.toml` do not drift apart: an advisory accepted in one is reflected in the other
+- A `[lints.*]` group entry (`all`, `pedantic`, `nursery`) declares `priority = -1`; without it Cargo rejects the manifest as soon as any per-lint override exists
+- No lint declared that no longer exists (`string_to_string`, `from_iter_instead_of_collect` now emit `unknown_lints`)
+- `unsafe_code` is not downgraded from `forbid` to `deny` without a justified per-item `#[allow(unsafe_code)]` accompanying the change
+- The `deny.toml` license allowlist is not widened, and `[sources]` is not loosened, without a stated reason
+
+**Review guidance**:
+- `Enforcement: clippy wildcard_dependencies (deny)` covers the wildcard version case; everything else here is review-only
+- An undocumented `ignore = ["RUSTSEC-...."]` entry is the highest-signal finding in this rule: it converts a known vulnerability into a silent one
+- A toolchain pin change in `rust-toolchain.toml` shifts which `Requires Rust >= X.Y` criteria are live across the whole catalog; call it out
 
 ---
 
@@ -350,6 +500,8 @@ Check that public APIs follow idiomatic Rust conventions.
 - No `let _ = ...` on meaningful failures unless explicitly intentional and documented
 - No empty error handlers
 - No failure paths that only log and continue when correctness requires propagation or state change
+- No `iter.by_ref().peekable().peek()` — it silently consumes and discards an item. Bind the `Peekable` or call `.next()`. The bug is real on any toolchain; only the `clippy::by_ref_peekable_peek` lint is new. `Requires Clippy >= 1.98`
+- No `mem::forget` on a type with a `Drop` impl; it is almost always a leak bug rather than an intentional leak
 
 ---
 
@@ -388,6 +540,19 @@ Check that public APIs follow idiomatic Rust conventions.
 - No casual assumptions around aliasing, lifetimes, initialization, or FFI contracts
 - No undocumented transmute-like behavior
 
+`Enforcement: rustc unsafe_code (forbid)` workspace-wide, and `forbid` cannot be overridden
+locally. The criteria below therefore apply only to a crate that deliberately opts out of the
+workspace lint block. Do not post them against a crate that inherits `forbid`.
+
+**Review guidance**:
+- Recover a sub-slice offset with `str::substr_range` / `[T]::subslice_range`, never `sub.as_ptr().offset_from(parent.as_ptr())`. Both return `Option` and need no `unsafe`; note `subslice_range` panics for zero-sized element types. `Requires Rust >= 1.98`
+- Use `Atomic::from_mut` / `from_mut_slice` / `get_mut_slice` instead of transmuting or `slice::from_raw_parts_mut`-casting a plain buffer to `[AtomicU32]`; `&mut` already proves exclusivity, so no `unsafe` is needed. `Requires Rust >= 1.98`
+- For a multi-byte read out of a `&[u8]`, use `u16::from_le_bytes(buf.get(a..b).ok_or(..)?.try_into().map_err(..)?)`, or `core::ptr::read_unaligned` with a `// SAFETY:` comment. Never `*(p as *const u16)` or `ptr::read::<u16>` on a pointer derived from a byte slice: both require T-alignment and are UB or a hardware trap on non-x86 targets. Never `try_into().unwrap()`
+- `#[unsafe(no_mangle)]`, `#[unsafe(link_section)]`, `#[unsafe(export_name)]`, and `#[unsafe(naked)]` now trip `unsafe_code`. A crate that needs them cannot stay on `forbid` — move it to `deny` plus a justified per-item `#[allow(unsafe_code)]` with a `// SAFETY:` note. `Requires Rust >= 1.98`
+- Do not define symbols the Rust runtime reserves (`memcmp`, `memset`, `strlen`); `invalid_runtime_symbol_definitions` is deny-by-default and sits outside the `warnings` group. Do not return `core::ffi::c_void` from an `extern "C"` shim. `Requires Rust >= 1.98`
+- Flag pointer casts that change alignment requirements, and raw-pointer arguments dereferenced in a safe fn, as prose findings even where the lints are silent
+- Negative guardrail: do not demand Miri coverage on a crate with `unsafe_code = "forbid"`, on an FFI-heavy crate, or on a bare-metal target. Use `cargo-geiger` for transitive `unsafe` instead
+
 ---
 
 ## RUST-NO-007: No Contract Drift by Accident
@@ -397,7 +562,8 @@ Check that public APIs follow idiomatic Rust conventions.
 - No accidental serde/wire/schema changes
 - No accidental visibility expansion
 - No accidental behavior changes hidden inside refactoring
-- No new blanket trait impls (`impl<T: Bound> Trait for T`) in a public API without deliberate justification — they are a semver/coherence hazard for downstream crates
+- No new blanket trait impls (`impl<T: Bound> Trait for T`) in a public API without deliberate justification — they are a semver/coherence hazard for downstream crates. The fix is to seal the trait behind a private supertrait so only this crate can implement it, or to write per-type impls
+- No `..Default::default()` in a crate-owned struct literal where a later field addition would be silently defaulted instead of breaking the build (see RUST-TYPE-001)
 
 ---
 
@@ -497,4 +663,6 @@ Before finalizing the review:
 * Do not request speculative abstractions
 * Do not nitpick formatting that tooling should handle
 * Escalate correctness, panic, async, concurrency, contract, and security problems first
-* Keep the report concise and engineering-focused
+* Drop anything marked `Enforcement: clippy ... (deny)` — the build already rejects it, and posting it costs a slot that a real finding needs
+* Check the toolchain before flagging a `Requires Rust >= X.Y` criterion
+* Word every comment per `docs/pr-review/comment-style.md`, which is the only authority on phrasing

--- a/docs/pr-review/toolkit-tests-quality-review.md
+++ b/docs/pr-review/toolkit-tests-quality-review.md
@@ -6,47 +6,60 @@ Focus on whether each test actually verifies logic, behavior, invariants, side e
 
 Review the tests against the following anti-patterns:
 
-1. Constructor Echo
+1. Constructor Echo (`TEST-QUALITY-1`)
 A test that only constructs a value and reads back the same field without exercising any logic.
 Example:
 let s = MyStruct { x: 42 };
 assert_eq!(s.x, 42);
 
-2. Tautology / Trivial Assertion
+2. Tautology / Trivial Assertion (`TEST-QUALITY-2`)
 An assertion that is true by definition and does not validate the code under test.
 Examples:
 assert!(true);
 assert_eq!(1 + 1, 2);
 assert_eq!("hello", "hello");
 
-3. Language Semantics Test
+3. Language Semantics Test (`TEST-QUALITY-3`)
 A test that verifies Rust language guarantees or compiler behavior rather than project logic.
 Example:
 let a = SomeEnum::Variant;
 let b = a;
 assert_eq!(a, b);
 
-4. No-op Test
+4. No-op Test (`TEST-QUALITY-4`)
 A test that calls code but makes no meaningful assertion.
 Example:
 fn test_constructs() {
     let _x = MyStruct::new();
 }
 
-5. Redundant / Duplicate Test
+5. Redundant / Duplicate Test (`TEST-QUALITY-5`)
 Multiple tests with different names but effectively the same setup and assertion, adding no new behavioral coverage.
 
-6. Mock-only / Side-effect Blindness
+6. Mock-only / Side-effect Blindness (`TEST-QUALITY-6`)
 A test that uses mocks but does not verify the actual externally visible effect, state change, emitted event, persisted data, log record, metric, or interaction that matters.
 
-7. Happy-path Only
+7. Happy-path Only (`TEST-QUALITY-7`)
 Tests cover only successful execution but ignore invalid input, errors, boundary conditions, and edge cases, especially for Result and Option returning code.
 
-8. Snapshot Abuse
+8. Snapshot Abuse (`TEST-QUALITY-8`)
 A test that snapshots formatting or debug output instead of validating meaningful behavior. Formatting-only assertions should be treated with suspicion unless formatting itself is the contract.
+The specific shape to look for is an assertion on a `Debug` rendering:
+assert_eq!(format!("{:?}", value), "Config { path: \"/tmp/x\" }");
+`Debug` output is not a stable format. Rust 1.98 escapes more characters than earlier versions, so an assertion like this can start failing without any change to the code under test. Assert on the data, or on an owned `render_*()` method whose format the type actually promises. The risk is highest in audit-log and redaction tests, where the assertion is often the only thing checking that a secret stays masked.
 
-9. Suppressed or Deleted Failing Test
+9. Suppressed or Deleted Failing Test (`TEST-QUALITY-9`)
 A previously-failing test was deleted, weakened, or marked `#[ignore]` in the diff with no linked follow-up issue or clear justification. This hides a real regression instead of fixing it.
+
+10. Assertion-Macro Temporaries (`TEST-QUALITY-10`)
+A guard, lock, or `RefCell` borrow created inline inside `assert_eq!` / `assert_ne!` rather than bound to a `let` first.
+Example:
+assert_eq!(shared.lock().unwrap().len(), 1);
+Rust 1.98 added a temporary scope to these macros, so the temporary now drops at the end of the assertion instead of the end of the statement. That changes borrow-checker outcomes and can turn a previously compiling test into a failing one, or mask a lock-held-too-long bug the old code exposed. Read the value inside a short block and assert on the copy:
+let len = { shared.lock().unwrap().len() };
+assert_eq!(len, 1);
+The block matters: binding the guard to a plain `let guard = shared.lock().unwrap();` holds the lock for the rest of the scope, so any later `shared.lock()` in the same test deadlocks on a non-reentrant `std::sync::Mutex`. Keep the guard alive only if the test needs several reads to be atomic, and then scope it explicitly.
+This applies only on Rust 1.98 and newer; check the toolchain pin before flagging.
 
 What to do:
 - Flag meaningless or weak tests.
@@ -61,7 +74,8 @@ What to do:
   - invariants
   - state transitions
   - interaction contracts
-- For parsing, validation, or serialization code, prefer at least one property-based test (proptest/quickcheck) over point examples alone.
+- For parsing, validation, or serialization code, prefer at least one property-based test (proptest/quickcheck) over point examples alone: no panic on arbitrary input, and roundtrip identity.
+- Check test tier placement. A test that needs live services or network access must not land in the unit tier; it belongs under `tests/integration` or `tests/e2e`, with the tier stated, so the default suite stays runnable without external dependencies.
 - Distinguish clearly between:
   - good tests
   - weak but salvageable tests


### PR DESCRIPTION
- Review comments were assembled by joining two terse fields, so they read like a template. Findings now carry a `comment` field written as prose, and the severity header stays only on CRITICAL and HIGH. Wording rules live in docs/pr-review/comment-style.md, replacing five copies that had drifted apart.

- Adds the rules the catalog was missing from RUST_GUIDELINES.md: new criteria under 17 existing rule IDs, plus RUST-SEC-002, RUST-OBS-002, RUST-LINT-001, RUST-DEP-001 and TEST-QUALITY-10. Each new criterion is tagged with the Rust version it needs and with the clippy lint that already denies it, so rules the build enforces are not posted as review comments.

- Manifest files are now collected into `manifest_files` so RUST-DEP-001 can fire on Cargo.toml, deny.toml and .cargo/audit.toml.

- The speculative-finding filter reads `issue` only. It matched on comment wording before, and would have dropped comments that keep uncertainty on purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dependency and advisory hygiene checks for Rust manifests and configuration.
  * Expanded review coverage for security, concurrency, performance, observability, API design, error handling, and test quality.
  * Added checks for HTTP security headers, unsafe-code patterns, property-based testing, and integration-test placement.
* **Improvements**
  * Standardized review comments with clearer severity labels and direct, actionable wording.
  * Reduced speculative and style-only findings for more focused results.
* **Documentation**
  * Added comment-style guidance and expanded Rust review checklists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->