### PR TITLE
feat(simple-user-settings): let the deployment say whose settings these are

### DIFF
--- a/gears/simple-user-settings/simple-user-settings-sdk/src/lib.rs
+++ b/gears/simple-user-settings/simple-user-settings-sdk/src/lib.rs
@@ -21,6 +21,8 @@
 
 pub mod api;
 pub mod models;
+pub mod owner;
 
 pub use api::SimpleUserSettingsClientV1;
 pub use models::{SimpleUserSettings, SimpleUserSettingsPatch, SimpleUserSettingsUpdate};
+pub use owner::SettingsOwnerResolver;

--- a/gears/simple-user-settings/simple-user-settings-sdk/src/owner.rs
+++ b/gears/simple-user-settings/simple-user-settings-sdk/src/owner.rs
@@ -1,0 +1,54 @@
+//! Who a set of settings belongs to.
+//!
+//! Settings are stored under a user key, and by default that key is the token
+//! subject — the identity that signed in. For a deployment where one human has
+//! exactly one way to sign in, subject and human are the same thing and there is
+//! nothing to decide.
+//!
+//! They come apart as soon as a product lets somebody reach the same account
+//! through more than one identity: an e-mail login and a brokered GitHub login,
+//! two accounts merged after the fact, a migration between identity providers.
+//! Then the token subject names *a way in*, not the person, and settings keyed
+//! on it silently fork — the same human signs in the other way and their theme,
+//! their language and everything else stored here is gone.
+//!
+//! A deployment that knows better can say so by publishing a
+//! [`SettingsOwnerResolver`] on the `ClientHub`. Nothing else changes: the gear
+//! keeps its storage, its API and its authorization, and only the key it files a
+//! person's settings under comes from somewhere better informed.
+
+use async_trait::async_trait;
+use toolkit_canonical_errors::CanonicalError;
+use toolkit_security::SecurityContext;
+use uuid::Uuid;
+
+/// Resolve the caller to the user key their settings are filed under.
+///
+/// Register an implementation on the `ClientHub` and the gear will consult it
+/// for every read and write:
+///
+/// ```ignore
+/// let resolver: Arc<dyn SettingsOwnerResolver> = Arc::new(MyResolver);
+/// hub.register(resolver);
+/// ```
+///
+/// With no implementation registered, the gear uses `ctx.subject_id()` exactly
+/// as it always has, so adding this costs an existing deployment nothing.
+#[async_trait]
+pub trait SettingsOwnerResolver: Send + Sync + 'static {
+    /// The key this caller's settings belong under, or `None` to fall back to
+    /// the token subject.
+    ///
+    /// Returning `None` rather than an error is deliberate: a deployment whose
+    /// resolver cannot answer for some callers (a service account, an identity
+    /// it has never seen) should degrade to the subject, which is always
+    /// available, rather than deny somebody their preferences.
+    ///
+    /// # Errors
+    ///
+    /// Only for a genuine failure to look the caller up — a database that is
+    /// down, not a caller the resolver has no opinion about. The gear reports it
+    /// rather than guessing, because silently filing a person's settings under
+    /// the wrong key is worse than telling them the read failed.
+    async fn settings_owner(&self, ctx: &SecurityContext) -> Result<Option<Uuid>, CanonicalError>;
+}

--- a/gears/simple-user-settings/simple-user-settings/src/domain/error.rs
+++ b/gears/simple-user-settings/simple-user-settings/src/domain/error.rs
@@ -51,3 +51,16 @@ impl From<authz_resolver_sdk::EnforcerError> for DomainError {
         }
     }
 }
+
+/// A resolver that could not answer is an internal failure, not a denial.
+///
+/// The gear asked a collaborator "whose settings are these?" and got no answer;
+/// carrying on with the token subject would file the caller's settings under a
+/// key their next request may not produce, so the read fails instead.
+#[allow(unknown_lints, de1302_error_from_to_string)]
+impl From<toolkit_canonical_errors::CanonicalError> for DomainError {
+    fn from(e: toolkit_canonical_errors::CanonicalError) -> Self {
+        tracing::error!(error = %e, "settings owner resolution failed");
+        Self::Internal(e.to_string())
+    }
+}

--- a/gears/simple-user-settings/simple-user-settings/src/domain/service.rs
+++ b/gears/simple-user-settings/simple-user-settings/src/domain/service.rs
@@ -1,13 +1,15 @@
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use authz_resolver_sdk::PolicyEnforcer;
 use authz_resolver_sdk::pep::{AccessRequest, ResourceType};
 use simple_user_settings_sdk::models::{
     SimpleUserSettings, SimpleUserSettingsPatch, SimpleUserSettingsUpdate,
 };
