### PR TITLE
chore(directory): remove dead openapi_spec from enumeration paths

### DIFF
--- a/gears/system/api-gateway/src/proxy.rs
+++ b/gears/system/api-gateway/src/proxy.rs
@@ -628,9 +628,10 @@ mod tests {
         )
         .await;
 
-        // Precondition: the snapshot is spec-less.
+        // Precondition: the snapshot is spec-less — it carries only the hash,
+        // never the inlined document.
         let snapshot = dir.list_all_instances().await.unwrap();
-        assert!(snapshot.iter().all(|i| i.openapi_spec.is_none()));
+        assert!(snapshot.iter().all(|i| i.openapi_spec_hash.is_some()));
 
         let registry = Arc::new(ProxyRegistry::new());
         let provider = ToolKitGatewayProvider::new(Arc::clone(&registry));

--- a/gears/system/gear-orchestrator/src/server.rs
+++ b/gears/system/gear-orchestrator/src/server.rs
@@ -141,9 +141,6 @@ impl DirectoryService for DirectoryServiceImpl {
             .await
             .map_err(|e| lookup_status(&e))?;
         instances.retain(|inst| selector.matches(&inst.labels));
-        for inst in &mut instances {
-            inst.openapi_spec = None;
-        }
 
         let resp = ListInstancesResponse {
             instances: instances
@@ -168,15 +165,12 @@ impl DirectoryService for DirectoryServiceImpl {
         let resp = ListAllInstancesResponse {
             instances: instances
                 .into_iter()
-                // `openapi_spec` and `labels` are both omitted from the broad
-                // cross-gear snapshot; `without_labels` is the shared transform
-                // (see the `list_all_instances` trait doc). The spec is dropped
-                // here too — it is never inlined into this snapshot.
+                // `labels` are omitted from the broad cross-gear snapshot;
+                // `without_labels` is the shared transform (see the
+                // `list_all_instances` trait doc). The full OpenAPI document is
+                // never inlined into any enumeration — `InstanceInfo` carries
+                // only the `openapi_spec_hash`.
                 .map(|inst| domain_instance_to_proto(inst.without_labels()))
-                .map(|mut proto| {
-                    proto.openapi_spec = None;
-                    proto
-                })
                 .collect(),
         };
 
@@ -274,7 +268,6 @@ fn domain_instance_to_proto(i: ServiceInstanceInfo) -> InstanceInfo {
         endpoint_uri: i.endpoint.map(|ep| ep.uri).unwrap_or_default(),
         version: i.version.unwrap_or_default(),
         rest_endpoint_uri: i.rest_endpoint.map(|ep| ep.uri),
-        openapi_spec: i.openapi_spec,
         openapi_spec_hash: i.openapi_spec_hash,
         labels: i.labels.into_iter().collect(),
         state: domain_state_to_proto(i.state) as i32,
@@ -874,8 +867,8 @@ mod tests {
         for inst in &all {
             assert!(inst.rest_endpoint_uri.is_some());
             assert!(
-                inst.openapi_spec.is_none(),
-                "discovery snapshot must not inline the OpenAPI document"
+                inst.openapi_spec_hash.is_some(),
+                "discovery snapshot carries only the spec hash, never the inline document"
             );
         }
         let gears: Vec<_> = all.iter().map(|i| i.gear_name.as_str()).collect();
@@ -1273,8 +1266,8 @@ mod tests {
             Some("1")
         );
         assert!(
-            matched[0].openapi_spec.is_none(),
-            "label-resolve path must strip the OpenAPI document"
+            matched[0].openapi_spec_hash.is_some(),
+            "label-resolve path carries only the spec hash, never the inline document"
         );
 
         // A selector matching nothing returns an empty list (not an error).
@@ -1303,12 +1296,8 @@ mod tests {
             .instances;
         assert_eq!(all_spec_free.len(), 2, "empty selector matches every shard");
         assert!(
-            all_spec_free.iter().all(|i| i.openapi_spec.is_none()),
-            "list_instances must never inline the OpenAPI document"
-        );
-        assert!(
             all_spec_free.iter().all(|i| i.openapi_spec_hash.is_some()),
-            "list_instances must still carry the spec hash"
+            "list_instances must carry the spec hash, never the inline document"
         );
     }
 
@@ -1366,8 +1355,8 @@ mod tests {
             Some("1")
         );
         assert!(
-            matched[0].openapi_spec.is_none(),
-            "resolve_by_labels must not carry the OpenAPI document"
+            matched[0].openapi_spec_hash.is_some(),
+            "resolve_by_labels carries only the spec hash, never the inline document"
         );
 
         // A selector matching nothing yields an empty set (not an error).
@@ -1383,8 +1372,8 @@ mod tests {
             .unwrap();
         assert_eq!(all.len(), 2, "empty selector matches every shard");
         assert!(
-            all.iter().all(|i| i.openapi_spec.is_none()),
-            "empty-selector resolve_by_labels must not carry the OpenAPI document"
+            all.iter().all(|i| i.openapi_spec_hash.is_some()),
+            "empty-selector resolve_by_labels carries only the spec hash"
         );
 
         server.abort();

--- a/libs/system-sdks/sdks/directory/proto/v1/directory.proto
+++ b/libs/system-sdks/sdks/directory/proto/v1/directory.proto
@@ -22,10 +22,10 @@ service DirectoryService {
   // List all instances across every registered gear (edge/gateway discovery).
   //
   // This response is a lightweight discovery snapshot: instances carry their
-  // identity and REST endpoint but NOT the full `openapi_spec` (see
-  // InstanceInfo), so the aggregated payload stays small and bounded even with
-  // many gears. The edge fetches a gear's document once, on first discovery,
-  // via `GetOpenApiSpec`.
+  // identity and REST endpoint but never the full OpenAPI document (only its
+  // `openapi_spec_hash`), so the aggregated payload stays small and bounded
+  // even with many gears. The edge fetches a gear's document once, on first
+  // discovery, via `GetOpenApiSpec`.
   rpc ListAllInstances(ListAllInstancesRequest) returns (ListAllInstancesResponse);
 
   // Register a new gear instance with the directory
@@ -77,12 +77,13 @@ enum InstanceState {
 }
 
 message InstanceInfo {
+  reserved 6;
+  reserved "openapi_spec";
   string gear_name = 1;
   string instance_id = 2;
   string endpoint_uri = 3;
   string version = 4;
   optional string rest_endpoint_uri = 5;
-  optional string openapi_spec = 6;
   optional string openapi_spec_hash = 7;
   map<string, string> labels = 8;
   InstanceState state = 9;

--- a/libs/system-sdks/sdks/directory/src/api.rs
+++ b/libs/system-sdks/sdks/directory/src/api.rs
@@ -136,9 +136,12 @@ pub struct ServiceInstanceInfo {
     /// exposes no REST API. This is the address the edge reverse-proxy actually
     /// dials for REST routing.
     pub rest_endpoint: Option<ServiceEndpoint>,
-    /// Optional `OpenAPI` spec (JSON) this instance published, if any.
-    pub openapi_spec: Option<String>,
     /// Stable content token for the published `OpenAPI` spec, if any.
+    ///
+    /// Enumeration is deliberately spec-free: only this hash rides along, never
+    /// the full document (fetched out-of-band via
+    /// [`DirectoryClient::get_openapi_spec`]). The hash lets a consumer detect a
+    /// spec change without inlining N copies of the document.
     pub openapi_spec_hash: Option<String>,
     /// Published gRPC services as `(service name, endpoint)` pairs.
     ///
@@ -191,13 +194,6 @@ impl ServiceInstanceInfo {
     #[must_use]
     pub fn with_rest_endpoint(mut self, rest_endpoint: Option<ServiceEndpoint>) -> Self {
         self.rest_endpoint = rest_endpoint;
-        self
-    }
-
-    /// Set the optional `OpenAPI` spec (JSON).
-    #[must_use]
-    pub fn with_openapi_spec(mut self, openapi_spec: Option<String>) -> Self {
-        self.openapi_spec = openapi_spec;
         self
     }
 
@@ -414,7 +410,7 @@ pub trait DirectoryClient: Send + Sync {
     /// List all service instances for a given gear.
     ///
     /// Entries are **spec-free**: only the `openapi_spec_hash` is carried, never
-    /// the full `openapi_spec` document, so a multi-instance response stays
+    /// the full `OpenAPI` document, so a multi-instance response stays
     /// bounded regardless of spec size. Callers fetch the document out-of-band
     /// via [`get_openapi_spec`](Self::get_openapi_spec); the hash lets a consumer
     /// detect a spec change without inlining N copies of the document.
@@ -444,14 +440,13 @@ pub trait DirectoryClient: Send + Sync {
     /// have the match silently hidden.
     ///
     /// Returned entries are **spec-free** on every implementation — the full
-    /// `openapi_spec` document is omitted (only its hash is carried), so the
+    /// `OpenAPI` document is omitted (only its hash is carried), so the
     /// polled resolve payload stays bounded; the caller fetches documents via
     /// [`get_openapi_spec`](Self::get_openapi_spec). This holds regardless of
     /// whether the selector is empty. The default body enumerates via
-    /// [`list_instances`](Self::list_instances), filters in-process, and drops
-    /// the spec; transport-backed clients (e.g. the gRPC client) override it to
-    /// push the selector server-side and request spec-free entries over the
-    /// wire.
+    /// [`list_instances`](Self::list_instances) and filters in-process;
+    /// transport-backed clients (e.g. the gRPC client) override it to push the
+    /// selector server-side.
     ///
     /// Label-based selection is effectively **out-of-process only**. Labels are
     /// published from the `OoP` serve path's configuration (`oop_http.labels`);
@@ -468,24 +463,20 @@ pub trait DirectoryClient: Send + Sync {
         // cancel-safe: the single await precedes any mutation; cancelling here
         // just drops the in-flight list and leaves no partial state.
         let instances = self.list_instances(gear).await?;
+        // Entries are spec-free by construction — `ServiceInstanceInfo` carries
+        // only the `openapi_spec_hash`, never the full OpenAPI document.
         Ok(instances
             .into_iter()
             .filter(|i| selector.matches(&i.labels))
-            // Spec-free entries, matching the documented contract and the
-            // transport-backed overrides: the label-resolve path never inlines
-            // the OpenAPI document (the hash still rides along).
-            .map(|mut i| {
-                i.openapi_spec = None;
-                i
-            })
             .collect())
     }
 
     /// List every service instance across all registered gears.
     ///
     /// Used by the edge gateway to discover which gears (and their REST
-    /// endpoints) to reverse-proxy. This is a lightweight discovery snapshot:
-    /// the returned instances do **not** carry `openapi_spec` — even when the
+    /// endpoints) to reverse-proxy. This is a lightweight discovery snapshot.
+    /// Like every enumeration path, it is **spec-free**: entries carry only the
+    /// `openapi_spec_hash`, never the full `OpenAPI` document, even when the
     /// backing store holds a stored specification. The edge fetches a gear's
     /// document once, on first discovery, via
     /// [`get_openapi_spec`](Self::get_openapi_spec).

--- a/libs/system-sdks/sdks/directory/src/grpc/client.rs
+++ b/libs/system-sdks/sdks/directory/src/grpc/client.rs
@@ -345,11 +345,7 @@ impl DirectoryClient for DirectoryGrpcClient {
             .into_inner()
             .instances
             .into_iter()
-            .map(|proto| {
-                let mut info = proto_instance_to_domain(proto).without_labels();
-                info.openapi_spec = None;
-                info
-            })
+            .map(|proto| proto_instance_to_domain(proto).without_labels())
             .collect();
 
         Ok(instances)
@@ -435,7 +431,6 @@ fn proto_instance_to_domain(proto: InstanceInfo) -> ServiceInstanceInfo {
             Some(proto.version)
         },
         rest_endpoint: proto.rest_endpoint_uri.map(ServiceEndpoint::new),
-        openapi_spec: proto.openapi_spec,
         openapi_spec_hash: proto.openapi_spec_hash,
         // The `InstanceInfo` proto message carries no per-service gRPC
         // breakdown, so nothing to reconstruct over the OoP directory transport;
@@ -585,8 +580,7 @@ mod tests {
             endpoint_uri: "http://calc:8080".to_owned(),
             version: "1.2.3".to_owned(),
             rest_endpoint_uri: Some("http://calc:8080".to_owned()),
-            openapi_spec: Some("{\"openapi\":\"3.1.0\"}".to_owned()),
-            openapi_spec_hash: None,
+            openapi_spec_hash: Some("1a2b3c4d5e6f7a8b".to_owned()),
             labels: [("shard".to_owned(), "7".to_owned())].into_iter().collect(),
             state: ProtoInstanceState::Healthy as i32,
         };
@@ -603,7 +597,11 @@ mod tests {
             domain.rest_endpoint.map(|e| e.uri),
             Some("http://calc:8080".to_owned())
         );
-        assert!(domain.openapi_spec.is_some());
+        // Enumeration is spec-free: only the hash crosses the wire.
+        assert_eq!(
+            domain.openapi_spec_hash.as_deref(),
+            Some("1a2b3c4d5e6f7a8b")
+        );
         // Labels cross the wire and land in a BTreeMap for deterministic matching.
         assert_eq!(domain.labels.get("shard"), Some(&"7".to_owned()));
     }
@@ -616,7 +614,6 @@ mod tests {
             endpoint_uri: "http://worker:7000".to_owned(),
             version: String::new(),
             rest_endpoint_uri: None,
-            openapi_spec: None,
             openapi_spec_hash: None,
             labels: std::collections::HashMap::new(),
             state: ProtoInstanceState::Unspecified as i32,
@@ -630,7 +627,7 @@ mod tests {
         // An empty proto version string maps to `None` rather than an empty string.
         assert!(domain.version.is_none());
         assert!(domain.rest_endpoint.is_none());
-        assert!(domain.openapi_spec.is_none());
+        assert!(domain.openapi_spec_hash.is_none());
         assert!(domain.labels.is_empty());
         // An unset proto state (`UNSPECIFIED`) maps to the non-serving Unknown
         // sentinel — distinct from the pre-serving Registered baseline.
@@ -649,7 +646,6 @@ mod tests {
             endpoint_uri: String::new(),
             version: String::new(),
             rest_endpoint_uri: None,
-            openapi_spec: None,
             openapi_spec_hash: None,
             labels: std::collections::HashMap::new(),
             state: ProtoInstanceState::Ready as i32,

--- a/libs/toolkit/src/directory.rs
+++ b/libs/toolkit/src/directory.rs
@@ -457,9 +457,10 @@ mod tests {
             billing.rest_endpoint.as_ref().map(|e| e.uri.as_str()),
             Some("http://billing:8080")
         );
-        // The cross-gear snapshot never inlines the OpenAPI document; consumers
-        // fetch it per gear via `get_openapi_spec`.
-        assert!(billing.openapi_spec.is_none());
+        // The cross-gear snapshot never inlines the OpenAPI document; it carries
+        // only the hash, and consumers fetch the document per gear via
+        // `get_openapi_spec`.
+        assert!(billing.openapi_spec_hash.is_some());
         assert!(
             api.get_openapi_spec("billing")
                 .await
@@ -478,7 +479,7 @@ mod tests {
             Some("http://reporting:7000")
         );
         assert!(reporting.rest_endpoint.is_none());
-        assert!(reporting.openapi_spec.is_none());
+        assert!(reporting.openapi_spec_hash.is_none());
     }
 
     fn labels(pairs: &[(&str, &str)]) -> std::collections::BTreeMap<String, String> {
@@ -636,20 +637,16 @@ mod tests {
             .unwrap();
         assert_eq!(matched.len(), 1);
         assert!(
-            matched[0].openapi_spec.is_none(),
-            "in-process resolve_by_labels must not attach the OpenAPI document"
+            matched[0].openapi_spec_hash.is_some(),
+            "in-process resolve_by_labels carries only the spec hash, never the document"
         );
 
         // The plain enumeration path is spec-free too: only the hash rides
         // along, the document is fetched via `get_openapi_spec`.
         let listed = api.list_instances("worker").await.unwrap();
         assert!(
-            listed[0].openapi_spec.is_none(),
-            "list_instances must not attach the OpenAPI document"
-        );
-        assert!(
             listed[0].openapi_spec_hash.is_some(),
-            "list_instances must still carry the spec hash"
+            "list_instances must carry the spec hash, never the document"
         );
     }
 


### PR DESCRIPTION
Closes #4580

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **API Changes**
  - Instance discovery responses no longer include the full OpenAPI document.
  - Instance listings now provide an OpenAPI specification hash instead, allowing clients to identify the specification without receiving its contents.
  - Aggregated discovery documentation now clarifies that responses include instance identity, REST endpoint, and specification hash only.
  - OpenAPI documents remain available during instance registration.
  - Client SDK instance metadata now exposes the specification hash without storing or returning the full document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->