+use simple_user_settings_sdk::owner::SettingsOwnerResolver;
 use toolkit_db::DBProvider;
 use toolkit_macros::domain_model;
 use toolkit_security::{SecurityContext, pep_properties};
+use uuid::Uuid;
 
 use super::error::DomainError;
 use super::fields::SettingsFields;
@@ -56,6 +58,9 @@ pub struct Service<R: SettingsRepository> {
     repo: Arc<R>,
     policy_enforcer: PolicyEnforcer,
     config: ServiceConfig,
+    /// Supplied by the deployment in the REST phase; `Some(None)` means it
+    /// published none and the token subject is the key.
+    owner_resolver: OnceLock<Option<Arc<dyn SettingsOwnerResolver>>>,
 }
 
 impl<R: SettingsRepository> Service<R> {
@@ -70,14 +75,42 @@ impl<R: SettingsRepository> Service<R> {
             repo,
             policy_enforcer,
             config,
+            owner_resolver: OnceLock::new(),
         }
+    }
+
+    /// Hand the service the deployment's view of who a caller is.
+    ///
+    /// Separate from `new` because the resolver comes from another gear, and
+    /// the REST phase is the first point at which every gear is known to have
+    /// initialized. Calling it twice is ignored.
+    pub fn attach_owner_resolver(&self, resolver: Option<Arc<dyn SettingsOwnerResolver>>) {
+        if self.owner_resolver.set(resolver).is_err() {
+            tracing::debug!("settings owner resolver already attached; keeping the first");
+        }
+    }
+
+    /// The key this caller's settings are filed under.
+    ///
+    /// The token subject unless the deployment published a resolver that knows
+    /// better — see [`SettingsOwnerResolver`]. One place decides it, so a read
+    /// and a write can never disagree about whose settings they are.
+    async fn owner_of(&self, ctx: &SecurityContext) -> Result<Uuid, DomainError> {
+        let Some(Some(resolver)) = self.owner_resolver.get() else {
+            return Ok(ctx.subject_id());
+        };
+        Ok(resolver
+            .settings_owner(ctx)
+            .await
+            .map_err(DomainError::from)?
+            .unwrap_or_else(|| ctx.subject_id()))
     }
 
     pub async fn get_settings(
         &self,
         ctx: &SecurityContext,
     ) -> Result<SimpleUserSettings, DomainError> {
-        let user_id = ctx.subject_id();
+        let user_id = self.owner_of(ctx).await?;
         let tenant_id = ctx.subject_tenant_id();
 
         let scope = self
@@ -113,7 +146,7 @@ impl<R: SettingsRepository> Service<R> {
         self.validate_field(SettingsFields::THEME, &update.theme)?;
         self.validate_field(SettingsFields::LANGUAGE, &update.language)?;
 
-        let user_id = ctx.subject_id();
+        let user_id = self.owner_of(ctx).await?;
         let tenant_id = ctx.subject_tenant_id();
 
         let scope = self
@@ -155,7 +188,7 @@ impl<R: SettingsRepository> Service<R> {
             self.validate_field(SettingsFields::LANGUAGE, language)?;
         }
 
-        let user_id = ctx.subject_id();
+        let user_id = self.owner_of(ctx).await?;
         let tenant_id = ctx.subject_tenant_id();
 
         let scope = self

--- a/gears/simple-user-settings/simple-user-settings/src/domain/service_test.rs
+++ b/gears/simple-user-settings/simple-user-settings/src/domain/service_test.rs
@@ -112,12 +112,150 @@ mod tests {
             .unwrap()
     }
 
+    /// A caller in a named organization.
+    ///
+    /// Settings are keyed on `(user, tenant)`, so a test about *whose* settings
+    /// these are has to hold the tenant still or it measures both at once.
+    fn context_in(tenant_id: Uuid) -> SecurityContext {
+        SecurityContext::builder()
+            .subject_id(Uuid::new_v4())
+            .subject_tenant_id(tenant_id)
+            .build()
+            .unwrap()
+    }
+
     fn build_service(db: Db, config: ServiceConfig) -> ConcreteService {
         let repo = Arc::new(SeaOrmSettingsRepository::new());
         let db: Arc<DBProvider<toolkit_db::DbError>> = Arc::new(DBProvider::new(db));
         let authz: Arc<dyn AuthZResolverApi> = Arc::new(MockAuthZResolver);
         let policy_enforcer = PolicyEnforcer::new(authz);
         Service::new(db, repo, policy_enforcer, config)
+    }
+
+    /// A deployment whose people hold more than one login.
+    ///
+    /// Answers with one fixed key for every caller, which is the shape that
+    /// matters: two different subjects must reach the same settings.
+    struct OnePerson(Option<Uuid>);
+
+    #[async_trait]
+    impl simple_user_settings_sdk::SettingsOwnerResolver for OnePerson {
+        async fn settings_owner(
+            &self,
+            _ctx: &SecurityContext,
+        ) -> Result<Option<Uuid>, CanonicalError> {
+            Ok(self.0)
+        }
+    }
+
+    /// A resolver that is having a bad day.
+    struct Broken;
+
+    #[async_trait]
+    impl simple_user_settings_sdk::SettingsOwnerResolver for Broken {
+        async fn settings_owner(
+            &self,
+            _ctx: &SecurityContext,
+        ) -> Result<Option<Uuid>, CanonicalError> {
+            Err(CanonicalError::internal("directory unavailable").create())
+        }
+    }
+
+    // =========================================================================
+    // whose settings these are
+    // =========================================================================
+
+    /// The point of the resolver: one human, two logins, one set of settings.
+    #[tokio::test]
+    async fn two_subjects_resolving_to_one_person_share_their_settings() {
+        let db = inmem_db().await;
+        let service = build_service(db, ServiceConfig::default());
+        let person = Uuid::new_v4();
+        service.attach_owner_resolver(Some(Arc::new(OnePerson(Some(person)))));
+
+        let org = Uuid::new_v4();
+        let first_login = context_in(org);
+        service
+            .update_settings(
+                &first_login,
+                SimpleUserSettingsUpdate {
+                    theme: "dark".to_owned(),
+                    language: "en".to_owned(),
+                },
+            )
+            .await
+            .expect("stored under the person");
+
+        // A different subject entirely — the same human signing in the other way.
+        let second_login = context_in(org);
+        assert_ne!(first_login.subject_id(), second_login.subject_id());
+
+        let seen = service
+            .get_settings(&second_login)
+            .await
+            .expect("read under the person");
+        assert_eq!(seen.theme.as_deref(), Some("dark"));
+        assert_eq!(seen.user_id, person, "settings belong to the person");
+    }
+
+    /// Without a resolver the gear behaves exactly as it always has, which is
+    /// what makes this addition safe for every deployment that has one login
+    /// per human.
+    #[tokio::test]
+    async fn with_no_resolver_the_subject_is_still_the_key() {
+        let db = inmem_db().await;
+        let service = build_service(db, ServiceConfig::default());
+        service.attach_owner_resolver(None);
+
+        let ctx = create_test_context();
+        let stored = service
+            .update_settings(
+                &ctx,
+                SimpleUserSettingsUpdate {
+                    theme: "light".to_owned(),
+                    language: "en".to_owned(),
+                },
+            )
+            .await
+            .expect("stored");
+        assert_eq!(stored.user_id, ctx.subject_id());
+    }
+
+    /// A resolver with no opinion about this caller yields to the subject
+    /// rather than denying somebody their preferences.
+    #[tokio::test]
+    async fn a_resolver_that_declines_falls_back_to_the_subject() {
+        let db = inmem_db().await;
+        let service = build_service(db, ServiceConfig::default());
+        service.attach_owner_resolver(Some(Arc::new(OnePerson(None))));
+
+        let ctx = create_test_context();
+        let stored = service
+            .update_settings(
+                &ctx,
+                SimpleUserSettingsUpdate {
+                    theme: "light".to_owned(),
+                    language: "en".to_owned(),
+                },
+            )
+            .await
+            .expect("stored");
+        assert_eq!(stored.user_id, ctx.subject_id());
+    }
+
+    /// A resolver that fails is reported, not guessed around: filing settings
+    /// under a key the next request will not produce loses them silently.
+    #[tokio::test]
+    async fn a_resolver_that_fails_fails_the_request() {
+        let db = inmem_db().await;
+        let service = build_service(db, ServiceConfig::default());
+        service.attach_owner_resolver(Some(Arc::new(Broken)));
+
+        let err = service
+            .get_settings(&create_test_context())
+            .await
+            .expect_err("the read must not fall back");
+        assert!(matches!(err, DomainError::Internal(_)), "got {err:?}");
     }
 
     // =========================================================================

--- a/gears/simple-user-settings/simple-user-settings/src/gear.rs
+++ b/gears/simple-user-settings/simple-user-settings/src/gear.rs
@@ -10,7 +10,7 @@ use tracing::info;
 
 use authz_resolver_sdk::{AuthZResolverApi, PolicyEnforcer};
 
-use simple_user_settings_sdk::SimpleUserSettingsClientV1;
+use simple_user_settings_sdk::{SettingsOwnerResolver, SimpleUserSettingsClientV1};
 
 use crate::api::rest::routes;
 use crate::config::SettingsConfig;
@@ -20,6 +20,21 @@ use crate::infra::storage::sea_orm_repo::SeaOrmSettingsRepository;
 
 /// Type alias for the concrete service type with ORM repository.
 type ConcreteService = Service<SeaOrmSettingsRepository>;
+
+/// Who a caller is, as the deployment understands it.
+///
+/// Looked up in the REST phase rather than in `init`: the resolver comes from
+/// another gear and this gear does not depend on it, so init order guarantees
+/// nothing — whereas every gear's `init` has run before any gear's REST phase.
+/// A deployment that publishes none keeps the token subject as the key, which
+/// is what this gear has always done.
+fn owner_resolver(ctx: &GearCtx) -> Option<Arc<dyn SettingsOwnerResolver>> {
+    let resolver = ctx.client_hub().get::<dyn SettingsOwnerResolver>().ok();
+    if resolver.is_some() {
+        info!("Settings gear: settings are keyed by the deployment's own user resolver");
+    }
+    resolver
+}
 
 #[toolkit::gear(
     name = "simple-user-settings",
@@ -82,7 +97,7 @@ impl Gear for SettingsGear {
 impl toolkit::contracts::RestApiCapability for SettingsGear {
     fn register_rest(
         &self,
-        _ctx: &GearCtx,
+        ctx: &GearCtx,
         router: Router,
         openapi: &dyn OpenApiRegistry,
     ) -> anyhow::Result<Router> {
@@ -92,6 +107,8 @@ impl toolkit::contracts::RestApiCapability for SettingsGear {
             .get()
             .ok_or_else(|| anyhow::anyhow!("Service not initialized"))?
             .clone();
+
+        service.attach_owner_resolver(owner_resolver(ctx));
 
         let router = routes::register_routes(router, openapi, service);
         info!("Settings gear: REST routes registered successfully");


### PR DESCRIPTION
## The problem

`simple-user-settings` files a person's settings under `ctx.subject_id()` — the identity that signed in.

Where one human has exactly one way in, subject and human are the same thing and there is nothing to decide. They come apart the moment a product lets somebody reach one account through more than one identity: an e-mail login and a brokered GitHub login, two accounts merged after the fact, a migration between identity providers. Then the subject names *a way in*, not the person, and settings keyed on it fork silently — the same human signs in the other way and their theme and language are gone.

That is the failure this gear is most likely to be blamed for and least able to see: nothing errors, the row is simply filed under a key the next request does not produce.

We hit it in Constructor Studio, which now has a canonical person with several logins mapping onto it. Every Studio gear can already resolve a caller to that person; this one cannot be told about it.

## The change

A deployment can publish a `SettingsOwnerResolver` on the ClientHub, and the gear asks it for the user key on every read and write:

```rust
#[async_trait]
pub trait SettingsOwnerResolver: Send + Sync + 'static {
    async fn settings_owner(&self, ctx: &SecurityContext)
        -> Result<Option<Uuid>, CanonicalError>;
}
```

Nothing else moves — same storage, same API, same authorization. Only the key comes from somewhere better informed, and it is decided in one place so a read and a write can never disagree about whose settings they are.

## Why this is safe to merge as-is

- **No resolver registered → today's behaviour, exactly.** `ctx.subject_id()`, as always. Every existing deployment is unaffected, and there is no migration and no config to set.
- **A resolver with no opinion about a caller returns `None`** and falls back the same way, so a deployment whose directory does not know a service account still serves it.
- **A resolver that genuinely fails is reported, not guessed around.** Falling back after a real failure would file settings under a key the caller's next request will not produce, losing them silently; a failed read is the better outcome and the caller can retry.
- **Read in the REST phase, not `init`.** The resolver comes from a gear this one does not depend on, so init order guarantees nothing — while every gear's `init` has run before any gear's REST phase.

## Tests

Four new cases in `domain/service_test.rs`, all against the existing in-memory SQLite harness:

- two different subjects resolving to one person share their settings — the point of the change;
- with no resolver, the subject is still the key;
- a resolver returning `None` falls back to the subject;
- a resolver that errors fails the request rather than falling back.

`cargo test -p cf-gears-simple-user-settings` → 32 passed. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean on both crates.

## One thing this does not address

Settings remain keyed on `(user, tenant)`, so a person in two organizations still has two themes. That is a separate decision about what a user setting is scoped to, and it is not touched here — the change is deliberately confined to *which user*.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings can now be associated with a resolved owner identity, allowing multiple callers to share settings when appropriate.
  * When no owner mapping is available, settings continue to use the caller’s token identity.
  * Resolver failures are reported as internal errors rather than silently falling back.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->